### PR TITLE
Add missing permission required for the updater

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -14,6 +14,7 @@
     <uses-permission android:name="android.permission.READ_LOGS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <application
         android:icon="@drawable/ic_launcher"


### PR DESCRIPTION
The game launches an `Intent` as part of the updating process. It is currently missing the required permission to install the APK file. This PR fixes the issue by adding the required permission to the manifest.