### PR TITLE
Fix storyboard crash upon retrying map

### DIFF
--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -680,6 +680,7 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
         scene.attachChild(bgScene);
         scene.attachChild(mgScene);
         if (storyboardOverlayProxy != null) {
+            storyboardOverlayProxy.detachSelf();
             scene.attachChild(storyboardOverlayProxy);
         }
         scene.attachChild(fgScene);


### PR DESCRIPTION
Just a minor fix.

Retrying a map with storyboard causes a crash. The bug is caused by trying to attach an entity that's already attached to a parent. I've applied a fix by detaching itself prior to attaching to the parent.