### PR TITLE
Delete non-osu!standard beatmaps during import

### DIFF
--- a/src/ru/nsu/ccfit/zuev/osu/LibraryManager.java
+++ b/src/ru/nsu/ccfit/zuev/osu/LibraryManager.java
@@ -395,6 +395,8 @@ public class LibraryManager {
             track.setCreator("unknown");
 
             if (parser.readMetaData(track, info) == false) {
+                // delete file if import fails
+                file.delete();
                 continue;
             }
             if (track.getBackground() != null) {


### PR DESCRIPTION
There is no use to keep `.osu` files of gamemodes other than osu!standard. This PR changes library manager behavior so that it deletes unused `.osu` files upon importing.

I do not see any usage for `<OSUParser>.readMetaData` outside `LibraryManager`, therefore I assumed this change should be safe and will cause no interference.