### PR TITLE
Decouple FPS and pp counter settings

### DIFF
--- a/res/values/options.xml
+++ b/res/values/options.xml
@@ -129,6 +129,12 @@
     <string name="opt_fps_title">FPS</string>
     <string name="opt_fps_summary">Display (frames per second) during gameplay</string>
 
+    <string name="opt_averageoffset_title">Average offset</string>
+    <string name="opt_averageoffset_summary">Display average offset of hits during gameplay. Higher value means hits are more offset</string>
+
+    <string name="opt_unstablerate_title">Unstable rate</string>
+    <string name="opt_unstablerate_summary">Display unstable rate during gameplay. Higher value means more instability</string>
+
     <!-- <string name="opt_skipoffset_title">Skip offset</string>
     <string name="opt_skipoffset_summary">This offset will be added when you press the &quot;Skip&quot; button. Enter -1 for auto offset</string> -->
 

--- a/res/values/options.xml
+++ b/res/values/options.xml
@@ -133,7 +133,7 @@
     <string name="opt_averageoffset_summary">Display average offset of hits during gameplay. Higher value means hits are more offset</string>
 
     <string name="opt_unstablerate_title">Unstable rate</string>
-    <string name="opt_unstablerate_summary">Display unstable rate during gameplay. Higher value means more instability</string>
+    <string name="opt_unstablerate_summary">Display unstable rate during gameplay. Higher value means hits are more inconsistent</string>
 
     <!-- <string name="opt_skipoffset_title">Skip offset</string>
     <string name="opt_skipoffset_summary">This offset will be added when you press the &quot;Skip&quot; button. Enter -1 for auto offset</string> -->

--- a/res/xml/settings_gameplay.xml
+++ b/res/xml/settings_gameplay.xml
@@ -101,6 +101,20 @@
 
         <CheckBoxPreference
             android:defaultValue="true"
+            android:key="averageOffset"
+            android:summary="@string/opt_averageoffset_summary"
+            android:title="@string/opt_averageoffset_title"
+            app:layout="@layout/settings_preference_checkbox_bottom" />
+
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="unstableRate"
+            android:summary="@string/opt_unstablerate_summary"
+            android:title="@string/opt_unstablerate_title"
+            app:layout="@layout/settings_preference_checkbox_bottom" />
+
+        <CheckBoxPreference
+            android:defaultValue="true"
             android:key="displayScoreStatistics"
             android:summary="@string/opt_display_score_statistics_summary"
             android:title="@string/opt_display_score_statistics_title" />

--- a/res/xml/settings_gameplay.xml
+++ b/res/xml/settings_gameplay.xml
@@ -97,21 +97,21 @@
             android:key="fps"
             android:summary="@string/opt_fps_summary"
             android:title="@string/opt_fps_title"
-            app:layout="@layout/settings_preference_checkbox_bottom" />
+            app:layout="@layout/settings_preference_checkbox" />
 
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="averageOffset"
             android:summary="@string/opt_averageoffset_summary"
             android:title="@string/opt_averageoffset_title"
-            app:layout="@layout/settings_preference_checkbox_bottom" />
+            app:layout="@layout/settings_preference_checkbox" />
 
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="unstableRate"
             android:summary="@string/opt_unstablerate_summary"
             android:title="@string/opt_unstablerate_title"
-            app:layout="@layout/settings_preference_checkbox_bottom" />
+            app:layout="@layout/settings_preference_checkbox" />
 
         <CheckBoxPreference
             android:defaultValue="true"

--- a/src/ru/nsu/ccfit/zuev/osu/Config.java
+++ b/src/ru/nsu/ccfit/zuev/osu/Config.java
@@ -46,6 +46,8 @@ public class Config {
         useCustomSounds,
         corovans,
         showFPS,
+        showAverageOffset,
+        showUnstableRate,
         animateFollowCircle,
         animateComboText,
         snakingInSliders,
@@ -111,7 +113,9 @@ public class Config {
         useCustomSounds = prefs.getBoolean("beatmapSounds", true);
         comboburst = prefs.getBoolean("comboburst", false);
         corovans = prefs.getBoolean("images", false);
-        showFPS = prefs.getBoolean("fps", false);
+        showFPS = prefs.getBoolean("fps", true);
+        showAverageOffset = prefs.getBoolean("averageOffset", true);
+        showUnstableRate = prefs.getBoolean("unstableRate", true);
         errorMeter = Integer.parseInt(prefs.getString("errormeter", "0"));
         spinnerStyle = Integer.parseInt(prefs.getString("spinnerstyle", "0"));
         showFirstApproachCircle = prefs.getBoolean("showfirstapproachcircle", false);
@@ -320,6 +324,22 @@ public class Config {
 
     public static void setShowFPS(final boolean showFPS) {
         Config.showFPS = showFPS;
+    }
+
+    public static boolean isShowAverageOffset() {
+        return showAverageOffset;
+    }
+
+    public static void setShowAverageOffset(final boolean showAverageOffset) {
+        Config.showAverageOffset = showAverageOffset;
+    }
+
+    public static boolean isShowUnstableRate() {
+        return showUnstableRate;
+    }
+
+    public static void setShowUnstableRate(final boolean showUnstableRate) {
+        Config.showUnstableRate = showUnstableRate;
     }
 
     public static boolean isShowScoreboard() {


### PR DESCRIPTION
Closes #357.

This adds two new settings: display average offset and display unstable rate, allowing finer control and breaking the dependency of some counters.