### PR TITLE
Apply system's timezone to online score date

### DIFF
--- a/src/ru/nsu/ccfit/zuev/osu/MainScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/MainScene.java
@@ -1173,7 +1173,7 @@ public class MainScene implements IUpdateHandler {
                     ResourceManager.getInstance().loadBackground(track.getBackground());
                     ru.nsu.ccfit.zuev.osu.GlobalManager.getInstance().getSongService().preLoad(track.getBeatmap().getMusic());
                     ru.nsu.ccfit.zuev.osu.GlobalManager.getInstance().getSongService().play();
-                    scorescene.load(stat, null, ru.nsu.ccfit.zuev.osu.GlobalManager.getInstance().getSongService(), replayFile, null, track);
+                    scorescene.load(stat, null, ru.nsu.ccfit.zuev.osu.GlobalManager.getInstance().getSongService(), replayFile, null, track, false);
                     GlobalManager.getInstance().getEngine().setScene(scorescene.getScene());
                 }
             }

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -258,8 +258,10 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
                 ToastLogger.showTextId(R.string.replay_cantdownload, true);
                 return false;
             }
-        } else
+        } else {
+            isOnlineReplay = false;
             this.replayFile = rFile;
+        }
 
         OSUParser parser = new OSUParser(track.getFilename());
         if (parser.openFile()) {

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -157,6 +157,7 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
     private Replay replay;
     private boolean replaying;
     private String replayFile;
+    private boolean isOnlineReplay = false;
     private float avgOffset;
     private int offsetRegs;
     private boolean kiai = false;
@@ -249,6 +250,7 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
 
     private boolean loadGame(final TrackInfo track, final String rFile) {
         if (rFile != null && rFile.startsWith("http://")) {
+            isOnlineReplay = true;
             this.replayFile = Config.getCachePath() + "/" +
                     MD5Calcuator.getStringMD5(rFile) + ".odr";
             Debug.i("ReplayFile = " + replayFile);
@@ -1824,7 +1826,7 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
                 }
 
                 if (replaying)
-                    scoringScene.load(scoringScene.getReplayStat(), null, GlobalManager.getInstance().getSongService(), replayFile, null, lastTrack);
+                    scoringScene.load(scoringScene.getReplayStat(), null, GlobalManager.getInstance().getSongService(), replayFile, null, lastTrack, isOnlineReplay);
                 else {
                     if (stat.getMod().contains(GameMod.MOD_AUTO)) {
                         stat.setPlayerName("osu!");
@@ -1836,7 +1838,7 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
                         storyboardSprite = null;
                     }
 
-                    scoringScene.load(stat, lastTrack, GlobalManager.getInstance().getSongService(), replayFile, trackMD5, null);
+                    scoringScene.load(stat, lastTrack, GlobalManager.getInstance().getSongService(), replayFile, trackMD5, null, isOnlineReplay);
                 }
                 GlobalManager.getInstance().getSongService().setVolume(0.2f);
                 engine.setScene(scoringScene.getScene());

--- a/src/ru/nsu/ccfit/zuev/osu/menu/SongMenu.java
+++ b/src/ru/nsu/ccfit/zuev/osu/menu/SongMenu.java
@@ -1140,7 +1140,7 @@ public class SongMenu implements IUpdateHandler, MenuItemListener,
 
                         StatisticV2 stat = new StatisticV2(params);
                         stat.setPlayerName(playerName);
-                        scorescene.load(stat, null, null, OnlineManager.getReplayURL(id), null, selectedTrack);
+                        scorescene.load(stat, null, null, OnlineManager.getReplayURL(id), null, selectedTrack, true);
                         engine.setScene(scorescene.getScene());
 
                     } catch (OnlineManagerException e) {
@@ -1161,7 +1161,7 @@ public class SongMenu implements IUpdateHandler, MenuItemListener,
 
 
         StatisticV2 stat = ScoreLibrary.getInstance().getScore(id);
-        scorescene.load(stat, null, null, stat.getReplayName(), null, selectedTrack);
+        scorescene.load(stat, null, null, stat.getReplayName(), null, selectedTrack, false);
         engine.setScene(scorescene.getScene());
     }
 

--- a/src/ru/nsu/ccfit/zuev/osu/scoring/ScoringScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/scoring/ScoringScene.java
@@ -16,6 +16,7 @@ import org.anddev.andengine.opengl.texture.region.TextureRegion;
 import org.anddev.andengine.util.Debug;
 
 import java.util.Locale;
+import java.util.Calendar;
 
 import ru.nsu.ccfit.zuev.audio.serviceAudio.SongService;
 import ru.nsu.ccfit.zuev.osu.Config;
@@ -54,7 +55,7 @@ public class ScoringScene {
 
     public void load(final StatisticV2 stat, final TrackInfo track,
                      final SongService player, final String replay, final String mapMD5,
-                     final TrackInfo trackToReplay) {
+                     final TrackInfo trackToReplay, final boolean isOnlineScore) {
         scene = new Scene();
         //music = player;
         this.songService = player;
@@ -85,7 +86,10 @@ public class ScoringScene {
                 (trackInfo.getBeatmap().getTitleUnicode() == null || Config.isForceRomanized() ? trackInfo.getBeatmap().getTitle() : trackInfo.getBeatmap().getTitleUnicode()) + " [" + trackInfo.getMode() + "]";
         String mapperStr = "Beatmap by " + trackInfo.getCreator();
         String playerStr = "Played by " + stat.getPlayerName() + " on " +
-                new java.text.SimpleDateFormat("yyyy/MM/dd HH:mm:ss", Locale.getDefault()).format(new java.util.Date(stat.getTime()));
+                new java.text.SimpleDateFormat(
+                        "yyyy/MM/dd HH:mm:ss",
+                        Locale.getDefault()).format(new java.util.Date(stat.getTime() + (isOnlineScore ? Calendar.getInstance().getTimeZone().getRawOffset() : 0))
+                );
         playerStr += String.format("  %s(%s)", BuildConfig.VERSION_NAME, BuildConfig.BUILD_TYPE);
         if (stat.getChangeSpeed() != 1 || stat.isEnableForceAR()){
             mapperStr += " [";

--- a/src/ru/nsu/ccfit/zuev/osu/scoring/StatisticV2.java
+++ b/src/ru/nsu/ccfit/zuev/osu/scoring/StatisticV2.java
@@ -6,7 +6,6 @@ import java.io.Serializable;
 import java.util.EnumSet;
 import java.util.Locale;
 import java.util.Random;
-import java.util.Calendar;
 
 import ru.nsu.ccfit.zuev.osu.Config;
 import ru.nsu.ccfit.zuev.osu.game.GameHelper;
@@ -95,7 +94,7 @@ public class StatisticV2 implements Serializable {
         misses = Integer.parseInt(params[9]);
         accuracy = Integer.parseInt(params[10]) / 100000f;
         if (params.length >= 12) {
-            time = Long.parseLong(params[11]) + Calendar.getInstance().getTimeZone().getRawOffset();
+            time = Long.parseLong(params[11]);
         }
         if (params.length >= 13) {
             perfect = Integer.parseInt(params[12]) != 0;

--- a/src/ru/nsu/ccfit/zuev/osu/scoring/StatisticV2.java
+++ b/src/ru/nsu/ccfit/zuev/osu/scoring/StatisticV2.java
@@ -6,6 +6,7 @@ import java.io.Serializable;
 import java.util.EnumSet;
 import java.util.Locale;
 import java.util.Random;
+import java.util.Calendar;
 
 import ru.nsu.ccfit.zuev.osu.Config;
 import ru.nsu.ccfit.zuev.osu.game.GameHelper;
@@ -94,7 +95,7 @@ public class StatisticV2 implements Serializable {
         misses = Integer.parseInt(params[9]);
         accuracy = Integer.parseInt(params[10]) / 100000f;
         if (params.length >= 12) {
-            time = Long.parseLong(params[11]);
+            time = Long.parseLong(params[11]) + Calendar.getInstance().getTimeZone().getRawOffset();
         }
         if (params.length >= 13) {
             perfect = Integer.parseInt(params[12]) != 0;


### PR DESCRIPTION
Me and @Acivev managed to fix online score date bug that was caused by a server-side bug, however the timestamp received by the client is in UTC. This PR converts that time to the user's local time.