### PR TITLE
Fix flashlight mod not showing when starting gameplay

### DIFF
--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -1152,6 +1152,23 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
             effectOffset += 25;
             timeOffset += 0.25f;
         }
+        if (stat.getMod().contains(GameMod.MOD_FLASHLIGHT)) {
+            final GameEffect effect = GameObjectPool.getInstance().getEffect(
+                    "selection-mod-flashlight");
+            effect.init(
+                    fgScene,
+                    new PointF(Utils.toRes(Config.getRES_WIDTH() - effectOffset), Utils
+                            .toRes(130)),
+                    scale,
+                    new SequenceEntityModifier(ModifierFactory
+                            .newScaleModifier(0.25f, 1.2f, 1), ModifierFactory
+                            .newDelayModifier(2 - timeOffset),
+                            new ParallelEntityModifier(ModifierFactory
+                                    .newFadeOutModifier(0.5f), ModifierFactory
+                                    .newScaleModifier(0.5f, 1, 1.5f))));
+            effectOffset += 25;
+            timeOffset += 0.25f;
+        }
         if (stat.getMod().contains(GameMod.MOD_SMALLCIRCLE)) {
             final GameEffect effect = GameObjectPool.getInstance().getEffect(
                     "selection-mod-smallcircle");


### PR DESCRIPTION
Flashlight mod icon doesn't appear at the start of a gameplay even when enabled.

Reported by a user in Discord.