### PR TITLE
Add hide ingame ui option with minor updates to Config.java and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,6 @@ Or if you prefer the command line and you are on Linux, run `chmod +x gradlew` a
 
 We welcome any sort of contributions, as long as they're helpful. Those who aren't able to contribute code may instead suggest small changes like grammar fixes, new features or report client issues via [Feature request](https://github.com/osudroid/osu-droid/issues/11) or [GitHub issues](https://github.com/osudroid/osu-droid/issues).
 
-## Licence
+## License
 
 osu-droid is licensed under the [Apache License 2.0](https://opensource.org/licenses/Apache-2.0). Please see the licence file for more information.

--- a/res/values/options.xml
+++ b/res/values/options.xml
@@ -309,12 +309,15 @@
     <string name="opt_display_score_pp_title">Display PP in score</string>
     <string name="opt_display_score_pp_summary">Displays PP value in score result screen</string>
 
-    <string name="opt_hide_replay_marquee_title">Hide replay marquee</string>
-    <string name="opt_hide_replay_marquee_summary">Hide the scrolling text when watching replays</string>
-
     <string name="opt_setplayfield_title">Set playfield size</string>
     <string name="opt_setplayfield_summary">Change the size of the playfield</string>
 
     <string name="opt_shrink_playfield_downwards_title">Shrink playfield downwards</string>
     <string name="opt_shrink_playfield_downwards_summary">Shrink playfield downwards</string>
+
+    <string name="opt_hide_replay_marquee_title">Hide replay marquee</string>
+    <string name="opt_hide_replay_marquee_summary">Hide the scrolling text when watching replays</string>
+
+    <string name="opt_hide_ingame_ui_title">Hide ingame ui</string>
+    <string name="opt_hide_ingame_ui_summary">Hide the score, accuracy and combo counter along with the healthbar and combo bursts when ingame</string>
 </resources>

--- a/res/xml/options.xml
+++ b/res/xml/options.xml
@@ -25,8 +25,6 @@
             <EditTextPreference android:summary="@string/opt_playername_summary" android:key="playername"
                 android:title="@string/opt_playername_title"/>
         </PreferenceCategory>
-
-
     </PreferenceScreen>
 
     <PreferenceScreen android:title="@string/opt_graphics" android:key="general">
@@ -44,6 +42,10 @@
             android:defaultValue="1" android:entryValues="@array/spinner_style_values"/>
         <CheckBoxPreference android:summary="@string/opt_show_first_approach_circle_summary" android:title="@string/opt_show_first_approach_circle_title"
             android:key="showfirstapproachcircle" android:defaultValue="false"/>
+        <CheckBoxPreference android:key="hideReplayMarquee" android:title="@string/opt_hide_replay_marquee_title"
+            android:summary="@string/opt_hide_replay_marquee_summary" android:defaultValue="false"/>
+        <CheckBoxPreference android:key="hideInGameUI" android:title="@string/opt_hide_ingame_ui_title"
+            android:summary="@string/opt_hide_ingame_ui_summary" android:defaultValue="false"/>
         <CheckBoxPreference android:summary="@string/opt_skin_summary" android:title="@string/opt_skin_title"
             android:key="skin" android:defaultValue="false"/>
         <CheckBoxPreference android:summary="@string/opt_combo_burst_summary" android:title="@string/opt_combo_burst_title"
@@ -158,8 +160,6 @@
             android:summary="@string/opt_calculate_slider_path_in_game_start_summary" android:defaultValue="false"/>
         <CheckBoxPreference android:key="displayScorePP" android:title="@string/opt_display_score_pp_title"
             android:summary="@string/opt_display_score_pp_summary" android:defaultValue="false"/>
-        <CheckBoxPreference android:key="hideReplayMarquee" android:title="@string/opt_hide_replay_marquee_title"
-            android:summary="@string/opt_hide_replay_marquee_summary" android:defaultValue="false"/>
         <!--CheckBoxPreference android:key="enableExtension" android:title="@string/opt_enable_extension_title"
                             android:defaultValue="false"/>
         <Preference android:key="downloadExtension" android:title="@string/opt_download_extension_title" /-->

--- a/src/ru/nsu/ccfit/zuev/osu/Config.java
+++ b/src/ru/nsu/ccfit/zuev/osu/Config.java
@@ -85,6 +85,7 @@ public class Config {
     private static boolean calculateSliderPathInGameStart = false;
     private static boolean displayScorePP = false;
     private static boolean hideReplayMarquee = false;
+    private static boolean hideInGameUI = false;
 
     private static float cursorSize = 1;
 
@@ -271,7 +272,8 @@ public class Config {
         calculateSliderPathInGameStart = prefs.getBoolean("calculateSliderPathInGameStart", false);
         displayScorePP = prefs.getBoolean("displayScorePP", false);
         hideReplayMarquee = prefs.getBoolean("hideReplayMarquee", false);
-      
+        hideInGameUI = prefs.getBoolean("hideInGameUI", false);
+
         //Init
         onlineDeviceID = prefs.getString("installID", null);
         if (onlineDeviceID == null) {
@@ -340,10 +342,6 @@ public class Config {
 
     public static boolean isDisplayScorePP() {
         return displayScorePP;
-    }
-
-    public static boolean isHideReplayMarquee() {
-        return hideReplayMarquee;
     }
 
     public static boolean isEnableExtension() {
@@ -806,15 +804,31 @@ public class Config {
         return playfieldSize;
     }
 
-    public static void setPlayfieldSize(final float playfieldSize){
+    public static void setPlayfieldSize(final float playfieldSize) {
         Config.playfieldSize = playfieldSize;
     }
 
-    public static boolean isShrinkPlayfieldDownwards(){
+    public static boolean isShrinkPlayfieldDownwards() {
         return shrinkPlayfieldDownwards;
     }
 
-    public static void setShrinkPlayfieldDownwards(boolean shrinkPlayfieldDownwards){
+    public static void setShrinkPlayfieldDownwards(boolean shrinkPlayfieldDownwards) {
         Config.shrinkPlayfieldDownwards = shrinkPlayfieldDownwards;
+    }
+
+    public static boolean isHideReplayMarquee() {
+        return hideReplayMarquee;
+    }
+
+    public static void setHideReplayMarquee(boolean hideReplayMarquee) {
+        Config.hideReplayMarquee = hideReplayMarquee;
+    }
+
+    public static boolean isHideInGameUI() {
+        return hideInGameUI;
+    }
+
+    public static void setHideInGameUI(boolean hideInGameUI) {
+        Config.hideInGameUI = hideInGameUI;
     }
 }

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -927,54 +927,56 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
             }*/
         }
         GameHelper.setGlobalTime(0);
-        scorebar = new ScoreBar(this, fgScene, stat);
-        addPassiveObject(scorebar);
-        final TextureRegion scoreDigitTex = ResourceManager.getInstance()
-                .getTexture("score-0");
-        accText = new GameScoreText(Config.getRES_WIDTH()
-                - scoreDigitTex.getWidth() * 4.75f, 50,
-                "000.00%", 0.6f);
-        comboText = new GameScoreText(Utils.toRes(2), Config.getRES_HEIGHT()
-                - Utils.toRes(95), "0000x", 1.5f);
-        comboText.changeText(new StringBuilder("0****"));
-        scoreText = new GameScoreText(Config.getRES_WIDTH()
-                - scoreDigitTex.getWidth() * 7.25f, 0, "0000000000", 0.9f);
-        comboText.attachToScene(fgScene);
-        accText.attachToScene(fgScene);
-        scoreText.attachToScene(fgScene);
-        if (Config.isComplexAnimations()) {
-            scoreShadow = new GameScoreTextShadow(0, Config.getRES_HEIGHT()
-                    - Utils.toRes(90), "0000x", 1.5f);
-            scoreShadow.attachToScene(bgScene);
-            passiveObjects.add(scoreShadow);
-        }
-        breakAnimator = new BreakAnimator(this, fgScene, stat, beatmapData
-                .getData("General", "LetterboxInBreaks").equals("1"), bgSprite);
 
         float effectOffset = 155 - 25;
-        if (stat.getMod().contains(GameMod.MOD_AUTO)) {
-            final Sprite autoIcon = new Sprite(Utils.toRes(Config.getRES_WIDTH() - 140),
-                    Utils.toRes(100), ResourceManager.getInstance().getTexture(
-                    "selection-mod-autoplay"));
-            bgScene.attachChild(autoIcon);
-            effectOffset += 25;
-        } else if (stat.getMod().contains(GameMod.MOD_RELAX)) {
-            final Sprite autoIcon = new Sprite(Utils.toRes(Config.getRES_WIDTH() - 140),
-                    Utils.toRes(98), ResourceManager.getInstance().getTexture(
-                    "selection-mod-relax"));
-            bgScene.attachChild(autoIcon);
-            effectOffset += 25;
-        } else if (stat.getMod().contains(GameMod.MOD_AUTOPILOT)) {
-            final Sprite autoIcon = new Sprite(Utils.toRes(Config.getRES_WIDTH() - 140),
-                    Utils.toRes(98), ResourceManager.getInstance().getTexture(
-                    "selection-mod-relax2"));
-            bgScene.attachChild(autoIcon);
-            effectOffset += 25;
-        }
-
-        if (Config.isComboburst()) {
-            comboBurst = new ComboBurst(Config.getRES_WIDTH(), Config.getRES_HEIGHT());
-            comboBurst.attachAll(bgScene);
+        breakAnimator = new BreakAnimator(this, fgScene, stat, beatmapData
+                    .getData("General", "LetterboxInBreaks").equals("1"), bgSprite);
+        if(!Config.isHideInGameUI()){
+            scorebar = new ScoreBar(this, fgScene, stat);
+            addPassiveObject(scorebar);
+            final TextureRegion scoreDigitTex = ResourceManager.getInstance()
+                    .getTexture("score-0");
+            accText = new GameScoreText(Config.getRES_WIDTH()
+                    - scoreDigitTex.getWidth() * 4.75f, 50,
+                    "000.00%", 0.6f);
+            comboText = new GameScoreText(Utils.toRes(2), Config.getRES_HEIGHT()
+                    - Utils.toRes(95), "0000x", 1.5f);
+            comboText.changeText(new StringBuilder("0****"));
+            scoreText = new GameScoreText(Config.getRES_WIDTH()
+                    - scoreDigitTex.getWidth() * 7.25f, 0, "0000000000", 0.9f);
+            comboText.attachToScene(fgScene);
+            accText.attachToScene(fgScene);
+            scoreText.attachToScene(fgScene);
+            if (Config.isComplexAnimations()) {
+                scoreShadow = new GameScoreTextShadow(0, Config.getRES_HEIGHT()
+                        - Utils.toRes(90), "0000x", 1.5f);
+                scoreShadow.attachToScene(bgScene);
+                passiveObjects.add(scoreShadow);
+            }
+            if (stat.getMod().contains(GameMod.MOD_AUTO)) {
+                final Sprite autoIcon = new Sprite(Utils.toRes(Config.getRES_WIDTH() - 140),
+                        Utils.toRes(100), ResourceManager.getInstance().getTexture(
+                        "selection-mod-autoplay"));
+                bgScene.attachChild(autoIcon);
+                effectOffset += 25;
+            } else if (stat.getMod().contains(GameMod.MOD_RELAX)) {
+                final Sprite autoIcon = new Sprite(Utils.toRes(Config.getRES_WIDTH() - 140),
+                        Utils.toRes(98), ResourceManager.getInstance().getTexture(
+                        "selection-mod-relax"));
+                bgScene.attachChild(autoIcon);
+                effectOffset += 25;
+            } else if (stat.getMod().contains(GameMod.MOD_AUTOPILOT)) {
+                final Sprite autoIcon = new Sprite(Utils.toRes(Config.getRES_WIDTH() - 140),
+                        Utils.toRes(98), ResourceManager.getInstance().getTexture(
+                        "selection-mod-relax2"));
+                bgScene.attachChild(autoIcon);
+                effectOffset += 25;
+            }
+    
+            if (Config.isComboburst()) {
+                comboBurst = new ComboBurst(Config.getRES_WIDTH(), Config.getRES_HEIGHT());
+                comboBurst.attachAll(bgScene);
+            }
         }
 
         float timeOffset = 0;
@@ -1447,13 +1449,13 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
                     mainCursorId = -1;
                     flashlightSprite.updateBreak(true);
                 }
-                scorebar.setVisible(false);
+                if(scorebar != null) scorebar.setVisible(false);
                 breakPeriods.poll();
             }
         }
         if (breakAnimator.isOver()) {
             gameStarted = true;
-            scorebar.setVisible(true);
+            if(scorebar != null) scorebar.setVisible(true);
             if(GameHelper.isFlashLight()){
                 mainCursorId = -1;
                 flashlightSprite.updateBreak(false);
@@ -1486,64 +1488,64 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
             hitErrorMeter.update(dt);
         }
 
+        if(!Config.isHideInGameUI()) {
+            //连击数////////////////////////
+            final StringBuilder comboBuilder = new StringBuilder();
+            comboBuilder.setLength(0);
+            comboBuilder.append(stat.getCombo());
+            while (comboBuilder.length() < 5) {
+                comboBuilder.append('*');
+            }
+            if (Config.isComplexAnimations()) {
+                scoreShadow.changeText(comboBuilder);
+                scoreShadow.registerEntityModifier(new DelayModifier(0.2f, new IEntityModifier.IEntityModifierListener() {
+                    @Override
+                    public void onModifierStarted(IModifier<IEntity> iModifier, IEntity iEntity) { 
+                    }
+                    @Override
+                    public void onModifierFinished(IModifier<IEntity> iModifier, IEntity iEntity) {
+                        //当CB数字阴影缩小完成的时候 更改CB数字
+                        comboText.changeText(comboBuilder);
+                    }
+                }));
+            } else {
+                comboText.changeText(comboBuilder);
+            }
 
-        //连击数////////////////////////
-        final StringBuilder comboBuilder = new StringBuilder();
-        comboBuilder.setLength(0);
-        comboBuilder.append(stat.getCombo());
-        while (comboBuilder.length() < 5) {
-            comboBuilder.append('*');
-        }
-        if (Config.isComplexAnimations()) {
-            scoreShadow.changeText(comboBuilder);
-            scoreShadow.registerEntityModifier(new DelayModifier(0.2f, new IEntityModifier.IEntityModifierListener() {
-                @Override
-                public void onModifierStarted(IModifier<IEntity> iModifier, IEntity iEntity) {
-
-                }
-
-                @Override
-                public void onModifierFinished(IModifier<IEntity> iModifier, IEntity iEntity) {
-                    //当CB数字阴影缩小完成的时候 更改CB数字
-                    comboText.changeText(comboBuilder);
-                }
-            }));
-        } else {
-            comboText.changeText(comboBuilder);
-        }
-
-        //连击数////////////////////////
-        strBuilder.setLength(0);
-        float rawAccuracy = stat.getAccuracy() * 100f;
-        strBuilder.append((int) rawAccuracy);
-        if ((int) rawAccuracy < 10) {
-            strBuilder.insert(0, '0');
-        }
-        strBuilder.append('.');
-        rawAccuracy -= (int) rawAccuracy;
-        rawAccuracy *= 100;
-        if ((int) rawAccuracy < 10) {
-            strBuilder.append('0');
-        }
-        strBuilder.append((int) rawAccuracy);
-        if (strBuilder.length() < 6) {
-            strBuilder.insert(0, '*');
-        }
-        accText.changeText(strBuilder);
-        strBuilder.setLength(0);
-        strBuilder.append(stat.getAutoTotalScore());
-        while (strBuilder.length() < 8) {
-            strBuilder.insert(0, '0');
-        }
-        int scoreTextOffset = 0;
-        while (strBuilder.length() < 10) {
-            strBuilder.insert(0, '*');
-            scoreTextOffset++;
+            //连击数////////////////////////
+            strBuilder.setLength(0);
+            float rawAccuracy = stat.getAccuracy() * 100f;
+            strBuilder.append((int) rawAccuracy);
+            if ((int) rawAccuracy < 10) {
+                strBuilder.insert(0, '0');
+            }
+            strBuilder.append('.');
+            rawAccuracy -= (int) rawAccuracy;
+            rawAccuracy *= 100;
+            if ((int) rawAccuracy < 10) {
+                strBuilder.append('0');
+            }
+            strBuilder.append((int) rawAccuracy);
+            if (strBuilder.length() < 6) {
+                strBuilder.insert(0, '*');
+            }
+            accText.changeText(strBuilder);
+            strBuilder.setLength(0);
+            strBuilder.append(stat.getAutoTotalScore());
+            while (strBuilder.length() < 8) {
+                strBuilder.insert(0, '0');
+            }
+            int scoreTextOffset = 0;
+            while (strBuilder.length() < 10) {
+                strBuilder.insert(0, '*');
+                scoreTextOffset++;
+            }
+    
+            scoreText.setPosition(Config.getRES_WIDTH()
+                    - ResourceManager.getInstance().getTexture("score-0").getWidth() * (9.25f - scoreTextOffset), 0);
+            scoreText.changeText(strBuilder);
         }
 
-        scoreText.setPosition(Config.getRES_WIDTH()
-                - ResourceManager.getInstance().getTexture("score-0").getWidth() * (9.25f - scoreTextOffset), 0);
-        scoreText.changeText(strBuilder);
         if (comboBurst != null) {
             if (stat.getCombo() == 0) {
                 comboBurst.breakCombo();
@@ -2450,7 +2452,7 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
             EdExtensionHelper.onGameover(lastTrack);
         }
 
-        scorebar.flush();
+        if(scorebar != null) scorebar.flush();
         ResourceManager.getInstance().getSound("failsound").play();
         final PauseMenu menu = new PauseMenu(engine, this, true);
         gameStarted = false;


### PR DESCRIPTION
This PR adds `Config.setHideReplayMarquee()` and the option to hide the following in-game elements: combo burst, healthbar(scorebar), combo, accuracy & score counter. Also some grammar fix on the README.