### PR TITLE
Fix crashes on devices running below Android 11

### DIFF
--- a/src/ru/nsu/ccfit/zuev/osu/Config.java
+++ b/src/ru/nsu/ccfit/zuev/osu/Config.java
@@ -138,13 +138,13 @@ public class Config {
             soundVolume = prefs.getInt("soundvolume", 100) / 100f;
             bgmVolume = prefs.getInt("bgmvolume", 100) / 100f;
             cursorSize = prefs.getInt("cursorSize", 50) / 100f;
-        }catch(RuntimeException e) { // migrate to integers to prevent crash
+        }catch(RuntimeException e) { // use valid integer since this makes the game crash on android m
             prefs.edit()
-                .putInt("offset", Integer.parseInt(prefs.getString("offset", "0")))
-                .putInt("bgbrightness", Integer.parseInt(prefs.getString("bgbrightness", "25")))
-                .putInt("soundvolume", Integer.parseInt(prefs.getString("soundvolume", "100")))
-                .putInt("bgmvolume", Integer.parseInt(prefs.getString("bgmvolume", "100")))
-                .putInt("cursorSize", Integer.parseInt(prefs.getString("cursorSize", "50")))
+                .putInt("offset", 0)
+                .putInt("bgbrightness", 25)
+                .putInt("soundvolume", 100)
+                .putInt("bgmvolume", 100)
+                .putInt("cursorSize", 50)
                 .commit();
             Config.loadConfig(context);
         }
@@ -194,14 +194,6 @@ public class Config {
         comboColors = new RGBColor[4];
         for (int i = 1; i <= 4; i++) {
             comboColors[i - 1] = RGBColor.hex2Rgb(ColorPickerPreference.convertToRGB(prefs.getInt("combo" + i, 0xff000000)));
-        }
-
-        // skins
-        File[] folders = FileUtils.listFiles(new File(skinTopPath), file -> file.isDirectory() && !file.getName().startsWith("."));
-        skins = new HashMap<String, String>();
-        for(File folder : folders) {
-            skins.put(folder.getName(), folder.getPath());
-            Debug.i("skins: " + folder.getName() + " - " + folder.getPath());
         }
 
         // beatmaps
@@ -765,6 +757,15 @@ public class Config {
 
     public static String getDefaultCorePath() {
         return defaultCorePath;
+    }
+
+    public static void loadSkins() {
+        File[] folders = FileUtils.listFiles(new File(skinTopPath), file -> file.isDirectory() && !file.getName().startsWith("."));
+        skins = new HashMap<String, String>();
+        for(File folder : folders) {
+            skins.put(folder.getName(), folder.getPath());
+            Debug.i("skins: " + folder.getName() + " - " + folder.getPath());
+        }
     }
 
     public static Map<String, String> getSkins(){

--- a/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
+++ b/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
@@ -309,6 +309,7 @@ public class MainActivity extends BaseGameActivity implements
                 GlobalManager.getInstance().init();
                 analytics.logEvent(FirebaseAnalytics.Event.APP_OPEN, null);
                 GlobalManager.getInstance().setLoadingProgress(50);
+                Config.loadSkins();
                 checkNewSkins();
                 checkNewBeatmaps();
                 if (!LibraryManager.getInstance().loadLibraryCache(MainActivity.this, true)) {

--- a/src/ru/nsu/ccfit/zuev/osu/helper/FileUtils.java
+++ b/src/ru/nsu/ccfit/zuev/osu/helper/FileUtils.java
@@ -6,6 +6,7 @@ import android.os.Environment;
 import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.File;
+import java.io.FileFilter;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
@@ -176,11 +177,9 @@ public class FileUtils {
         return null;
     }
 
-    public static File[] listFiles(File directory, FileUtilsFilter filter) {
+    public static File[] listFiles(File directory, FileFilter filter) {
         File[] filelist = null;
-        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            filelist = directory.listFiles(pathname -> filter.accept(pathname));
-        }else if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             LinkedList<File> cachedFiles = new LinkedList<File>();
             DirectoryStream.Filter<Path> directoryFilter = new DirectoryStream.Filter<Path>() {
                 @Override
@@ -196,12 +195,10 @@ public class FileUtils {
                 Debug.e("FileUtils.listFiles: " + err.getMessage(), err);
             }
             filelist = cachedFiles.toArray(new File[cachedFiles.size()]);
+        }else {
+            filelist = directory.listFiles(filter);
         }
         return filelist;
-    }
-
-    public interface FileUtilsFilter {
-        boolean accept(File file);
     }
 
 }


### PR DESCRIPTION
This PR fixes the crashes experienced by users after they update to the new version when they're not running Android Oreo or above.