### PR TITLE
Implement AR checking for Auto cursor

### DIFF
--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -1595,7 +1595,7 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
         }
 
         if (GameHelper.isAuto() || GameHelper.isAutopilotMod()) {
-            autoCursor.moveToObject(activeObjects.peek(), secPassed, approachRate, stat, this);
+            autoCursor.moveToObject(activeObjects.peek(), secPassed, approachRate, this);
         }
 
         int clickCount = 0;

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -1595,7 +1595,7 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
         }
 
         if (GameHelper.isAuto() || GameHelper.isAutopilotMod()) {
-            autoCursor.moveToObject(activeObjects.peek(), secPassed, approachRate, this);
+            autoCursor.moveToObject(activeObjects.peek(), secPassed, approachRate, stat, this);
         }
 
         int clickCount = 0;

--- a/src/ru/nsu/ccfit/zuev/osu/game/cursor/main/AutoCursor.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/cursor/main/AutoCursor.java
@@ -10,7 +10,6 @@ import ru.nsu.ccfit.zuev.osu.game.GameObject;
 import ru.nsu.ccfit.zuev.osu.game.GameObjectListener;
 import ru.nsu.ccfit.zuev.osu.game.ISliderListener;
 import ru.nsu.ccfit.zuev.osu.game.Spinner;
-import ru.nsu.ccfit.zuev.osu.scoring.StatisticV2;
 
 public class AutoCursor extends CursorEntity implements ISliderListener {
     private MoveModifier currentModifier;
@@ -60,13 +59,13 @@ public class AutoCursor extends CursorEntity implements ISliderListener {
 
     /**
      * Moves the cursor to the specified object.
+     *
      * @param object       The object to move the cursor to.
      * @param secPassed    The amount of seconds that have passed since the game has started.
      * @param approachRate The approach rate of the beatmap.
-     * @param stat         The StatisticsV2 class for force AR checking.
      * @param listener     The listener that listens to when this cursor is moved.
      */
-    public void moveToObject(GameObject object, float secPassed, float approachRate, StatisticV2 stat, GameObjectListener listener) {
+    public void moveToObject(GameObject object, float secPassed, float approachRate, GameObjectListener listener) {
         if (object == null || currentObjectId == object.getId()) {
             return;
         }
@@ -81,14 +80,10 @@ public class AutoCursor extends CursorEntity implements ISliderListener {
         }
 
         currentObjectId = object.getId();
-        if (stat.getForceAR() != approachRate && stat.isEnableForceAR()) {
-            if (stat.getForceAR() > 12f) {
-                approachRate = (float) GameHelper.ar2ms(stat.getForceAR()); // AR 12 is pretty much instantaneous so it doesn't matter
-            } else if (stat.getForceAR() > 10f) {
-                approachRate = (float) GameHelper.ar2ms(stat.getForceAR()) / 250f;
-            } else {
-                approachRate = (float) GameHelper.ar2ms(stat.getForceAR()) / 1000f;
-            }
+        if (GameHelper.ms2ar(approachRate) > 12f) {
+            approachRate *= 1000f;
+        } else if (GameHelper.ms2ar(approachRate) > 10f) {
+            approachRate *= 4f;
         }
         float moveDelay = (deltaT / approachRate) + 0.1f;
         doAutoMove(movePositionX, movePositionY, moveDelay, listener);

--- a/src/ru/nsu/ccfit/zuev/osu/game/cursor/main/AutoCursor.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/cursor/main/AutoCursor.java
@@ -5,10 +5,12 @@ import org.anddev.andengine.util.modifier.ease.EaseQuadOut;
 import org.anddev.andengine.util.modifier.ease.IEaseFunction;
 
 import ru.nsu.ccfit.zuev.osu.Config;
+import ru.nsu.ccfit.zuev.osu.game.GameHelper;
 import ru.nsu.ccfit.zuev.osu.game.GameObject;
 import ru.nsu.ccfit.zuev.osu.game.GameObjectListener;
 import ru.nsu.ccfit.zuev.osu.game.ISliderListener;
 import ru.nsu.ccfit.zuev.osu.game.Spinner;
+import ru.nsu.ccfit.zuev.osu.scoring.StatisticV2;
 
 public class AutoCursor extends CursorEntity implements ISliderListener {
     private MoveModifier currentModifier;
@@ -58,13 +60,13 @@ public class AutoCursor extends CursorEntity implements ISliderListener {
 
     /**
      * Moves the cursor to the specified object.
-     *
      * @param object       The object to move the cursor to.
      * @param secPassed    The amount of seconds that have passed since the game has started.
      * @param approachRate The approach rate of the beatmap.
+     * @param stat         The StatisticsV2 class for force AR checking.
      * @param listener     The listener that listens to when this cursor is moved.
      */
-    public void moveToObject(GameObject object, float secPassed, float approachRate, GameObjectListener listener) {
+    public void moveToObject(GameObject object, float secPassed, float approachRate, StatisticV2 stat, GameObjectListener listener) {
         if (object == null || currentObjectId == object.getId()) {
             return;
         }
@@ -79,7 +81,15 @@ public class AutoCursor extends CursorEntity implements ISliderListener {
         }
 
         currentObjectId = object.getId();
-        // smoothing factor is arbitrary
+        if (stat.getForceAR() != approachRate && stat.isEnableForceAR()) {
+            if (stat.getForceAR() > 12f) {
+                approachRate = (float) GameHelper.ar2ms(stat.getForceAR()); // AR 12 is pretty much instantaneous so it doesn't matter
+            } else if (stat.getForceAR() > 10f) {
+                approachRate = (float) GameHelper.ar2ms(stat.getForceAR()) / 250f;
+            } else {
+                approachRate = (float) GameHelper.ar2ms(stat.getForceAR()) / 1000f;
+            }
+        }
         float moveDelay = (deltaT / approachRate) + 0.1f;
         doAutoMove(movePositionX, movePositionY, moveDelay, listener);
     }


### PR DESCRIPTION
With my previous improvement on Auto cursor, it completely breaks at high AR (above AR10, more so above AR11). This fixes it by adjusting the speed (more like the "time" required for the cursor to go from the first note to the next) by modifying the approach rate **used for calculation**.

Since the velocity of the cursor depends on approach rate, forcing AR slightly above AR 10 (something like AR 10.1) speeds up the cursor considerably. I don't find this worth changing, so I left it as it is.

I've only tested it on 2 maps on my AVD, each with 2 difficulties, with DTHR and Force AR tested, so far no issues. If anyone who tests this finds one, let me know.