### PR TITLE
Add the option to disable/enable beatmap ranking status

### DIFF
--- a/res/values/options.xml
+++ b/res/values/options.xml
@@ -263,7 +263,7 @@
     <string name="opt_show_first_approach_circle_summary">Do not hide the first approach circle in hidden mods</string>
 
     <string name="opt_apikey_title">[Beta] osu!ppy API Key</string>
-    <string name="opt_apikey_summary">Uses osu!ppy API to get beatmaps\' information. &#xD;If key is invalid, uses bloodcat instead (might be outdated/bad connection)</string>
+    <string name="opt_apikey_summary">Uses osu!ppy API to get beatmaps\' information if \"Display beatmap ranking status\" is enabled. &#xD;If key is invalid, uses bloodcat instead (might be outdated/bad connection)</string>
 
     <string name="opt_show_scoreboard_summary">Show scoreboard of selected beatmap during game</string>
     <string name="opt_show_scoreboard_title">Show scoreboard</string>
@@ -294,4 +294,7 @@
 
     <string name="opt_display_score_pp_title">Display PP in score</string>
     <string name="opt_display_score_pp_summary">Displays PP value in score result screen</string>
+
+    <string name="opt_retrieve_beatmap_info_title">[Beta] Display beatmap ranking status</string>
+    <string name="opt_retrieve_beatmap_info_summary">Displays beatmap ranking status when viewing global beatmap leaderboard</string>
 </resources>

--- a/res/xml/options.xml
+++ b/res/xml/options.xml
@@ -19,6 +19,8 @@
                 android:inputType="textPassword" android:summary="@string/opt_password_summary"/>
             <Preference android:key="registerAcc" android:title="@string/opt_register_title"
                 android:summary="@string/opt_register_summary"/>
+            <CheckBoxPreference android:key="retrieveBeatmapInfo" android:title="@string/opt_retrieve_beatmap_info_title"
+                android:summary="@string/opt_retrieve_beatmap_info_summary" android:defaultValue="true"/>
             <EditTextPreference android:key="APIKey" android:title="@string/opt_apikey_title"
                 android:summary="@string/opt_apikey_summary"/>
         </PreferenceCategory>

--- a/src/ru/nsu/ccfit/zuev/osu/Config.java
+++ b/src/ru/nsu/ccfit/zuev/osu/Config.java
@@ -267,6 +267,7 @@ public class Config {
                 .getDefaultSharedPreferences(context);
 
         APIKey = prefs.getString("APIKey", "");
+        retrieveBeatmapInfo = prefs.getBoolean("retrieveBeatmapInfo", true);
         onlineUsername = prefs.getString("onlineUsername", "");
         onlinePassword = prefs.getString("onlinePassword", null);
         stayOnline = prefs.getBoolean("stayOnline", true);

--- a/src/ru/nsu/ccfit/zuev/osu/Config.java
+++ b/src/ru/nsu/ccfit/zuev/osu/Config.java
@@ -29,6 +29,7 @@ public class Config {
     private static String skinTopPath = skinPath;
     private static String scorePath = corePath + "Scores/";
     private static String APIKey = "";
+    private static boolean retrieveBeatmapInfo = true;
     private static int errorMeter = 0;
     private static int spinnerStyle = 0;
     private static boolean showFirstApproachCircle = false;
@@ -777,5 +778,13 @@ public class Config {
 
     public static void setCursorSize() {
         Config.cursorSize = cursorSize;
+    }
+
+    public static boolean isRetrieveBeatmapInfo() {
+        return retrieveBeatmapInfo;
+    }
+
+    public static void setRetrieveBeatmapInfo(boolean retrieveBeatmapInfo) {
+        Config.retrieveBeatmapInfo = retrieveBeatmapInfo;
     }
 }

--- a/src/ru/nsu/ccfit/zuev/osu/online/OnlineMapInfo.java
+++ b/src/ru/nsu/ccfit/zuev/osu/online/OnlineMapInfo.java
@@ -144,12 +144,12 @@ public class OnlineMapInfo {
     }
 
     public int getBeatmapsStateFromHash(TrackInfo t) {
-        if (!Config.isRetrieveBeatmapInfo()) {
-            return 7;
-        }
         this.map = t;
         update = null;
         updateNeccessary = false;
+        if (!Config.isRetrieveBeatmapInfo()) {
+            return 7;
+        }
         // 0"No connection", 1"ranking_disabled", 2"ranking_ranked", 3"ranking_latest" , 4"ranking_loved", 5"ranking_unsubmitted", 6"ranking_download", 7"ranking_unknown"
         //ppy                   |bloodcat
         //4 loved               |4          |4

--- a/src/ru/nsu/ccfit/zuev/osu/online/OnlineMapInfo.java
+++ b/src/ru/nsu/ccfit/zuev/osu/online/OnlineMapInfo.java
@@ -144,6 +144,9 @@ public class OnlineMapInfo {
     }
 
     public int getBeatmapsStateFromHash(TrackInfo t) {
+        if (!Config.isRetrieveBeatmapInfo()) {
+            return 7;
+        }
         this.map = t;
         update = null;
         updateNeccessary = false;


### PR DESCRIPTION
Sometimes Bloodcat servers are down and when the game attempts to retrieve beatmap ranking status (without osu! API), this message pops up a couple of seconds later:

![image](https://user-images.githubusercontent.com/52914632/101981097-0537b100-3c9d-11eb-8992-66744807ef58.png)

This seems silly, but in gameplay it can be very annoying (as shown in the screenshot above).

This PR allows players to explicitly enable/disable this feature if they do so choose. Not many players know what osu! API is, let alone owning an osu! account to get API key.