### PR TITLE
Library rework to support multithreading

### DIFF
--- a/src/com/reco1l/legacy/ui/ChimuWebView.java
+++ b/src/com/reco1l/legacy/ui/ChimuWebView.java
@@ -182,7 +182,7 @@ public class ChimuWebView extends WebViewFragment implements IDownloaderObserver
                 return;
             }
 
-            LibraryManager.getInstance().updateLibrary(true);
+            LibraryManager.INSTANCE.updateLibrary(true);
         }
         catch (IOException e)
         {

--- a/src/ru/nsu/ccfit/zuev/audio/serviceAudio/NotifyPlayer.java
+++ b/src/ru/nsu/ccfit/zuev/audio/serviceAudio/NotifyPlayer.java
@@ -91,14 +91,14 @@ public class NotifyPlayer {
                         break;
                     case actionPrev:
                         service.stop();
-                        BeatmapInfo prevBeatmap = LibraryManager.getInstance().getPrevBeatmap();
+                        BeatmapInfo prevBeatmap = LibraryManager.INSTANCE.getPrevBeatmap();
                         service.preLoad(prevBeatmap.getMusic());
                         updateSong(prevBeatmap);
                         service.play();
                         break;
                     case actionNext:
                         service.stop();
-                        BeatmapInfo nextBeatmap = LibraryManager.getInstance().getNextBeatmap();
+                        BeatmapInfo nextBeatmap = LibraryManager.INSTANCE.getNextBeatmap();
                         service.preLoad(nextBeatmap.getMusic());
                         updateSong(nextBeatmap);
                         service.play();

--- a/src/ru/nsu/ccfit/zuev/audio/serviceAudio/SongService.java
+++ b/src/ru/nsu/ccfit/zuev/audio/serviceAudio/SongService.java
@@ -271,9 +271,9 @@ public class SongService extends Service {
         setVolume(Config.getBgmVolume());
 
         // Reload audio, otherwise it will be choppy or offset for whatever reason.
-        if (LibraryManager.getInstance().getBeatmap() != null) {
+        if (LibraryManager.INSTANCE.getBeatmap() != null) {
             int position = getPosition();
-            preLoad(LibraryManager.getInstance().getBeatmap().getMusic());
+            preLoad(LibraryManager.INSTANCE.getBeatmap().getMusic());
             seekTo(position);
         }
 

--- a/src/ru/nsu/ccfit/zuev/osu/LibraryManager.java
+++ b/src/ru/nsu/ccfit/zuev/osu/LibraryManager.java
@@ -389,11 +389,9 @@ public enum LibraryManager {
 
     public int findBeatmap(BeatmapInfo info) {
         synchronized (library) {
-            if (library.size() > 0) {
-                for (int i = 0; i < library.size(); i++) {
-                    if (library.get(i).equals(info)) {
-                        return currentIndex = i;
-                    }
+            for (int i = 0; i < library.size(); i++) {
+                if (library.get(i).equals(info)) {
+                    return currentIndex = i;
                 }
             }
         }
@@ -402,11 +400,9 @@ public enum LibraryManager {
 
     public int findBeatmapById(int mapSetId) {
         synchronized (library) {
-            if (library.size() > 0) {
-                for (int i = 0; i < library.size(); i++) {
-                    if (library.get(i).getTrack(0).getBeatmapSetID() == mapSetId) {
-                        return currentIndex = i;
-                    }
+            for (int i = 0; i < library.size(); i++) {
+                if (library.get(i).getTrack(0).getBeatmapSetID() == mapSetId) {
+                    return currentIndex = i;
                 }
             }
         }
@@ -423,16 +419,14 @@ public enum LibraryManager {
 
     public TrackInfo findTrackByFileNameAndMD5(String fileName, String md5) {
         synchronized (library) {
-            if (library.size() > 0) {
-                for (BeatmapInfo info : library) {
-                    for (int j = 0; j < info.getCount(); j++) {
-                        TrackInfo track = info.getTrack(j);
-                        File trackFile = new File(track.getFilename());
-                        if (fileName.equals(trackFile.getName())) {
-                            String trackMD5 = FileUtils.getMD5Checksum(trackFile);
-                            if (md5.equals(trackMD5)) {
-                                return track;
-                            }
+            for (BeatmapInfo info : library) {
+                for (int j = 0; j < info.getCount(); j++) {
+                    TrackInfo track = info.getTrack(j);
+                    File trackFile = new File(track.getFilename());
+                    if (fileName.equals(trackFile.getName())) {
+                        String trackMD5 = FileUtils.getMD5Checksum(trackFile);
+                        if (md5.equals(trackMD5)) {
+                            return track;
                         }
                     }
                 }

--- a/src/ru/nsu/ccfit/zuev/osu/LibraryManager.java
+++ b/src/ru/nsu/ccfit/zuev/osu/LibraryManager.java
@@ -1,29 +1,19 @@
 package ru.nsu.ccfit.zuev.osu;
 
-import android.app.Activity;
-
 import android.os.Build;
+import org.anddev.andengine.util.Debug;
 import ru.nsu.ccfit.zuev.osu.beatmap.BeatmapData;
 import ru.nsu.ccfit.zuev.osu.beatmap.parser.BeatmapParser;
 import ru.nsu.ccfit.zuev.osu.helper.FileUtils;
-import org.anddev.andengine.util.Debug;
+import ru.nsu.ccfit.zuev.osu.helper.StringTable;
+import ru.nsu.ccfit.zuev.osuplus.R;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
+import java.io.*;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-// import java.util.HashSet;
-// import java.util.Set;
-
-import ru.nsu.ccfit.zuev.osu.helper.StringTable;
-import ru.nsu.ccfit.zuev.osuplus.R;
 
 public enum LibraryManager {
     INSTANCE;

--- a/src/ru/nsu/ccfit/zuev/osu/LibraryManager.java
+++ b/src/ru/nsu/ccfit/zuev/osu/LibraryManager.java
@@ -477,9 +477,6 @@ public enum LibraryManager {
                         synchronized (this) {
                             totalMaps += info.getCount();
                         }
-
-                        Debug.i("Library Cache: " + fileCached + "/" + list.size());
-                        FileUtils.getMD5Checksum(file);
                     }
                 }));
             }
@@ -487,11 +484,13 @@ public enum LibraryManager {
             try {
                 if (executors.awaitTermination(10, TimeUnit.MINUTES)) {
                     Debug.i("Library Cache: " + totalMaps + " maps loaded");
-                }
-                isCaching = false;
+                    isCaching = false;
 
-                synchronized (LibraryManager.class) {
-                    LibraryManager.class.notify();
+                    synchronized (LibraryManager.class) {
+                        LibraryManager.class.notify();
+                    }
+                } else {
+                    Debug.e("Library Cache: Timeout");
                 }
             } catch (InterruptedException e) {
                 Debug.e(e);

--- a/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
+++ b/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
@@ -311,8 +311,8 @@ public class MainActivity extends BaseGameActivity implements
                 Config.loadSkins();
                 checkNewSkins();
                 checkNewBeatmaps();
-                if (!LibraryManager.getInstance().loadLibraryCache(MainActivity.this, true)) {
-                    LibraryManager.getInstance().scanLibrary(MainActivity.this);
+                if (!LibraryManager.INSTANCE.loadLibraryCache(true)) {
+                    LibraryManager.INSTANCE.scanLibrary();
                     System.gc();
                 }
                 SplashScene.INSTANCE.playWelcomeAnimation();
@@ -413,8 +413,8 @@ public class MainActivity extends BaseGameActivity implements
                         false);
 
                 FileUtils.extractZip(beatmapToAdd, Config.getBeatmapPath());
-                // LibraryManager.getInstance().sort();
-                LibraryManager.getInstance().savetoCache(MainActivity.this);
+                // LibraryManager.INSTANCE.sort();
+                LibraryManager.INSTANCE.saveToCache();
             } else if (file.getName().endsWith(".odr")) {
                 willReplay = true;
             }
@@ -464,8 +464,8 @@ public class MainActivity extends BaseGameActivity implements
                 }
                 // Config.setDELETE_OSZ(deleteOsz);
 
-                // LibraryManager.getInstance().sort();
-                LibraryManager.getInstance().savetoCache(MainActivity.this);
+                // LibraryManager.INSTANCE.sort();
+                LibraryManager.INSTANCE.saveToCache();
             }
         }
     }

--- a/src/ru/nsu/ccfit/zuev/osu/MainScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/MainScene.java
@@ -216,8 +216,8 @@ public class MainScene implements IUpdateHandler {
                             GlobalManager.getInstance().getEngine().setScene(new LoadingScreen().getScene());
                             GlobalManager.getInstance().getMainActivity().checkNewSkins();
                             GlobalManager.getInstance().getMainActivity().checkNewBeatmaps();
-                            if (!LibraryManager.getInstance().loadLibraryCache(GlobalManager.getInstance().getMainActivity(), true)) {
-                                LibraryManager.getInstance().scanLibrary(GlobalManager.getInstance().getMainActivity());
+                            if (!LibraryManager.INSTANCE.loadLibraryCache(true)) {
+                                LibraryManager.INSTANCE.scanLibrary();
                                 System.gc();
                             }
                             GlobalManager.getInstance().getSongMenu().reload();
@@ -506,7 +506,7 @@ public class MainScene implements IUpdateHandler {
             scene.attachChild(spectrum[i]);
         }
 
-        LibraryManager.getInstance().loadLibraryCache((Activity) context, false);
+        LibraryManager.INSTANCE.loadLibraryCache(false);
 
         TextureRegion starRegion = ResourceManager.getInstance().getTexture("star");
 
@@ -658,7 +658,7 @@ public class MainScene implements IUpdateHandler {
                     GlobalManager.getInstance().getSongService().stop();
                 }
                 firstTimingPoint = null;
-                LibraryManager.getInstance().getPrevBeatmap();
+                LibraryManager.INSTANCE.getPrevBeatmap();
                 loadBeatmapInfo();
                 loadTimeingPoints(true);
                 doChange = false;
@@ -713,7 +713,7 @@ public class MainScene implements IUpdateHandler {
                 if (GlobalManager.getInstance().getSongService().getStatus() == Status.PLAYING || GlobalManager.getInstance().getSongService().getStatus() == Status.PAUSED) {
                     GlobalManager.getInstance().getSongService().stop();
                 }
-                LibraryManager.getInstance().getNextBeatmap();
+                LibraryManager.INSTANCE.getNextBeatmap();
                 firstTimingPoint = null;
                 loadBeatmapInfo();
                 loadTimeingPoints(true);
@@ -925,14 +925,14 @@ public class MainScene implements IUpdateHandler {
     }
 
     public void loadBeatmap() {
-        LibraryManager.getInstance().shuffleLibrary();
+        LibraryManager.INSTANCE.shuffleLibrary();
         loadBeatmapInfo();
         loadTimeingPoints(true);
     }
 
     public void loadBeatmapInfo() {
-        if (LibraryManager.getInstance().getSizeOfBeatmaps() != 0) {
-            beatmapInfo = LibraryManager.getInstance().getBeatmap();
+        if (LibraryManager.INSTANCE.getSizeOfBeatmaps() != 0) {
+            beatmapInfo = LibraryManager.INSTANCE.getBeatmap();
             Log.w("MainMenuActivity", "Next song: " + beatmapInfo.getMusic() + ", Start at: " + beatmapInfo.getPreviewTime());
 
             if (musicInfoText == null) {
@@ -1133,7 +1133,7 @@ public class MainScene implements IUpdateHandler {
     }
 
     public void setBeatmap(BeatmapInfo info) {
-        int playIndex = LibraryManager.getInstance().findBeatmap(info);
+        int playIndex = LibraryManager.INSTANCE.findBeatmap(info);
         Debug.i("index " + playIndex);
         loadBeatmapInfo();
         loadTimeingPoints(false);
@@ -1147,7 +1147,7 @@ public class MainScene implements IUpdateHandler {
                 //replay
                 ScoringScene scorescene = GlobalManager.getInstance().getScoring();
                 StatisticV2 stat = replay.getStat();
-                TrackInfo track = LibraryManager.getInstance().findTrackByFileNameAndMD5(replay.getMapFile(), replay.getMd5());
+                TrackInfo track = LibraryManager.INSTANCE.findTrackByFileNameAndMD5(replay.getMapFile(), replay.getMd5());
                 if (track != null) {
                     GlobalManager.getInstance().getMainScene().setBeatmap(track.getBeatmap());
                     GlobalManager.getInstance().getSongMenu().select();

--- a/src/ru/nsu/ccfit/zuev/osu/helper/FileUtils.java
+++ b/src/ru/nsu/ccfit/zuev/osu/helper/FileUtils.java
@@ -78,7 +78,7 @@ public class FileUtils {
                         false);
                 Debug.e("FileUtils.extractZip: " + file.getName() + " is invalid");
                 file.renameTo(new File(file.getParentFile(), sourceFileName + ".badzip"));
-                LibraryManager.getInstance().deleteDir(folderFile);
+                LibraryManager.deleteDir(folderFile);
                 return false;
             }
 

--- a/src/ru/nsu/ccfit/zuev/osu/menu/MenuItem.java
+++ b/src/ru/nsu/ccfit/zuev/osu/menu/MenuItem.java
@@ -314,7 +314,7 @@ public class MenuItem {
         freeBackground();
         visible = false;
         deleted = true;
-        LibraryManager.getInstance().deleteMap(beatmap);
+        LibraryManager.INSTANCE.deleteMap(beatmap);
     }
 
     public boolean isVisible() {

--- a/src/ru/nsu/ccfit/zuev/osu/menu/SettingsMenu.java
+++ b/src/ru/nsu/ccfit/zuev/osu/menu/SettingsMenu.java
@@ -143,7 +143,7 @@ public class SettingsMenu extends SettingsFragment {
 
         final Preference pref = findPreference("clear");
         pref.setOnPreferenceClickListener(preference -> {
-            LibraryManager.getInstance().clearCache();
+            LibraryManager.INSTANCE.clearCache();
             return true;
         });
         final Preference clearProps = findPreference("clear_properties");

--- a/src/ru/nsu/ccfit/zuev/osu/menu/SongMenu.java
+++ b/src/ru/nsu/ccfit/zuev/osu/menu/SongMenu.java
@@ -185,7 +185,7 @@ public class SongMenu implements IUpdateHandler, MenuItemListener,
         board = new ScoreBoard(scene, backLayer, this, context);
 
         float oy = 10;
-        for (final BeatmapInfo i : LibraryManager.getInstance().getLibrary()) {
+        for (final BeatmapInfo i : LibraryManager.INSTANCE.getLibrary()) {
             final MenuItem item = new MenuItem(this, i);
             items.add(item);
             item.attachToScene(scene, backLayer);
@@ -1330,7 +1330,7 @@ public class SongMenu implements IUpdateHandler, MenuItemListener,
             items.clear();
             switch (type) {
                 case MapSet:
-                    for (final BeatmapInfo i : LibraryManager.getInstance().getLibrary()) {
+                    for (final BeatmapInfo i : LibraryManager.INSTANCE.getLibrary()) {
                         final MenuItem item = new MenuItem(this, i);
                         items.add(item);
                         item.attachToScene(scene, backLayer);
@@ -1338,7 +1338,7 @@ public class SongMenu implements IUpdateHandler, MenuItemListener,
                     }
                     break;
                 case SingleDiff:
-                    for (final BeatmapInfo i : LibraryManager.getInstance().getLibrary()) {
+                    for (final BeatmapInfo i : LibraryManager.INSTANCE.getLibrary()) {
                         for (int j = 0; j < i.getCount(); j++) {
                             final MenuItem item = new MenuItem(this, i, j);
                             items.add(item);


### PR DESCRIPTION
`LibraryManager` loads and caches beatmaps synchronously and in a single-threaded operation, which causes long caching times as most is spent on a single thread while the rest of the CPU does nothing.. This PR reworks the loading operation to utilize all available cores to finish caching as fast as possible.