### PR TITLE
Fixed bug : "enable metronome in speed modify" option caps final speed Multiplier at 0.75-1.5

### DIFF
--- a/res/values/options.xml
+++ b/res/values/options.xml
@@ -285,7 +285,7 @@
 	
     <string name="opt_changespeed_title">Speed Modify</string>
     <string name="opt_forcear_title">Force AR</string>
-    <string name="opt_enablenc_whenspeedchange_title">Enable metronome in speed modify</string>
+    <string name="opt_enablenc_whenspeedchange_title">Enable pitch shift in speed modify</string>
     <string name="opt_enablespeedchange_title">Enable speed modify</string>
     <string name="opt_enableforcear_title">Enable force AR</string>
 	

--- a/src/ru/nsu/ccfit/zuev/audio/serviceAudio/BassAudioFunc.java
+++ b/src/ru/nsu/ccfit/zuev/audio/serviceAudio/BassAudioFunc.java
@@ -95,16 +95,16 @@ public class BassAudioFunc {
         // BASS.BASS_ChannelSetAttribute(channel, BASS.BASS_ATTRIB_NOBUFFER, 1);
         if (enableNC) {
             BASS.BASS_ChannelGetInfo(channel, fx);
+            BASS.BASS_ChannelSetAttribute(channel, BASS.BASS_ATTRIB_FREQ, (int) (fx.freq * speed));
             if (speed > 1.5){
-                BASS.BASS_ChannelSetAttribute(channel, BASS.BASS_ATTRIB_FREQ, (int) (fx.freq * 1.5));
+                BASS.BASS_ChannelSetAttribute(channel, BASS_FX.BASS_ATTRIB_TEMPO, (speed - 1.5f) * 100);
             }
             else if (speed < 0.75){
-                BASS.BASS_ChannelSetAttribute(channel, BASS.BASS_ATTRIB_FREQ, (int) (fx.freq * 0.75));
+                BASS.BASS_ChannelSetAttribute(channel, BASS_FX.BASS_ATTRIB_TEMPO, (speed - 0.75f) * 100);
             }
             else {
-                BASS.BASS_ChannelSetAttribute(channel, BASS.BASS_ATTRIB_FREQ, (int) (fx.freq * speed));
+                BASS.BASS_ChannelSetAttribute(channel, BASS_FX.BASS_ATTRIB_TEMPO, 0.0f);
             }
-            BASS.BASS_ChannelSetAttribute(channel, BASS_FX.BASS_ATTRIB_TEMPO, 0.0f);
         }
         else{
             BASS.BASS_ChannelSetAttribute(channel, BASS_FX.BASS_ATTRIB_TEMPO, (speed - 1.0f) * 100);

--- a/src/ru/nsu/ccfit/zuev/audio/serviceAudio/BassAudioFunc.java
+++ b/src/ru/nsu/ccfit/zuev/audio/serviceAudio/BassAudioFunc.java
@@ -92,17 +92,18 @@ public class BassAudioFunc {
         this.mode = PlayMode.MODE_SC;
         channel = BASS.BASS_StreamCreateFile(filePath, 0, 0, BASS.BASS_STREAM_DECODE | BASS.BASS_STREAM_PRESCAN);
         channel = BASS_FX.BASS_FX_TempoCreate(channel, BASS.BASS_STREAM_AUTOFREE);
-        // BASS.BASS_ChannelSetAttribute(channel, BASS.BASS_ATTRIB_NOBUFFER, 1);
         if (enableNC) {
             BASS.BASS_ChannelGetInfo(channel, fx);
-            BASS.BASS_ChannelSetAttribute(channel, BASS.BASS_ATTRIB_FREQ, (int) (fx.freq * speed));
             if (speed > 1.5){
-                BASS.BASS_ChannelSetAttribute(channel, BASS_FX.BASS_ATTRIB_TEMPO, (speed - 1.5f) * 100);
+                BASS.BASS_ChannelSetAttribute(channel, BASS.BASS_ATTRIB_FREQ, (int) (fx.freq * 1.5f));
+                BASS.BASS_ChannelSetAttribute(channel, BASS_FX.BASS_ATTRIB_TEMPO, (speed / 1.5f - 1.0f) * 100);
             }
             else if (speed < 0.75){
-                BASS.BASS_ChannelSetAttribute(channel, BASS_FX.BASS_ATTRIB_TEMPO, (speed - 0.75f) * 100);
+                BASS.BASS_ChannelSetAttribute(channel, BASS.BASS_ATTRIB_FREQ, (int) (fx.freq * 0.75f));
+                BASS.BASS_ChannelSetAttribute(channel, BASS_FX.BASS_ATTRIB_TEMPO, (speed / 0.75f - 1.0f) * 100);
             }
             else {
+                BASS.BASS_ChannelSetAttribute(channel, BASS.BASS_ATTRIB_FREQ, (int) (fx.freq * speed));
                 BASS.BASS_ChannelSetAttribute(channel, BASS_FX.BASS_ATTRIB_TEMPO, 0.0f);
             }
         }


### PR DESCRIPTION
Fixed bug : When use "enable metronome in speed modify" option, it caps final speed Multiplier at 0.75-1.5