### PR TITLE
Fix sliders with custom speed multiplier disappearing before active in Hidden mod

### DIFF
--- a/src/ru/nsu/ccfit/zuev/osu/game/Slider.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/Slider.java
@@ -8,6 +8,7 @@ import com.edlplan.framework.math.line.LinePath;
 import com.edlplan.osu.support.slider.SliderBody2D;
 import com.edlplan.osu.support.timing.controlpoint.TimingControlPoint;
 
+import org.anddev.andengine.entity.modifier.AlphaModifier;
 import org.anddev.andengine.entity.modifier.FadeInModifier;
 import org.anddev.andengine.entity.modifier.FadeOutModifier;
 import org.anddev.andengine.entity.modifier.SequenceEntityModifier;
@@ -80,6 +81,7 @@ public class Slider extends GameObject {
     private float borderPolyVerts[] = null;
 
     private boolean kiai;
+    private boolean isHiddenFadeOutActive = false;
     private RGBColor color = new RGBColor();
     private RGBColor circleColor = color;
 
@@ -730,6 +732,7 @@ public class Slider extends GameObject {
         GameObjectPool.getInstance().putSlider(this);
         GameObjectPool.getInstance().putNumber(number);
         scene = null;
+        isHiddenFadeOutActive = false;
     }
 
     private void over() {
@@ -1126,32 +1129,9 @@ public class Slider extends GameObject {
                 startOverlay.setAlpha(0);
             }
 
-            // Slider body, border, and hint gradually fades in Hidden mod
-            // ball = null means the slider has just started
-            if (GameHelper.isHidden() && ball == null) {
-                final float sliderDuration = maxTime * repeatCount;
-                final FadeOutModifier hiddenFadeOut = new FadeOutModifier(sliderDuration);
-                if (group != null) {
-                    group.registerEntityModifier(hiddenFadeOut);
-                }
-                if (trackPoly != null) {
-                    trackPoly.registerEntityModifier(hiddenFadeOut);
-                }
-                if (borderPoly != null) {
-                    borderPoly.registerEntityModifier(hiddenFadeOut);
-                }
-                if (borderGroup != null) {
-                    borderGroup.registerEntityModifier(hiddenFadeOut);
-                }
-                if (body != null) {
-                    body.registerEntityModifier(hiddenFadeOut);
-                }
-                if (border != null) {
-                    border.registerEntityModifier(hiddenFadeOut);
-                }
-                if (abstractSliderBody != null) {
-                    abstractSliderBody.fadeOut(sliderDuration);
-                }
+            // Slider body, border, and hint gradually fade in Hidden mod
+            if (GameHelper.isHidden()) {
+                hiddenFadeOut();
             }
         }
 
@@ -1238,6 +1218,53 @@ public class Slider extends GameObject {
         // If we got 100% time, finishing slider
         if (percentage >= 1) {
             over();
+        }
+    }
+
+    private void hiddenFadeOut() {
+        if (isHiddenFadeOutActive) {
+            return;
+        }
+        isHiddenFadeOutActive = true;
+        final float realDuration = maxTime * repeatCount * GameHelper.getTimeMultiplier();
+        if (group != null) {
+            group.registerEntityModifier(new AlphaModifier(realDuration,
+                group.getAlpha(), 0));
+        }
+        if (trackPoly != null) {
+            trackPoly.registerEntityModifier(new AlphaModifier(realDuration,
+                trackPoly.getAlpha(), 0));
+        }
+        if (borderPoly != null) {
+            borderPoly.registerEntityModifier(new AlphaModifier(realDuration,
+                borderPoly.getAlpha(), 0));
+        }
+        if (borderGroup != null) {
+            borderGroup.registerEntityModifier(new AlphaModifier(realDuration,
+                borderGroup.getAlpha(), 0));
+        }
+        if (body != null) {
+            body.registerEntityModifier(new AlphaModifier(realDuration,
+                body.getAlpha(), 0));
+        }
+        if (border != null) {
+            border.registerEntityModifier(new AlphaModifier(realDuration,
+                border.getAlpha(), 0));
+        }
+        for (final Sprite sp : trackSprites) {
+            sp.registerEntityModifier(new AlphaModifier(realDuration,
+                sp.getAlpha(), 0));
+        }
+        for (final Sprite sp : trackBorders) {
+            sp.registerEntityModifier(new AlphaModifier(realDuration,
+                sp.getAlpha(), 0));
+        }
+        for (final Sprite sp : trackBoundaries) {
+            sp.registerEntityModifier(new AlphaModifier(realDuration,
+                sp.getAlpha(), 0));
+        }
+        if (abstractSliderBody != null) {
+            abstractSliderBody.fadeOut(realDuration);
         }
     }
 


### PR DESCRIPTION
Originally reported by @el-dasher, sliders would disappear before they even appear in Hidden mod:
https://user-images.githubusercontent.com/52914632/115642035-728ed900-a344-11eb-995d-6f0ffaa0b83d.mp4

Also made it so that the fade-out duration reflects speed-changing mods properly.