### PR TITLE
Improve auto cursor behavior

### DIFF
--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -901,7 +901,7 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
         }
 
         if (GameHelper.isAuto() || GameHelper.isAutopilotMod()) {
-            autoCursor = new AutoCursor();
+            autoCursor = new AutoCursor(approachRate);
             autoCursor.attachToScene(fgScene);
         }
 
@@ -1625,7 +1625,7 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
         updateActiveObjects(dt);
 
         if (GameHelper.isAuto() || GameHelper.isAutopilotMod()) {
-            autoCursor.moveToObject(activeObjects.peek(), secPassed, approachRate, this);
+            autoCursor.moveToObject(activeObjects.peek(), secPassed, this);
         }
 
         if (Config.isRemoveSliderLock()) {

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -901,7 +901,7 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
         }
 
         if (GameHelper.isAuto() || GameHelper.isAutopilotMod()) {
-            autoCursor = new AutoCursor(approachRate);
+            autoCursor = new AutoCursor();
             autoCursor.attachToScene(fgScene);
         }
 

--- a/src/ru/nsu/ccfit/zuev/osu/game/cursor/main/AutoCursor.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/cursor/main/AutoCursor.java
@@ -1,7 +1,6 @@
 package ru.nsu.ccfit.zuev.osu.game.cursor.main;
 
 import org.anddev.andengine.entity.modifier.MoveModifier;
-import org.anddev.andengine.util.Debug;
 import org.anddev.andengine.util.modifier.ease.EaseQuadOut;
 import org.anddev.andengine.util.modifier.ease.IEaseFunction;
 
@@ -23,11 +22,8 @@ public class AutoCursor extends CursorEntity implements ISliderListener {
      */
     private final IEaseFunction easeFunction = EaseQuadOut.getInstance();
 
-    private final float modifiedApproachRate;
-
-    public AutoCursor(float approachRate) {
+    public AutoCursor() {
         super();
-        this.modifiedApproachRate = approachRate * 2f;
         this.setPosition(Config.getRES_WIDTH() / 2f, Config.getRES_HEIGHT() / 2f);
         this.setShowing(true);
     }
@@ -82,14 +78,12 @@ public class AutoCursor extends CursorEntity implements ISliderListener {
         }
 
         currentObjectId = object.getId();
-        float moveDelay = deltaT / modifiedApproachRate;
 
-        if (moveDelay < 0.08f && !(object instanceof Spinner)) {
-            moveDelay = 0.08f;
+        if (deltaT < 0.085f && !(object instanceof Spinner)) {
+            deltaT = 0.085f;
         }
 
-        Debug.d("moveDelay: " + moveDelay);
-        doAutoMove(movePositionX, movePositionY, moveDelay, listener);
+        doAutoMove(movePositionX, movePositionY, deltaT, listener);
     }
 
     @Override

--- a/src/ru/nsu/ccfit/zuev/osu/game/cursor/main/AutoCursor.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/cursor/main/AutoCursor.java
@@ -1,11 +1,11 @@
 package ru.nsu.ccfit.zuev.osu.game.cursor.main;
 
 import org.anddev.andengine.entity.modifier.MoveModifier;
+import org.anddev.andengine.util.Debug;
 import org.anddev.andengine.util.modifier.ease.EaseQuadOut;
 import org.anddev.andengine.util.modifier.ease.IEaseFunction;
 
 import ru.nsu.ccfit.zuev.osu.Config;
-import ru.nsu.ccfit.zuev.osu.game.GameHelper;
 import ru.nsu.ccfit.zuev.osu.game.GameObject;
 import ru.nsu.ccfit.zuev.osu.game.GameObjectListener;
 import ru.nsu.ccfit.zuev.osu.game.ISliderListener;
@@ -23,8 +23,11 @@ public class AutoCursor extends CursorEntity implements ISliderListener {
      */
     private final IEaseFunction easeFunction = EaseQuadOut.getInstance();
 
-    public AutoCursor() {
+    private final float modifiedApproachRate;
+
+    public AutoCursor(float approachRate) {
         super();
+        this.modifiedApproachRate = approachRate * 2f;
         this.setPosition(Config.getRES_WIDTH() / 2f, Config.getRES_HEIGHT() / 2f);
         this.setShowing(true);
     }
@@ -62,10 +65,9 @@ public class AutoCursor extends CursorEntity implements ISliderListener {
      *
      * @param object       The object to move the cursor to.
      * @param secPassed    The amount of seconds that have passed since the game has started.
-     * @param approachRate The approach rate of the beatmap.
      * @param listener     The listener that listens to when this cursor is moved.
      */
-    public void moveToObject(GameObject object, float secPassed, float approachRate, GameObjectListener listener) {
+    public void moveToObject(GameObject object, float secPassed, GameObjectListener listener) {
         if (object == null || currentObjectId == object.getId()) {
             return;
         }
@@ -80,12 +82,13 @@ public class AutoCursor extends CursorEntity implements ISliderListener {
         }
 
         currentObjectId = object.getId();
-        if (GameHelper.ms2ar(approachRate * 1000f) > 12f) {
-            approachRate *= 500f;
-        } else if (GameHelper.ms2ar(approachRate * 1000f) > 10f) {
-            approachRate *= 2f;
+        float moveDelay = deltaT / modifiedApproachRate;
+
+        if (moveDelay < 0.08f && !(object instanceof Spinner)) {
+            moveDelay = 0.08f;
         }
-        float moveDelay = (deltaT / (approachRate * 2f)) + 0.1f;
+
+        Debug.d("moveDelay: " + moveDelay);
         doAutoMove(movePositionX, movePositionY, moveDelay, listener);
     }
 


### PR DESCRIPTION
This PR closes #324.

The way osu!droid handles the movement of the auto cursor is suboptimal (thanks to me :D). This PR fixes it by making the cursor move based only on the time delta between two notes, and purposefully set a minimum time delta to give an impression of "flow aim" in streams. The time delta already scales with AR, so AR is no longer needed to be taken into account.