### PR TITLE
Fix speed multiplier and force AR storing method

### DIFF
--- a/src/ru/nsu/ccfit/zuev/osu/scoring/StatisticV2.java
+++ b/src/ru/nsu/ccfit/zuev/osu/scoring/StatisticV2.java
@@ -4,6 +4,7 @@ import com.dgsrz.bancho.security.SecurityUtils;
 
 import java.io.Serializable;
 import java.util.EnumSet;
+import java.util.Locale;
 import java.util.Random;
 
 import ru.nsu.ccfit.zuev.osu.Config;
@@ -749,10 +750,10 @@ public class StatisticV2 implements Serializable {
     private String getExtraModString() {
         StringBuilder builder = new StringBuilder();
         if (changeSpeed != 1){
-            builder.append(String.format("x%.2f|", changeSpeed));
+            builder.append(String.format(Locale.US, "x%.2f|", changeSpeed));
         }
         if (enableForceAR){
-            builder.append(String.format("AR%.1f|", forceAR));
+            builder.append(String.format(Locale.US, "AR%.1f|", forceAR));
         }
         if (builder.length() > 0){
             builder.delete(builder.length() - 1, builder.length());

--- a/src/ru/nsu/ccfit/zuev/osu/scoring/StatisticV2.java
+++ b/src/ru/nsu/ccfit/zuev/osu/scoring/StatisticV2.java
@@ -750,10 +750,10 @@ public class StatisticV2 implements Serializable {
     private String getExtraModString() {
         StringBuilder builder = new StringBuilder();
         if (changeSpeed != 1){
-            builder.append(String.format(Locale.US, "x%.2f|", changeSpeed));
+            builder.append(String.format(Locale.ENGLISH, "x%.2f|", changeSpeed));
         }
         if (enableForceAR){
-            builder.append(String.format(Locale.US, "AR%.1f|", forceAR));
+            builder.append(String.format(Locale.ENGLISH, "AR%.1f|", forceAR));
         }
         if (builder.length() > 0){
             builder.delete(builder.length() - 1, builder.length());


### PR DESCRIPTION
Using the system's default locale when formatting strings can result in an improperly formatted string in some languages (for example, `1.20` (float) gets be converted to `1,20` (string)). This will cause mod string to be stored incorrectly in score database and further causes crash when:
- Trying to load scores from local leaderboard
- Importing a replay where the user that exports the replay has this bug

Example screenshot of improperly formatted mod string (device uses Vietnamese language):
![image](https://user-images.githubusercontent.com/52914632/97308781-d489ec80-1893-11eb-827f-cc95631893db.png)

Screenshot of exported replay after device switches to English language:
![image](https://user-images.githubusercontent.com/52914632/97309642-e28c3d00-1894-11eb-95b9-9478a95d22cf.png)