### PR TITLE
Fix AR checking for Auto cursor

### DIFF
--- a/src/ru/nsu/ccfit/zuev/osu/game/cursor/main/AutoCursor.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/cursor/main/AutoCursor.java
@@ -80,12 +80,12 @@ public class AutoCursor extends CursorEntity implements ISliderListener {
         }
 
         currentObjectId = object.getId();
-        if (GameHelper.ms2ar(approachRate) > 12f) {
-            approachRate *= 1000f;
-        } else if (GameHelper.ms2ar(approachRate) > 10f) {
-            approachRate *= 4f;
+        if (GameHelper.ms2ar(approachRate * 1000f) > 12f) {
+            approachRate *= 500f;
+        } else if (GameHelper.ms2ar(approachRate * 1000f) > 10f) {
+            approachRate *= 2f;
         }
-        float moveDelay = (deltaT / approachRate) + 0.1f;
+        float moveDelay = (deltaT / (approachRate * 2f)) + 0.1f;
         doAutoMove(movePositionX, movePositionY, moveDelay, listener);
     }
 


### PR DESCRIPTION
This happened because in the pre-release I saw the cursor to be faster than I originally planned.

In my recent Auto cursor fix, I overlooked the millisecond to AR in AR checking. It was supposed to be multiplied by 1000 as the approach rate given by the parameter was in seconds. As such, this PR fixes that issue. It should work properly now.

While I'm at it, I made the cursor faster when AR is below AR 10, as I think some people may find it too slow.