### PR TITLE
Fix for fragments still showing after game exit.

### DIFF
--- a/src/ru/nsu/ccfit/zuev/osu/MainScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/MainScene.java
@@ -1163,7 +1163,7 @@ public class MainScene implements IUpdateHandler {
                     GlobalManager.getInstance().getMainActivity().stopService(new Intent(GlobalManager.getInstance().getMainActivity(), SongService.class));
                     musicStarted = false;
                 }
-                android.os.Process.killProcess(android.os.Process.myPid());
+                GlobalManager.getInstance().getMainActivity().finish();
             }
         }, 3000, TimeUnit.MILLISECONDS);
     }


### PR DESCRIPTION
Basically solves this bug:

![Screenshot_2022-07-14-22-08-20-758_ru nsu ccfit zuev osuplus](https://user-images.githubusercontent.com/103213881/179127036-9f21ed05-7916-44d2-8579-587c9385b14a.jpg)

By replacing `android.os.Process.killProcess()` with `MainActivity.finish()` in the method `MainScene.exit()` that does pretty much the same but also removes all fragments.

`exit()` is called when the user clicks on **Exit** from the main menu or when the user clicks on the close button from the notification.

To produce that bug in pre-release 3: 
1. Click **Play** and **Settings** at the same time.
2. Close the Settings Menu
3. Open Mod Menu
4. Then minimize the game, and close it from the notification.
6. Now start the game again and you get it.