### PR TITLE
Add restart dialog when toggling dither

### DIFF
--- a/res/values/options.xml
+++ b/res/values/options.xml
@@ -244,7 +244,7 @@
     <string name="opt_hitlighting_summary">Adds a subtle glow behind hit explosions which lights the playfield</string>
 
     <string name="opt_dither_title">Dither</string>
-    <string name="opt_dither_summary">Use hardware dither for better image quality (requires restart)</string>
+    <string name="opt_dither_summary">Use hardware dither for better image quality (requires a restart to apply changes)</string>
 
     <string name="opt_particles_title">Particle effects</string>
     <string name="opt_particles_summary">Show particle-based effects like cursor trail</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -45,6 +45,8 @@
 	<string name="dialog_exit_yes">Yes</string>
 	<string name="dialog_exit_no">No</string>
 
+	<string name="dialog_dither_confirm">Restart to apply changes.</string>
+
 	<string name="dialog_visit_osu_website_message">Do you want to visit the official osu! website?</string>
 	<string name="dialog_visit_osudroid_website_message">Do you want to visit the official osu!droid website?</string>
 

--- a/src/ru/nsu/ccfit/zuev/osu/MainScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/MainScene.java
@@ -1170,6 +1170,20 @@ public class MainScene implements IUpdateHandler {
         }, 3000, TimeUnit.MILLISECONDS);
     }
 
+    public void restart() {
+        MainActivity mActivity = GlobalManager.getInstance().getMainActivity();
+        mActivity.runOnUiThread(() -> new ConfirmDialogFragment().setMessage(R.string.dialog_dither_confirm).showForResult(
+                isAccepted -> {
+                    if (isAccepted) {
+                        Intent mIntent = new Intent(mActivity, MainActivity.class);
+                        mIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+                        mActivity.startActivity(mIntent);
+                        System.exit(0);
+                    }
+                }
+        ));
+    }
+
     public Scene getScene() {
         return scene;
     }

--- a/src/ru/nsu/ccfit/zuev/osu/menu/SettingsMenu.java
+++ b/src/ru/nsu/ccfit/zuev/osu/menu/SettingsMenu.java
@@ -159,6 +159,14 @@ public class SettingsMenu extends SettingsFragment {
             Updater.getInstance().checkForUpdates();
             return true;
         });
+
+        final Preference dither = findPreference("dither");
+        dither.setOnPreferenceChangeListener((preference, newValue) -> {
+            if (Config.isUseDither() != (boolean) newValue) {
+                GlobalManager.getInstance().getMainScene().restart();
+            }
+            return true;
+        });
     }
 
     public void onNavigateToScreen(PreferenceScreen preferenceScreen) {


### PR DESCRIPTION
Toggling dithering on or off without a restart (closing the game directly from the recents list) may cause a crash on certain devices when closing options; this PR adds a restart dialog when toggling the option.

Pressing "ok" will restart the game, while pressing/swiping back will not restart the game, nor will it crash when closing options (tested this on my phone, which prior to this addition/fix, the crash was easily reproduced), as the change will apply at restart. Toggling back the option to its initial value (let's say, on -> off -> on) won't display the dialog.

While I'm at it, I changed the dithering option's description to be... more descriptive.