### PR TITLE
Improve unranked play notice

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -146,7 +146,7 @@
 	<string name="test_ed_storyboard">View storyboard (experiment)</string>
 
 	<!-- <string name="mod_precise_is_unrank_now">MOD_PRECISE is unrank now</string>-->
-	<string name="mods_somemods_is_unrank_now">Some unrank feature is actived, prevent score upload</string>
+	<string name="mods_unranked_notice" formatted="false">%s is/are currently unranked</string>
 
 	<!-- new data after 1.6.7(beta1) -->
     <string name="beta_checking_upgrade">Checking Upgrade...</string>

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -8,6 +8,7 @@ import com.edlplan.ext.EdExtensionHelper;
 import com.edlplan.framework.math.FMath;
 import com.edlplan.framework.support.ProxySprite;
 import com.edlplan.framework.support.osb.StoryboardSprite;
+import com.edlplan.framework.utils.functionality.SmartIterator;
 import com.edlplan.osu.support.timing.TimingPoints;
 import com.edlplan.osu.support.timing.controlpoint.ControlPoints;
 
@@ -1221,14 +1222,17 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
         bgScene.attachChild(kiaiRect, 0);
 
         unranked = new Sprite(0, 0, ResourceManager.getInstance().getTexture("play-unranked"));
-        unranked.setPosition(Config.getRES_WIDTH() / 2 - unranked.getWidth() / 2, 80);
-        unranked.setVisible(false);
+        unranked.setPosition(Config.getRES_WIDTH() / 2f - unranked.getWidth() / 2, 80);
+        unranked.setVisible(SmartIterator.wrap(stat.getMod().iterator()).applyFilter(m -> m.typeAuto).hasNext());
         fgScene.attachChild(unranked);
