### PR TITLE
Combine score and replay uploads into one HTTP request

### DIFF
--- a/src/ru/nsu/ccfit/zuev/osu/online/FormDataPostBuilder.java
+++ b/src/ru/nsu/ccfit/zuev/osu/online/FormDataPostBuilder.java
@@ -1,0 +1,22 @@
+package ru.nsu.ccfit.zuev.osu.online;
+
+import okhttp3.MultipartBody;
+import okhttp3.RequestBody;
+
+public class FormDataPostBuilder extends PostBuilder {
+    private final MultipartBody.Builder multipartBodyBuilder = new MultipartBody.Builder();
+
+    public void addRequestBody(final String key, final String filename, final RequestBody value) {
+        multipartBodyBuilder.addFormDataPart(key, filename, value);
+    }
+
+    @Override
+    protected void addParamInternal(final String key, final String value) {
+        multipartBodyBuilder.addFormDataPart(key, value);
+    }
+
+    @Override
+    protected RequestBody getRequestBody() {
+        return multipartBodyBuilder.build();
+    }
+}

--- a/src/ru/nsu/ccfit/zuev/osu/online/FormDataPostBuilder.java
+++ b/src/ru/nsu/ccfit/zuev/osu/online/FormDataPostBuilder.java
@@ -6,7 +6,7 @@ import okhttp3.RequestBody;
 public class FormDataPostBuilder extends PostBuilder {
     private final MultipartBody.Builder multipartBodyBuilder = new MultipartBody.Builder().setType(MultipartBody.FORM);
 
-    public void addRequestBody(final String key, final String filename, final RequestBody value) {
+    public void addParam(final String key, final String filename, final RequestBody value) {
         multipartBodyBuilder.addFormDataPart(key, filename, value);
     }
 

--- a/src/ru/nsu/ccfit/zuev/osu/online/FormDataPostBuilder.java
+++ b/src/ru/nsu/ccfit/zuev/osu/online/FormDataPostBuilder.java
@@ -4,7 +4,7 @@ import okhttp3.MultipartBody;
 import okhttp3.RequestBody;
 
 public class FormDataPostBuilder extends PostBuilder {
-    private final MultipartBody.Builder multipartBodyBuilder = new MultipartBody.Builder();
+    private final MultipartBody.Builder multipartBodyBuilder = new MultipartBody.Builder().setType(MultipartBody.FORM);
 
     public void addRequestBody(final String key, final String filename, final RequestBody value) {
         multipartBodyBuilder.addFormDataPart(key, filename, value);

--- a/src/ru/nsu/ccfit/zuev/osu/online/OnlineFileOperator.java
+++ b/src/ru/nsu/ccfit/zuev/osu/online/OnlineFileOperator.java
@@ -1,65 +1,20 @@
 package ru.nsu.ccfit.zuev.osu.online;
 
-import com.dgsrz.bancho.security.SecurityUtils;
-
 import java.io.File;
 import java.io.IOException;
-import java.net.URLEncoder;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import okhttp3.MediaType;
-import okhttp3.MultipartBody;
 import okhttp3.Response;
 import okhttp3.Request;
-import okhttp3.RequestBody;
 import okio.BufferedSink;
 import okio.Okio;
 
 import org.anddev.andengine.util.Debug;
-import ru.nsu.ccfit.zuev.osu.helper.FileUtils;
 
 public class OnlineFileOperator {
-
-    public static void sendFile(String urlstr, String filename, String replayID) {
-        try {
-            File file = new File(filename);
-            if (!file.exists()) {
-                Debug.i(filename + " does not exist.");
-                return;
-            }
-
-            String checksum = FileUtils.getSHA256Checksum(file);
-            String sb = URLEncoder.encode(checksum, "UTF-8") +
-                    "_" +
-                    URLEncoder.encode(replayID, "UTF-8");
-            String signature = SecurityUtils.signRequest(sb);
-
-            MediaType mime = MediaType.parse("application/octet-stream");
-            RequestBody fileBody = RequestBody.create(mime, file);
-            RequestBody requestBody = new MultipartBody.Builder().setType(MultipartBody.FORM)
-                .addFormDataPart("uploadedfile", file.getName(), fileBody)
-                .addFormDataPart("hash", checksum)
-                .addFormDataPart("replayID", replayID)
-                .addFormDataPart("sign", signature)
-                .build();
-            Request request = new Request.Builder().url(urlstr)
-                .post(requestBody).build();
-            try (Response response = OnlineManager.client.newCall(request).execute()) {
-                if (response.isSuccessful() && response.body() != null) {
-                    String responseMsg = response.body().string();
-                    Debug.i("sendFile signatureResponse " + responseMsg);
-                }
-            }
-        } catch (final IOException e) {
-            Debug.e("sendFile IOException " + e.getMessage(), e);
-        } catch (final Exception e) {
-            Debug.e("sendFile Exception " + e.getMessage(), e);
-        }
-    }
-
     public static boolean downloadFile(String urlstr, String filename) {
         return downloadFile(urlstr, filename, false);
     }

--- a/src/ru/nsu/ccfit/zuev/osu/online/OnlineManager.java
+++ b/src/ru/nsu/ccfit/zuev/osu/online/OnlineManager.java
@@ -119,7 +119,7 @@ public class OnlineManager {
         this.username = username;
         this.password = password;
 
-        PostBuilder post = new PostBuilder();
+        PostBuilder post = new URLEncodedPostBuilder();
         post.addParam("username", username);
         post.addParam(
                 "password",
@@ -186,7 +186,7 @@ public class OnlineManager {
         else
             osuID = null;
 
-        PostBuilder post = new PostBuilder();
+        PostBuilder post = new URLEncodedPostBuilder();
         post.addParam("userID", String.valueOf(userId));
         post.addParam("ssid", ssid);
         post.addParam("filename", trackfile.getName());
@@ -235,7 +235,7 @@ public class OnlineManager {
 
         Debug.i("Sending record...");
 
-        PostBuilder post = new PostBuilder();
+        PostBuilder post = new URLEncodedPostBuilder();
         post.addParam("userID", String.valueOf(userId));
         post.addParam("playID", playID);
         post.addParam("data", data);
@@ -275,7 +275,7 @@ public class OnlineManager {
     }
 
     public ArrayList<String> getTop(final File trackFile, final String hash) throws OnlineManagerException {
-        PostBuilder post = new PostBuilder();
+        PostBuilder post = new URLEncodedPostBuilder();
         post.addParam("filename", trackFile.getName());
         post.addParam("hash", hash);
         post.addParam("uid", String.valueOf(userId));
@@ -363,7 +363,7 @@ public class OnlineManager {
     }
 
     public String getScorePack(int playid) throws OnlineManagerException {
-        PostBuilder post = new PostBuilder();
+        PostBuilder post = new URLEncodedPostBuilder();
         post.addParam("playID", String.valueOf(playid));
 
         ArrayList<String> response = sendRequest(post, endpoint + "gettop.php");

--- a/src/ru/nsu/ccfit/zuev/osu/online/OnlineScoring.java
+++ b/src/ru/nsu/ccfit/zuev/osu/online/OnlineScoring.java
@@ -154,7 +154,7 @@ public class OnlineScoring {
                     }
 
                     try {
-                        success = OnlineManager.getInstance().sendRecord(recordData);
+                        success = OnlineManager.getInstance().sendRecord(recordData, replay);
                     } catch (OnlineManager.OnlineManagerException e) {
                         Debug.e("Login error: " + e.getMessage());
                         success = false;
@@ -165,7 +165,6 @@ public class OnlineScoring {
                         if (OnlineManager.getInstance().getFailMessage().equals("Invalid record data"))
                             i = attemptCount;
                     } else if (success) {
-                        OnlineManager.getInstance().sendReplay(replay);
                         updatePanels();
                         OnlineManager mgr = OnlineManager.getInstance();
                         panel.show(mgr.getMapRank(), mgr.getScore(), mgr.getRank(), mgr.getAccuracy());

--- a/src/ru/nsu/ccfit/zuev/osu/online/PostBuilder.java
+++ b/src/ru/nsu/ccfit/zuev/osu/online/PostBuilder.java
@@ -2,21 +2,21 @@ package ru.nsu.ccfit.zuev.osu.online;
 
 import com.dgsrz.bancho.security.SecurityUtils;
 
-import okhttp3.FormBody;
+import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.Request;
 
 import org.anddev.andengine.util.Debug;
 
 import java.io.BufferedReader;
+import java.io.Serial;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.net.UnknownHostException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 
-public class PostBuilder {
-    private final FormBody.Builder formBodyBuilder = new FormBody.Builder();
+public abstract class PostBuilder {
     private final StringBuilder values = new StringBuilder();
 
     public void addParam(final String key, final String value) {
@@ -24,11 +24,10 @@ public class PostBuilder {
             if (values.length() > 0) {
                 values.append("_");
             }
-            formBodyBuilder.add(key, value);
+            addParamInternal(key, value);
             values.append(URLEncoder.encode(value, "UTF-8"));
         } catch (UnsupportedEncodingException ignored) {
         }
-
     }
 
     public ArrayList<String> requestWithAttempts(final String scriptUrl, int attempts) throws RequestException {
@@ -50,7 +49,7 @@ public class PostBuilder {
                 response = null;
             }
 
-            if (response == null || response.isEmpty() || response.get(0).length() == 0
+            if (response == null || response.isEmpty() || response.get(0).isEmpty()
                     || !(response.get(0).equals("FAIL") || response.get(0).equals("SUCCESS"))) {
                 try {
                     Thread.sleep(3000);
@@ -74,7 +73,7 @@ public class PostBuilder {
 
         Request request = new Request.Builder()
             .url(scriptUrl)
-            .post(formBodyBuilder.build())
+            .post(getRequestBody())
             .build();
 
         try (Response resp = OnlineManager.client.newCall(request).execute()) {
@@ -101,7 +100,12 @@ public class PostBuilder {
         return response;
     }
 
+    protected abstract void addParamInternal(final String key, final String value);
+
+    protected abstract RequestBody getRequestBody();
+
     public static class RequestException extends Exception {
+        @Serial
         private static final long serialVersionUID = 671773899432746143L;
 
         public RequestException(final Throwable cause) {

--- a/src/ru/nsu/ccfit/zuev/osu/online/URLEncodedPostBuilder.java
+++ b/src/ru/nsu/ccfit/zuev/osu/online/URLEncodedPostBuilder.java
@@ -1,0 +1,18 @@
+package ru.nsu.ccfit.zuev.osu.online;
+
+import okhttp3.FormBody;
+import okhttp3.RequestBody;
+
+public class URLEncodedPostBuilder extends PostBuilder {
+    private final FormBody.Builder formBodyBuilder = new FormBody.Builder();
+
+    @Override
+    protected void addParamInternal(final String key, final String value) {
+        formBodyBuilder.add(key, value);
+    }
+
+    @Override
+    protected RequestBody getRequestBody() {
+        return formBodyBuilder.build();
+    }
+}


### PR DESCRIPTION
Pending change server-side.

This is a pre-requisite for dpp integration, and ensures that replays are *always* uploaded, which resolves the issue where a score's replay is outdated or non-existent.