### PR TITLE
Fix crash when unknown input event is received

### DIFF
--- a/AndEngine/src/org/anddev/andengine/extension/input/touch/controller/MultiTouchController.java
+++ b/AndEngine/src/org/anddev/andengine/extension/input/touch/controller/MultiTouchController.java
@@ -55,7 +55,7 @@ public class MultiTouchController extends BaseTouchController {
 			case MotionEvent.ACTION_MOVE:
 				return this.onHandleTouchMove(pMotionEvent);
 			default:
-				throw new IllegalArgumentException("Invalid Action detected: " + action);
+				return false;
 		}
 	}
 


### PR DESCRIPTION
The game throws an `IllegalArgumentException` when it receives an unknown input event, leading to crashes most noticeable when tapping on the screen with the S-Pen button pressed. This PR solves this issue.