### PR TITLE
Process hitobject combo information

### DIFF
--- a/src/com/rian/osu/beatmap/BeatmapConverter.kt
+++ b/src/com/rian/osu/beatmap/BeatmapConverter.kt
@@ -41,7 +41,7 @@ class BeatmapConverter(
                 hitObject.startTime,
                 hitObject.position,
                 hitObject.isNewCombo,
-                hitObject.comboColorOffset
+                hitObject.comboOffset
             )
 
             is Slider -> Slider(
@@ -50,7 +50,7 @@ class BeatmapConverter(
                 hitObject.repeatCount,
                 hitObject.path,
                 hitObject.isNewCombo,
-                hitObject.comboColorOffset,
+                hitObject.comboOffset,
                 hitObject.nodeSamples
             ).also {
                 // Prior to v8, speed multipliers don't adjust for how many ticks are generated over the same distance.
@@ -61,7 +61,7 @@ class BeatmapConverter(
                 it.generateTicks = hitObject.generateTicks
             }
 
-            is Spinner -> Spinner(hitObject.startTime, hitObject.endTime)
+            is Spinner -> Spinner(hitObject.startTime, hitObject.endTime, hitObject.isNewCombo)
 
             else -> throw IllegalArgumentException("Invalid type of hit object")
         }.also { it.samples = hitObject.samples }

--- a/src/com/rian/osu/beatmap/BeatmapProcessor.kt
+++ b/src/com/rian/osu/beatmap/BeatmapProcessor.kt
@@ -24,7 +24,14 @@ class BeatmapProcessor(
      *
      * This can only be used to add alterations to [HitObject]s generated directly through the conversion process.
      */
-    fun preProcess() = Unit
+    fun preProcess() {
+        var lastObj: HitObject? = null
+
+        beatmap.hitObjects.objects.forEach {
+            it.updateComboInformation(lastObj)
+            lastObj = it
+        }
+    }
 
     /**
      * Processes the converted [Beatmap] after [HitObject.applyDefaults] has been invoked.

--- a/src/com/rian/osu/beatmap/hitobject/HitCircle.kt
+++ b/src/com/rian/osu/beatmap/hitobject/HitCircle.kt
@@ -19,10 +19,15 @@ class HitCircle(
     /**
      * Whether this [HitCircle] starts a new combo.
      */
-    isNewCombo: Boolean = false,
+    isNewCombo: Boolean,
 
     /**
-     * How many combo colors to skip, if this [HitCircle] starts a new combo.
+     * When starting a new combo, the offset of the new combo relative to the current one.
+     *
+     * This is generally a setting provided by a beatmap creator to choreograph interesting color patterns
+     * which can only be achieved by skipping combo colors with per-[HitObject] level.
+     *
+     * It is exposed via [HitObject.comboIndexWithOffsets].
      */
-    comboColorOffset: Int = 0
-) : HitObject(startTime, position, isNewCombo, comboColorOffset)
+    comboOffset: Int
+) : HitObject(startTime, position, isNewCombo, comboOffset)

--- a/src/com/rian/osu/beatmap/hitobject/Slider.kt
+++ b/src/com/rian/osu/beatmap/hitobject/Slider.kt
@@ -36,12 +36,17 @@ class Slider(
     /**
      * Whether this [Slider] starts a new combo.
      */
-    isNewCombo: Boolean = false,
+    isNewCombo: Boolean,
 
     /**
-     * How many combo colors to skip, if this [Slider] starts a new combo.
+     * When starting a new combo, the offset of the new combo relative to the current one.
+     *
+     * This is generally a setting provided by a beatmap creator to choreograph interesting color patterns
+     * which can only be achieved by skipping combo colors with per-[HitObject] level.
+     *
+     * It is exposed via [HitObject.comboIndexWithOffsets].
      */
-    comboColorOffset: Int = 0,
+    comboOffset: Int,
 
     /**
      * The samples to be played when each node of this [Slider] is hit.
@@ -55,7 +60,8 @@ class Slider(
      */
     @JvmField
     var nodeSamples: MutableList<MutableList<HitSampleInfo>>
-) : HitObject(startTime, position, isNewCombo, comboColorOffset), IHasDuration {
+) : HitObject(startTime, position, isNewCombo, comboOffset),
+    IHasDuration {
     override val endTime: Double
         get() = startTime + spanCount * path.expectedDistance / velocity
 

--- a/src/com/rian/osu/beatmap/hitobject/Spinner.kt
+++ b/src/com/rian/osu/beatmap/hitobject/Spinner.kt
@@ -11,8 +11,13 @@ class Spinner(
      */
     startTime: Double,
 
-    override var endTime: Double
-) : HitObject(startTime, Vector2(256f, 192f)), IHasDuration {
+    override var endTime: Double,
+
+    /**
+     * Whether this [Spinner] starts a new combo.
+     */
+    isNewCombo: Boolean,
+) : HitObject(startTime, Vector2(256f, 192f), isNewCombo, 0), IHasDuration {
     init {
         auxiliarySamples.apply {
             samples.filterIsInstance<BankHitSampleInfo>().firstOrNull()?.let { add(it.copy(name = "spinnerspin")) }

--- a/src/com/rian/osu/beatmap/hitobject/sliderobject/SliderHitObject.kt
+++ b/src/com/rian/osu/beatmap/hitobject/sliderobject/SliderHitObject.kt
@@ -27,7 +27,7 @@ abstract class SliderHitObject(
      * The start time of the span at which this [SliderHitObject] lies, in milliseconds.
      */
     spanStartTime: Double
-) : HitObject(startTime, position) {
+) : HitObject(startTime, position, false, 0) {
     /**
      * The index of the span at which this [SliderHitObject] lies.
      */

--- a/src/com/rian/osu/beatmap/parser/BeatmapParser.kt
+++ b/src/com/rian/osu/beatmap/parser/BeatmapParser.kt
@@ -189,7 +189,10 @@ class BeatmapParser : Closeable {
                 it.applySamples(controlPoints)
             }
 
-            BeatmapProcessor(this).postProcess(mode)
+            BeatmapProcessor(this).also {
+                it.preProcess()
+                it.postProcess(mode)
+            }
         }
     }
 


### PR DESCRIPTION
To be used to substitute `GameObjectData` in the future, so that the game does not need to reparse the same information. This further reduces the work done in the update thread during gameplay.

More PRs will come as more values are gradually substituted.