-
-        if (stat.getMod().contains(GameMod.MOD_RELAX)
-                || stat.getMod().contains(GameMod.MOD_AUTOPILOT)
-                || stat.getMod().contains(GameMod.MOD_AUTO)) {
+        if (!unranked.isVisible() &&
+            (SmartIterator.wrap(stat.getMod().iterator())
+                .applyFilter(m -> !m.isRanked).hasNext()
+            || Config.isRemoveSliderLock()
+            || ModMenu.getInstance().isChangeSpeed()
+            || ModMenu.getInstance().isEnableForceAR())) {
             unranked.setVisible(true);
+            unranked.registerEntityModifier(ModifierFactory.newFadeOutModifier(5));
         }
 
         String playname = null;

--- a/src/ru/nsu/ccfit/zuev/osu/game/mods/GameMod.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/mods/GameMod.java
@@ -3,7 +3,7 @@ package ru.nsu.ccfit.zuev.osu.game.mods;
 public enum GameMod {
     MOD_NOFAIL("nf", 0.5f, true),
     MOD_AUTO("auto", 0, false, true),
-    MOD_EASY("es", 0.5f, true),
+    MOD_EASY("ez", 0.5f, true),
     MOD_HARDROCK("hr", 1.06f, true),
     MOD_HIDDEN("hd", 1.06f, true),
     MOD_RELAX("relax", 0.001f, false, true),

--- a/src/ru/nsu/ccfit/zuev/osu/game/mods/GameMod.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/mods/GameMod.java
@@ -1,38 +1,42 @@
 package ru.nsu.ccfit.zuev.osu.game.mods;
 
 public enum GameMod {
-    MOD_NOFAIL("nf", 0.5f),
-    MOD_AUTO("auto", 0, true),
-    MOD_EASY("es", 0.5f),
-    MOD_HARDROCK("hr", 1.06f),
-    MOD_HIDDEN("hd", 1.06f),
-    MOD_RELAX("relax", 0.001f, true),
-    MOD_AUTOPILOT("ap", 0.001f, true),
-    MOD_DOUBLETIME("dt", 1.12f),
-    MOD_NIGHTCORE("nc", 1.12f),
-    MOD_HALFTIME("ht", 0.3f),
-    MOD_SUDDENDEATH("sd", 1),
-    MOD_PERFECT("pf", 1),
-    MOD_FLASHLIGHT("fl", 1.12f),
-    MOD_PRECISE("pr", 1.06f),
-    MOD_SMALLCIRCLE("sc", 1.06f),
-    MOD_REALLYEASY("re", 0.5f),
-    MOD_SCOREV2("v2", 1),
-    MOD_SPEEDUP("su", 1.06f);
+    MOD_NOFAIL("nf", 0.5f, true),
+    MOD_AUTO("auto", 0, false, true),
+    MOD_EASY("es", 0.5f, true),
+    MOD_HARDROCK("hr", 1.06f, true),
+    MOD_HIDDEN("hd", 1.06f, true),
+    MOD_RELAX("relax", 0.001f, false, true),
+    MOD_AUTOPILOT("ap", 0.001f, false, true),
+    MOD_DOUBLETIME("dt", 1.12f, true),
+    MOD_NIGHTCORE("nc", 1.12f, true),
+    MOD_HALFTIME("ht", 0.3f, true),
+    MOD_SUDDENDEATH("sd", 1, false),
+    MOD_PERFECT("pf", 1, false),
+    MOD_FLASHLIGHT("fl", 1.12f, false),
+    MOD_PRECISE("pr", 1.06f, true),
+    MOD_SMALLCIRCLE("sc", 1.06f, false),
+    MOD_REALLYEASY("re", 0.5f, false),
+    MOD_SCOREV2("v2", 1, false),
+    MOD_SPEEDUP("su", 1.06f, false);
     
     public final String shortName;
     public final float scoreMultiplier;
+    public final boolean isRanked;
     public final boolean typeAuto;
 
-    GameMod(String shortName, float scoreMultiplier) {
+    GameMod(String shortName, float scoreMultiplier, boolean isRanked) {
         this.shortName = shortName;
         this.scoreMultiplier = scoreMultiplier;
+        this.isRanked = isRanked;
         this.typeAuto = false;
     }
 
-    GameMod(String shortName, float scoreMultiplier, boolean typeAuto) {
+    GameMod(String shortName, float scoreMultiplier, boolean isRanked, boolean typeAuto) {
         this.shortName = shortName;
         this.scoreMultiplier = scoreMultiplier;
+        // Generally, autoplaying mods should not be ranked
+        this.isRanked = !typeAuto && isRanked;
         this.typeAuto = typeAuto;
     }
 }

--- a/src/ru/nsu/ccfit/zuev/osu/menu/ModMenu.java
+++ b/src/ru/nsu/ccfit/zuev/osu/menu/ModMenu.java
@@ -1,5 +1,6 @@
 package ru.nsu.ccfit.zuev.osu.menu;
 
+import com.edlplan.framework.utils.functionality.SmartIterator;
 import com.edlplan.ui.fragment.InGameSettingMenu;
 
 import org.anddev.andengine.entity.primitive.Rectangle;
@@ -230,12 +231,16 @@ public class ModMenu implements IModSwitcher {
         multiplierText.setPosition(
                 Config.getRES_WIDTH() / 2f - multiplierText.getWidth() / 2,
                 multiplierText.getY());
-        if (mult == 1) {
-            multiplierText.setColor(1, 1, 1);
-        } else if (mult < 1) {
-            multiplierText.setColor(1, 150f / 255f, 0);
+        if (SmartIterator.wrap(mod.iterator()).applyFilter(m -> !m.isRanked).hasNext()) {
+            multiplierText.setColor(1, 0, 0);
         } else {
-            multiplierText.setColor(5 / 255f, 240 / 255f, 5 / 255f);
+            if (mult == 1) {
+                multiplierText.setColor(1, 1, 1);
+            } else if (mult < 1) {
+                multiplierText.setColor(1, 150f / 255f, 0);
+            } else {
+                multiplierText.setColor(5 / 255f, 240 / 255f, 5 / 255f);
+            }
         }
     }
 

--- a/src/ru/nsu/ccfit/zuev/osu/scoring/ScoringScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/scoring/ScoringScene.java
@@ -482,7 +482,7 @@ public class ScoringScene {
         if (track != null && mapMD5 != null) {
             if (stat.getModifiedTotalScore() > 0 && OnlineManager.getInstance().isStayOnline() &&
                     OnlineManager.getInstance().isReadyToSend()) {
-                if (!SmartIterator.wrap(stat.getMod().iterator())
+                if (SmartIterator.wrap(stat.getMod().iterator())
                     .applyFilter(m -> !m.isRanked && !m.typeAuto)
                     .hasNext()
                 || Config.isRemoveSliderLock()

--- a/src/ru/nsu/ccfit/zuev/osu/scoring/ScoringScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/scoring/ScoringScene.java
@@ -482,16 +482,13 @@ public class ScoringScene {
         if (track != null && mapMD5 != null) {
             if (stat.getModifiedTotalScore() > 0 && OnlineManager.getInstance().isStayOnline() &&
                     OnlineManager.getInstance().isReadyToSend()) {
-                if (stat.getMod().contains(GameMod.MOD_SUDDENDEATH)
-                || stat.getMod().contains(GameMod.MOD_PERFECT)
-                || stat.getMod().contains(GameMod.MOD_SMALLCIRCLE)
-                || stat.getMod().contains(GameMod.MOD_REALLYEASY)
-                || stat.getMod().contains(GameMod.MOD_FLASHLIGHT)
-                || stat.getMod().contains(GameMod.MOD_SCOREV2)
+                if (!SmartIterator.wrap(stat.getMod().iterator())
+                    .applyFilter(m -> !m.isRanked && !m.typeAuto)
+                    .hasNext()
                 || Config.isRemoveSliderLock()
                 || ModMenu.getInstance().isChangeSpeed()
                 || ModMenu.getInstance().isEnableForceAR()){
-                    ToastLogger.showText(StringTable.get(R.string.mods_somemods_is_unrank_now), true);
+                    ToastLogger.showText(StringTable.format(R.string.mods_unranked_notice, getUnrankedModString(stat)), true);
                 }
                 else if(
                         !SmartIterator.wrap(stat.getMod().iterator())
@@ -500,7 +497,7 @@ public class ScoringScene {
                 ){
                     SendingPanel sendingPanel = new SendingPanel(OnlineManager.getInstance().getRank(),
                             OnlineManager.getInstance().getScore(), OnlineManager.getInstance().getAccuracy());
-                    sendingPanel.setPosition(Config.getRES_WIDTH() / 2 - 400, Utils.toRes(-300));
+                    sendingPanel.setPosition(Config.getRES_WIDTH() / 2f - 400, Utils.toRes(-300));
                     scene.registerTouchArea(sendingPanel.getDismissTouchArea());
                     scene.attachChild(sendingPanel);
                     ScoreLibrary.getInstance().sendScoreOnline(stat, replay, sendingPanel);
@@ -511,6 +508,30 @@ public class ScoringScene {
             ScoreLibrary.getInstance().addScore(track.getFilename(), stat, replay);
         }
 
+    }
+
+    private String getUnrankedModString(final StatisticV2 stat) {
+        StringBuilder builder = new StringBuilder();
+        for (final GameMod mod : stat.getMod()) {
+            // Ensure autoplaying mods aren't included
+            if (!mod.isRanked && !mod.typeAuto) {
+                builder.append(mod.shortName.toUpperCase())
+                    .append(", ");
+            }
+        }
+
+        if (Config.isRemoveSliderLock()) {
+            builder.append("slider lock removal, ");
+        }
+        if (ModMenu.getInstance().isChangeSpeed()) {
+            builder.append("speed multiplier, ");
+        }
+        if (ModMenu.getInstance().isChangeSpeed()) {
+            builder.append("force AR, ");
+        }
+
+        final String result = builder.toString();
+        return result.substring(0, 1).toUpperCase() + result.substring(1, result.length() - 2);
     }
 
     public Scene getScene() {


### PR DESCRIPTION
With the new mods and features added, many players are confused as to which one of them (especially mods) are unranked.

With that in consideration, this PR changes a few things, namely:
- The score multiplier text on mod menu will be set to red if an unranked mod is active (perhaps a better approach of this is to directly add "unranked" at the end of the text, will consider).
- If the player activates at least one unranked features, the unranked sprite will be shown temporarily at the start of the gameplay.
- Give custom message based on enabled unranked features instead of fixed message at score submission.