### PR TITLE
Improved conversion and edge case workaround for OSK skins

### DIFF
--- a/src/com/reco1l/legacy/data/SkinConverter.kt
+++ b/src/com/reco1l/legacy/data/SkinConverter.kt
@@ -1,0 +1,55 @@
+@file:JvmName("SkinConverter")
+
+package com.reco1l.legacy.data
+
+import android.graphics.Bitmap
+import android.graphics.Bitmap.CompressFormat
+import android.graphics.Bitmap.Config
+import android.graphics.BitmapFactory
+import android.graphics.Color
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+
+//--------------------------------------------------------------------------------------------------------------------//
+
+fun ensureOptionalTexture(file: File)
+{
+    if (!file.exists()) return
+
+    val bitmap = Bitmap.createBitmap(1, 1, Config.ARGB_8888)
+    bitmap.setHasAlpha(true)
+    bitmap.setPixel(0, 0, Color.TRANSPARENT)
+
+    try
+    {
+        FileOutputStream(file).use {
+            bitmap.compress(CompressFormat.PNG, 100, it)
+        }
+    }
+    catch (e: IOException) { e.printStackTrace() }
+}
+
+//--------------------------------------------------------------------------------------------------------------------//
+
+fun ensureTexture(file: File)
+{
+    if (!file.exists()) return
+
+    BitmapFactory.decodeFile(file.path)?.apply {
+
+        if (width <= 1 || height <= 1)
+        {
+            file.delete()
+            return
+        }
+
+        val pixels = IntArray(width * height)
+        getPixels(pixels, 0, width, 0, 0, width, height)
+
+        if (pixels.all { Color.alpha(it) == 0 })
+        {
+            file.delete()
+        }
+    }
+}

--- a/src/com/reco1l/legacy/data/SkinIniConverter.kt
+++ b/src/com/reco1l/legacy/data/SkinIniConverter.kt
@@ -45,6 +45,7 @@ fun convertToJson(ini: IniReader) = JsonContent().apply {
 
         put("MenuItemSelectedTextColor", convertToHex(ini["Colours", "SongSelectActiveText"]) ?: "#FFFFFF")
         put("MenuItemDefaultTextColor", convertToHex(ini["Colours", "SongSelectInactiveText"]) ?: "#000000")
+        put("MenuItemDefaultColor", "#EB4999") // Matching osu! stable inactive color.
     }
 
     putGroup("Fonts").apply {

--- a/src/ru/nsu/ccfit/zuev/osu/ResourceManager.java
+++ b/src/ru/nsu/ccfit/zuev/osu/ResourceManager.java
@@ -8,6 +8,7 @@ import android.util.Log;
 import com.dgsrz.bancho.security.SecurityUtils;
 
 import com.reco1l.framework.data.IniReader;
+import com.reco1l.legacy.data.SkinConverter;
 import com.reco1l.legacy.data.SkinIniConverter;
 import com.reco1l.legacy.engine.BlankTextureRegion;
 import org.anddev.andengine.engine.Engine;
@@ -147,6 +148,13 @@ public class ResourceManager {
                     {
                         e.printStackTrace();
                     }
+
+                    SkinConverter.ensureOptionalTexture(new File(folder, "sliderendcircle.png"));
+                    SkinConverter.ensureOptionalTexture(new File(folder, "sliderendcircleoverlay.png"));
+
+                    SkinConverter.ensureTexture(new File(folder, "selection-mods.png"));
+                    SkinConverter.ensureTexture(new File(folder, "selection-random.png"));
+                    SkinConverter.ensureTexture(new File(folder, "selection-options.png"));
                 }
             }
             if (skinjson == null) skinjson = new JSONObject();


### PR DESCRIPTION
- If `sliderendcircle` or `sliderendcircleoverlay` are not present in the imported skin it'll place a 1x1 transparent texture.
- If `selection-mods`, `selection-options` or `selection-options` textures are fully transparent or 1x1 textures it'll remove them to let use default textures (the reason behind this is because otherwise the buttons will become untargetable or invisible).
- The default inactive menu item color will match osu! stable now (pink).
- Moved skin change to asynchronous and added a loading indicator.