### PR TITLE
Add 95% and 85% options for Playfield Shrink

### DIFF
--- a/res/values/options.xml
+++ b/res/values/options.xml
@@ -56,16 +56,16 @@
     </string-array>
     <string-array name="set_playfield_names">
         <item>100%</item>
-	    <item>95%</item>
-    	<item>90%</item>
-	    <item>85%</item>
+        <item>95%</item>
+        <item>90%</item>
+        <item>85%</item>
         <item>80%</item>
     </string-array>
     <string-array name="set_playfield_values">
         <item>100</item>
-	    <item>95</item>
+        <item>95</item>
         <item>90</item>
-	    <item>85</item>
+        <item>85</item>
         <item>80</item>
     </string-array>
     <string name="opt_onlineOpt">Account Option</string>

--- a/res/values/options.xml
+++ b/res/values/options.xml
@@ -56,16 +56,16 @@
     </string-array>
     <string-array name="set_playfield_names">
         <item>100%</item>
-	<item>95%</item>
+	    <item>95%</item>
     	<item>90%</item>
-	<item>85%</item>
+	    <item>85%</item>
         <item>80%</item>
     </string-array>
     <string-array name="set_playfield_values">
         <item>100</item>
-	<item>95</item>
+	    <item>95</item>
         <item>90</item>
-	<item>85</item>
+	    <item>85</item>
         <item>80</item>
     </string-array>
     <string name="opt_onlineOpt">Account Option</string>

--- a/res/values/options.xml
+++ b/res/values/options.xml
@@ -56,12 +56,16 @@
     </string-array>
     <string-array name="set_playfield_names">
         <item>100%</item>
-        <item>90%</item>
+	<item>95%</item>
+    	<item>90%</item>
+	<item>85%</item>
         <item>80%</item>
     </string-array>
     <string-array name="set_playfield_values">
         <item>100</item>
+	<item>95</item>
         <item>90</item>
+	<item>85</item>
         <item>80</item>
     </string-array>
     <string name="opt_onlineOpt">Account Option</string>


### PR DESCRIPTION
So better precision is available for the playfield shrink. 90% feels too small for comfort compared to 100%. Or we should allow the user to change the shrink to any integer percentage from 100% to 10% since the touch position clamp was implemented (But I don't know how to do that)