### PR TITLE
Fix entity modifiers still running when the object is already recycled

### DIFF
--- a/src/ru/nsu/ccfit/zuev/osu/game/HitCircle.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/HitCircle.java
@@ -152,6 +152,12 @@ public class HitCircle extends GameObject {
         if (scene == null) {
             return;
         }
+
+        overlay.clearEntityModifiers();
+        circle.clearEntityModifiers();
+        number.clearEntityModifiers();
+        approachCircle.clearEntityModifiers();
+
         // Detach all objects
         overlay.detachSelf();
         circle.detachSelf();


### PR DESCRIPTION
* Fixes #347 

The title might not be clear so I'm gonna explain:
Before this PR entity modifiers were pooled with the entity itself, once they're recycled/reused the entity modifier too and there's a small chance of it causing havoc with the newer applied modifiers.