### PR TITLE
Fix crash when menus get called to show twice

### DIFF
--- a/src/com/edlplan/ui/ActivityOverlay.kt
+++ b/src/com/edlplan/ui/ActivityOverlay.kt
@@ -44,6 +44,10 @@ object ActivityOverlay {
     @Synchronized
     fun addOverlay(fragment: BaseFragment, tag: String?) {
         if (fragmentManager != null) {
+            fragmentManager!!.executePendingTransactions()
+            if (fragment.isAdded()) {
+                return
+            }
             if (displayingOverlay.contains(fragment) || fragmentManager!!.findFragmentByTag(tag) != null) {
                 displayingOverlay.remove(fragment)
                 fragmentManager!!.beginTransaction()


### PR DESCRIPTION
this should fix the `Exception: Fragment already added` error on all fragments/menus including the back button.