### PR TITLE
Fix a bug in LibraryManager where a loop may terminate prematurely

### DIFF
--- a/src/ru/nsu/ccfit/zuev/osu/LibraryManager.java
+++ b/src/ru/nsu/ccfit/zuev/osu/LibraryManager.java
@@ -474,12 +474,12 @@ public enum LibraryManager {
             // Remove all beatmaps that are no longer in the library
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 // For some reason forEach() doesn't work here (produces NullPointerException)
-                var testList = library.stream().filter(i -> !files.contains(new File(i.getPath()))).collect(Collectors.toList());
-                library.removeAll(testList);
+                var removedMaps = library.stream().filter(i -> !files.contains(new File(i.getPath()))).collect(Collectors.toList());
+                library.removeAll(removedMaps);
             } else {
-                for (BeatmapInfo i : library) {
-                    if (!files.contains(new File(i.getPath()))) {
-                        synchronized (library) {
+                synchronized (library) {
+                    for (BeatmapInfo i : library) {
+                        if (!files.contains(new File(i.getPath()))) {
                             library.remove(i);
                         }
                     }

--- a/src/ru/nsu/ccfit/zuev/osu/LibraryManager.java
+++ b/src/ru/nsu/ccfit/zuev/osu/LibraryManager.java
@@ -527,8 +527,8 @@ public enum LibraryManager {
                     GlobalManager.getInstance().setInfo("Loading " + file.getName() + " ...");
 
                     scanFolder(info);
-                    if (info.getCount() == 0) {
-                        return;
+                    if (info.getCount() < 1) {
+                        continue;
                     }
 
                     fillEmptyFields(info);


### PR DESCRIPTION
I erroneously used a `return` instead of a `continue` in one of the loops updating the cache when it detects a new beatmap (when `tracks` in `TrackInfo` is empty), potentially resulting in certain beatmaps to not be imported if the loop hits an unparseable beatmap mid-caching. This PR fixes that issue.