### PR TITLE
Fix picture dithering issues

### DIFF
--- a/res/values/options.xml
+++ b/res/values/options.xml
@@ -239,7 +239,7 @@
     <string name="opt_hitlighting_summary">Adds a subtle glow behind hit explosions which lights the playfield</string>
 
     <string name="opt_dither_title">Dither</string>
-    <string name="opt_dither_summary">User hardware dither (picture processing)</string>
+    <string name="opt_dither_summary">Use hardware dither (picture processing)</string>
 
     <string name="opt_particles_title">Particle effects</string>
     <string name="opt_particles_summary">Show particle-based effects like cursor trail</string>

--- a/res/values/options.xml
+++ b/res/values/options.xml
@@ -239,7 +239,7 @@
     <string name="opt_hitlighting_summary">Adds a subtle glow behind hit explosions which lights the playfield</string>
 
     <string name="opt_dither_title">Dither</string>
-    <string name="opt_dither_summary">Use hardware dither (picture processing)</string>
+    <string name="opt_dither_summary">Use hardware dither for better image quality (requires restart)</string>
 
     <string name="opt_particles_title">Particle effects</string>
     <string name="opt_particles_summary">Show particle-based effects like cursor trail</string>

--- a/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
+++ b/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
@@ -14,6 +14,7 @@ import android.content.ServiceConnection;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.graphics.Color;
+import android.graphics.PixelFormat;
 import android.os.*;
 import android.preference.PreferenceManager;
 
@@ -342,7 +343,12 @@ public class MainActivity extends BaseGameActivity implements
     @Override
     protected void onSetContentView() {
         this.mRenderSurfaceView = new RenderSurfaceView(this);
-        this.mRenderSurfaceView.setEGLConfigChooser(true);
+        if(Config.isUseDither()) {
+            this.mRenderSurfaceView.setEGLConfigChooser(8,8,8,8,24,0);
+            this.mRenderSurfaceView.getHolder().setFormat(PixelFormat.RGBA_8888);
+        } else {
+            this.mRenderSurfaceView.setEGLConfigChooser(true);
+        }
         this.mRenderSurfaceView.setRenderer(this.mEngine);
 
         RelativeLayout layout = new RelativeLayout(this);


### PR DESCRIPTION
Fixes issue #95.

On lower background brightness, the image artifacts are more visible. No code is handling the "Use Hardware Dither" in options, so I used the option to toggle this dithering option. Ideally I'd remove the option and permanently apply the fix, but I figured it may cause problems I did not catch. **This fix requires a restart.**

I've tested it myself, but if possible, this requires testing on different devices to check for issues. Please notify me immediately if issues are found.