### PR TITLE
Limit Flashlight position to screen size

### DIFF
--- a/src/ru/nsu/ccfit/zuev/osu/game/cursor/flashlight/FlashLightEntity.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/cursor/flashlight/FlashLightEntity.java
@@ -1,5 +1,7 @@
 package ru.nsu.ccfit.zuev.osu.game.cursor.flashlight;
 
+import com.edlplan.framework.math.FMath;
+
 import org.anddev.andengine.entity.Entity;
 import org.anddev.andengine.entity.modifier.IEntityModifier;
 import org.anddev.andengine.entity.modifier.MoveModifier;


### PR DESCRIPTION
Basically as from now in some maps like solace of oblivion using auto mod, fl will go out of screen because of the sliders that extends over the total game size, this fixes that.