### PR TITLE
Unify time multiplier application

### DIFF
--- a/src/ru/nsu/ccfit/zuev/osu/game/GameHelper.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameHelper.java
@@ -23,7 +23,7 @@ public class GameHelper {
     private static float approachRate = 1;
     private static float drain = 0;
     private static float stackLeniency = 0;
-    private static float timeMultiplier = 0;
+    private static float speedMultiplier = 0;
     private static RGBColor sliderColor = new RGBColor();
     private static boolean hidden = false;
     private static boolean flashLight = false;
@@ -201,12 +201,12 @@ public class GameHelper {
         GameHelper.approachRate = approachRate;
     }
 
-    public static float getTimeMultiplier() {
-        return timeMultiplier;
+    public static float getSpeedMultiplier() {
+        return speedMultiplier;
     }
 
-    public static void setTimeMultiplier(float timeMultiplier) {
-        GameHelper.timeMultiplier = timeMultiplier;
+    public static void setSpeedMultiplier(float speedMultiplier) {
+        GameHelper.speedMultiplier = speedMultiplier;
     }
 
     public static double getSpeed() {

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameHelper.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameHelper.java
@@ -201,10 +201,16 @@ public class GameHelper {
         GameHelper.approachRate = approachRate;
     }
 
+    /**
+     * Gets the rate at which gameplay progresses in terms of time.
+     */
     public static float getSpeedMultiplier() {
         return speedMultiplier;
     }
 
+    /**
+     * Sets the rate at which gameplay progresses in terms of time.
+     */
     public static void setSpeedMultiplier(float speedMultiplier) {
         GameHelper.speedMultiplier = speedMultiplier;
     }

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -155,7 +155,6 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
     private float skipTime;
     private boolean musicStarted;
     private double distToNextObject;
-    private float timeMultiplier = 1.0f;
     private CursorEntity[] cursorSprites;
     private AutoCursor autoCursor;
     private FlashLightEntity flashlightSprite;
@@ -264,7 +263,7 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
         if (Config.isVideoEnabled() && beatmap.events.videoFilename != null
                 // Unfortunately MediaPlayer API doesn't allow to change playback speed on APIs < 23, so in that case
                 // the video will not be shown.
-                && (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M || timeMultiplier == 1.0f)) {
+                && (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M || GameHelper.getSpeedMultiplier() == 1.0f)) {
             try {
                 videoStarted = false;
                 videoOffset = beatmap.events.videoStartTime / 1000f;
@@ -419,35 +418,31 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
             GameHelper.setHardrock(true);
         }
 
-        timeMultiplier = 1f;
+        GameHelper.setSpeedMultiplier(1f);
         GameHelper.setDoubleTime(false);
         GameHelper.setNightCore(false);
         GameHelper.setHalfTime(false);
 
         GlobalManager.getInstance().getSongService().preLoad(filePath, PlayMode.MODE_NONE);
-        GameHelper.setTimeMultiplier(1f);
+
         //Speed Change
         if (ModMenu.getInstance().getChangeSpeed() != 1.00f){
-            timeMultiplier = ModMenu.getInstance().getSpeed();
-            GlobalManager.getInstance().getSongService().preLoad(filePath, timeMultiplier,
+            GlobalManager.getInstance().getSongService().preLoad(filePath, ModMenu.getInstance().getSpeed(),
                 ModMenu.getInstance().isEnableNCWhenSpeedChange() ||
                         ModMenu.getInstance().getMod().contains(GameMod.MOD_NIGHTCORE));
-            GameHelper.setTimeMultiplier(1 / timeMultiplier);
+            GameHelper.setSpeedMultiplier(ModMenu.getInstance().getSpeed());
         } else if (ModMenu.getInstance().getMod().contains(GameMod.MOD_DOUBLETIME)) {
             GlobalManager.getInstance().getSongService().preLoad(filePath, PlayMode.MODE_DT);
-            timeMultiplier = 1.5f;
             GameHelper.setDoubleTime(true);
-            GameHelper.setTimeMultiplier(2 / 3f);
+            GameHelper.setSpeedMultiplier(1.5f);
         } else if (ModMenu.getInstance().getMod().contains(GameMod.MOD_NIGHTCORE)) {
             GlobalManager.getInstance().getSongService().preLoad(filePath, PlayMode.MODE_NC);
-            timeMultiplier = 1.5f;
             GameHelper.setNightCore(true);
-            GameHelper.setTimeMultiplier(2 / 3f);
+            GameHelper.setSpeedMultiplier(1.5f);
         } else if (ModMenu.getInstance().getMod().contains(GameMod.MOD_HALFTIME)) {
             GlobalManager.getInstance().getSongService().preLoad(filePath, PlayMode.MODE_HT);
-            timeMultiplier = 0.75f;
             GameHelper.setHalfTime(true);
-            GameHelper.setTimeMultiplier(4 / 3f);
+            GameHelper.setSpeedMultiplier(0.75f);
         }
 
         if (ModMenu.getInstance().getMod().contains(GameMod.MOD_REALLYEASY)) {
@@ -459,12 +454,12 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
                 ar *= 2;
                 ar -= 0.5f;
             }
-            ar -= (timeMultiplier - 1.0f) + 0.5f;
+            ar -= (GameHelper.getSpeedMultiplier() - 1.0f) + 0.5f;
             approachRate = (float)(GameHelper.ar2ms(ar) / 1000f);
         }
 
         if (ModMenu.getInstance().isCustomAR()){
-            approachRate = (float) GameHelper.ar2ms(ModMenu.getInstance().getCustomAR()) / 1000f * timeMultiplier;
+            approachRate = (float) GameHelper.ar2ms(ModMenu.getInstance().getCustomAR()) / 1000f;
         }
         if (ModMenu.getInstance().isCustomOD()) {
             overallDifficulty = ModMenu.getInstance().getCustomOD();
@@ -1050,7 +1045,7 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
     public void onUpdate(final float pSecondsElapsed) {
         previousFrameTime = SystemClock.uptimeMillis();
         Utils.clearSoundMask();
-        float dt = pSecondsElapsed * timeMultiplier;
+        float dt = pSecondsElapsed * GameHelper.getSpeedMultiplier();
         if (GlobalManager.getInstance().getSongService().getStatus() == Status.PLAYING) {
             //处理时间差过于庞大的情况
             final float offset = totalOffset / 1000f;
@@ -1378,7 +1373,7 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
         {
             if (!videoStarted) {
                 video.getTexture().play();
-                video.getTexture().setPlaybackSpeed(timeMultiplier);
+                video.getTexture().setPlaybackSpeed(GameHelper.getSpeedMultiplier());
                 videoStarted = true;
             }
 
@@ -1509,8 +1504,8 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
                 if (params.length > 6) {
                     tempSound = params[6];
                 }
-                spinner.init(this, bgScene, (data.getTime() - secPassed) / timeMultiplier,
-                        (endTime - data.getTime()) / timeMultiplier, rps, Integer.parseInt(params[4]),
+                spinner.init(this, bgScene, (data.getTime() - secPassed) / GameHelper.getSpeedMultiplier(),
+                        (endTime - data.getTime()) / GameHelper.getSpeedMultiplier(), rps, Integer.parseInt(params[4]),
                         tempSound, stat);
                 spinner.setEndsCombo(nextObj == null || nextObj.isNewCombo());
                 addObject(spinner);
@@ -2088,6 +2083,8 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
 
         final PointF pos = new PointF((float) Config.getRES_WIDTH() / 2,
                 (float) Config.getRES_HEIGHT() / 2);
+        final float speedMultiplier = GameHelper.getSpeedMultiplier();
+
         if (score == 0) {
             final GameEffect effect = GameObjectPool.getInstance().getEffect(
                     "hit0");
@@ -2096,9 +2093,9 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
                     pos,
                     scale,
                     Modifiers.sequence(
-                        Modifiers.fadeIn(0.15f * timeMultiplier),
-                        Modifiers.delay(0.35f * timeMultiplier),
-                        Modifiers.fadeOut(0.25f * timeMultiplier)
+                        Modifiers.fadeIn(0.15f / speedMultiplier),
+                        Modifiers.delay(0.35f / speedMultiplier),
+                        Modifiers.fadeOut(0.25f / speedMultiplier)
                     )
             );
             registerHit(id, 0, endCombo);
@@ -2120,10 +2117,10 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
                     mgScene,
                     pos,
                     scale,
-                    Modifiers.fadeOut(0.7f * timeMultiplier),
+                    Modifiers.fadeOut(0.7f / speedMultiplier),
                     Modifiers.sequence(
-                        Modifiers.scale(0.25f * timeMultiplier, scale, 1.5f * scale),
-                        Modifiers.scale(0.45f * timeMultiplier, 1.5f * scale, 2f * scale)
+                        Modifiers.scale(0.25f / speedMultiplier, scale, 1.5f * scale),
+                        Modifiers.scale(0.45f / speedMultiplier, 1.5f * scale, 2f * scale)
                     )
             );
         }
@@ -2134,15 +2131,15 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
                 pos,
                 scale,
                 Modifiers.sequence(
-                    Modifiers.scale(0.15f * timeMultiplier, scale, 1.2f * scale),
-                    Modifiers.scale(0.05f * timeMultiplier, 1.2f * scale, scale),
-                    Modifiers.fadeOut(timeMultiplier)
+                    Modifiers.scale(0.15f / speedMultiplier, scale, 1.2f * scale),
+                    Modifiers.scale(0.05f / speedMultiplier, 1.2f * scale, scale),
+                    Modifiers.fadeOut(1 / speedMultiplier)
                 )
         );
 
         pos.y /= 2f;
         effect = GameObjectPool.getInstance().getEffect("spinner-osu");
-        effect.init(mgScene, pos, 1, Modifiers.fadeOut(1.5f * timeMultiplier));
+        effect.init(mgScene, pos, 1, Modifiers.fadeOut(1.5f / speedMultiplier));
     }
 
     public void playSound(final String name, final int sampleSet, final int addition) {
@@ -2278,7 +2275,7 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
             sprite.setPosition(cursor.mousePos.x, cursor.mousePos.y);
         }
 
-        var frameOffset = previousFrameTime > 0 ? (event.getMotionEvent().getEventTime() - previousFrameTime) * timeMultiplier : 0;
+        var frameOffset = previousFrameTime > 0 ? (event.getMotionEvent().getEventTime() - previousFrameTime) * GameHelper.getSpeedMultiplier() : 0;
         var eventTime = (int) (secPassed * 1000 + frameOffset);
 
         if (event.isActionDown()) {
@@ -2367,7 +2364,7 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
 
         // Release all pressed cursors to avoid getting stuck at resume.
         if (!GameHelper.isAuto() && !GameHelper.isAutopilotMod() && !replaying) {
-            var frameOffset = previousFrameTime > 0 ? (SystemClock.uptimeMillis() - previousFrameTime) * timeMultiplier : 0;
+            var frameOffset = previousFrameTime > 0 ? (SystemClock.uptimeMillis() - previousFrameTime) * GameHelper.getSpeedMultiplier() : 0;
             var time = (int) (secPassed * 1000 + frameOffset);
 
             for (int i = 0; i < CursorCount; ++i) {
@@ -2461,7 +2458,7 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
 
     private void createHitEffect(final PointF pos, final String name, RGBColor color) {
         final GameEffect effect = GameObjectPool.getInstance().getEffect(name);
-        final float timeMultiplier = GameHelper.getTimeMultiplier();
+        final float speedMultiplier = GameHelper.getSpeedMultiplier();
 
         if (name.equals("hit0")) {
             effect.init(
@@ -2469,9 +2466,9 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
                     pos,
                     GameHelper.isSuddenDeath() ? scale * 3 : scale,
                     Modifiers.sequence(
-                        Modifiers.fadeIn(0.15f * timeMultiplier),
-                        Modifiers.delay(0.35f * timeMultiplier),
-                        Modifiers.fadeOut(0.25f * timeMultiplier)
+                        Modifiers.fadeIn(0.15f / speedMultiplier),
+                        Modifiers.delay(0.35f / speedMultiplier),
+                        Modifiers.fadeOut(0.25f / speedMultiplier)
                     )
             );
 
@@ -2488,11 +2485,11 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
                     bgScene,
                     pos,
                     scale,
-                    Modifiers.fadeOut(timeMultiplier),
+                    Modifiers.fadeOut(1 / speedMultiplier),
                     Modifiers.sequence(
-                        Modifiers.scale(0.25f * timeMultiplier, scale, 1.5f * scale),
-                        Modifiers.scale(0.45f * timeMultiplier, scale * 1.5f, 1.9f * scale),
-                        Modifiers.scale(0.3f * timeMultiplier, scale * 1.9f, scale * 2f)
+                        Modifiers.scale(0.25f / speedMultiplier, scale, 1.5f * scale),
+                        Modifiers.scale(0.45f / speedMultiplier, scale * 1.5f, 1.9f * scale),
+                        Modifiers.scale(0.3f / speedMultiplier, scale * 1.9f, scale * 2f)
                     )
             );
             light.setBlendFunction(GL10.GL_SRC_ALPHA, GL10.GL_DST_ALPHA);
@@ -2503,9 +2500,9 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
                 pos,
                 scale,
                 Modifiers.sequence(
-                    Modifiers.scale(0.15f * timeMultiplier, scale, 1.2f * scale),
-                    Modifiers.scale(0.05f * timeMultiplier, 1.2f * scale, scale),
-                    Modifiers.fadeOut(0.5f * timeMultiplier)
+                    Modifiers.scale(0.15f / speedMultiplier, scale, 1.2f * scale),
+                    Modifiers.scale(0.05f / speedMultiplier, 1.2f * scale, scale),
+                    Modifiers.fadeOut(0.5f / speedMultiplier)
                 )
         );
     }
@@ -2514,19 +2511,19 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
         if (!Config.isBurstEffects() || stat.getMod().contains(GameMod.MOD_HIDDEN))
             return;
 
-        final float timeMultiplier = GameHelper.getTimeMultiplier();
+        final float speedMultiplier = GameHelper.getSpeedMultiplier();
 
         final GameEffect burst1 = GameObjectPool.getInstance().getEffect("hitcircle");
         burst1.init(mgScene, pos, scale,
-                Modifiers.scale(0.25f * timeMultiplier, scale, 1.5f * scale),
-                Modifiers.alpha(0.25f * timeMultiplier, 0.8f, 0)
+                Modifiers.scale(0.25f / speedMultiplier, scale, 1.5f * scale),
+                Modifiers.alpha(0.25f / speedMultiplier, 0.8f, 0)
         );
         burst1.setColor(color);
 
         final GameEffect burst2 = GameObjectPool.getInstance().getEffect("hitcircleoverlay");
         burst2.init(mgScene, pos, scale,
-                Modifiers.scale(0.25f * timeMultiplier, scale, 1.5f * scale),
-                Modifiers.alpha(0.25f * timeMultiplier, 0.8f, 0)
+                Modifiers.scale(0.25f / speedMultiplier, scale, 1.5f * scale),
+                Modifiers.alpha(0.25f / speedMultiplier, 0.8f, 0)
         );
     }
 
@@ -2534,19 +2531,19 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
         if (!Config.isBurstEffects() || stat.getMod().contains(GameMod.MOD_HIDDEN))
             return;
 
-        final float timeMultiplier = GameHelper.getTimeMultiplier();
+        final float speedMultiplier = GameHelper.getSpeedMultiplier();
 
         final GameEffect burst1 = GameObjectPool.getInstance().getEffect("sliderstartcircle");
         burst1.init(mgScene, pos, scale,
-                Modifiers.scale(0.25f * timeMultiplier, scale, 1.5f * scale),
-                Modifiers.alpha(0.25f * timeMultiplier, 0.8f, 0)
+                Modifiers.scale(0.25f / speedMultiplier, scale, 1.5f * scale),
+                Modifiers.alpha(0.25f / speedMultiplier, 0.8f, 0)
         );
         burst1.setColor(color);
 
         final GameEffect burst2 = GameObjectPool.getInstance().getEffect("sliderstartcircleoverlay");
         burst2.init(mgScene, pos, scale,
-                Modifiers.scale(0.25f * timeMultiplier, scale, 1.5f * scale),
-                Modifiers.alpha(0.25f * timeMultiplier, 0.8f, 0)
+                Modifiers.scale(0.25f / speedMultiplier, scale, 1.5f * scale),
+                Modifiers.alpha(0.25f / speedMultiplier, 0.8f, 0)
         );
     }
 
@@ -2554,19 +2551,19 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
         if (!Config.isBurstEffects() || stat.getMod().contains(GameMod.MOD_HIDDEN))
             return;
 
-        final float timeMultiplier = GameHelper.getTimeMultiplier();
+        final float speedMultiplier = GameHelper.getSpeedMultiplier();
 
         final GameEffect burst1 = GameObjectPool.getInstance().getEffect("sliderendcircle");
         burst1.init(mgScene, pos, scale,
-                Modifiers.scale(0.25f * timeMultiplier, scale, 1.5f * scale),
-                Modifiers.alpha(0.25f * timeMultiplier, 0.8f, 0)
+                Modifiers.scale(0.25f / speedMultiplier, scale, 1.5f * scale),
+                Modifiers.alpha(0.25f / speedMultiplier, 0.8f, 0)
         );
         burst1.setColor(color);
 
         final GameEffect burst2 = GameObjectPool.getInstance().getEffect("sliderendcircleoverlay");
         burst2.init(mgScene, pos, scale,
-                Modifiers.scale(0.25f * timeMultiplier, scale, 1.5f * scale),
-                Modifiers.alpha(0.25f * timeMultiplier, 0.8f, 0)
+                Modifiers.scale(0.25f / speedMultiplier, scale, 1.5f * scale),
+                Modifiers.alpha(0.25f / speedMultiplier, 0.8f, 0)
         );
     }
 
@@ -2574,13 +2571,13 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
         if (!Config.isBurstEffects() || stat.getMod().contains(GameMod.MOD_HIDDEN))
             return;
 
-        final float timeMultiplier = GameHelper.getTimeMultiplier();
+        final float speedMultiplier = GameHelper.getSpeedMultiplier();
 
         final GameEffect burst1 = GameObjectPool.getInstance().getEffect("reversearrow");
         burst1.hit.setRotation(ang);
         burst1.init(mgScene, pos, scale,
-                Modifiers.scale(0.25f * timeMultiplier, scale, 1.5f * scale),
-                Modifiers.alpha(0.25f * timeMultiplier, 0.8f, 0)
+                Modifiers.scale(0.25f / speedMultiplier, scale, 1.5f * scale),
+                Modifiers.alpha(0.25f / speedMultiplier, 0.8f, 0)
         );
 
     }

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -459,7 +459,8 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
         }
 
         if (ModMenu.getInstance().isCustomAR()){
-            approachRate = (float) GameHelper.ar2ms(ModMenu.getInstance().getCustomAR()) / 1000f;
+            // Scale the approach rate with speed multiplier to ensure that the real-time AR value stays the same.
+            approachRate = (float) GameHelper.ar2ms(ModMenu.getInstance().getCustomAR()) / 1000f * GameHelper.getSpeedMultiplier();
         }
         if (ModMenu.getInstance().isCustomOD()) {
             overallDifficulty = ModMenu.getInstance().getCustomOD();

--- a/src/ru/nsu/ccfit/zuev/osu/game/HitCircle.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/HitCircle.java
@@ -104,8 +104,8 @@ public class HitCircle extends GameObject {
         float fadeInDuration;
 
         if (GameHelper.isHidden()) {
-            fadeInDuration = time * 0.4f * GameHelper.getTimeMultiplier();
-            float fadeOutDuration = time * 0.3f * GameHelper.getTimeMultiplier();
+            fadeInDuration = time * 0.4f / GameHelper.getSpeedMultiplier();
+            float fadeOutDuration = time * 0.3f / GameHelper.getSpeedMultiplier();
 
             number.registerEntityModifier(Modifiers.sequence(
                     Modifiers.fadeIn(fadeInDuration),
@@ -124,7 +124,7 @@ public class HitCircle extends GameObject {
             // This uniform speedup is hard to match 1:1, however we can at least make AR>10 (via mods) feel good by extending the upper linear function above.
             // Note that this doesn't exactly match the AR>10 visuals as they're classically known, but it feels good.
             // This adjustment is necessary for AR>10, otherwise TimePreempt can become smaller leading to hitcircles not fully fading in.
-            fadeInDuration = 0.4f * Math.min(1, time / 0.45f) * GameHelper.getTimeMultiplier();
+            fadeInDuration = 0.4f * Math.min(1, time / 0.45f) / GameHelper.getSpeedMultiplier();
 
             circle.registerEntityModifier(Modifiers.fadeIn(fadeInDuration));
             overlay.registerEntityModifier(Modifiers.fadeIn(fadeInDuration));
@@ -132,8 +132,8 @@ public class HitCircle extends GameObject {
         }
 
         if (approachCircle.isVisible()) {
-            approachCircle.registerEntityModifier(Modifiers.alpha(Math.min(fadeInDuration * 2, time * GameHelper.getTimeMultiplier()), 0, 0.9f));
-            approachCircle.registerEntityModifier(Modifiers.scale(time * GameHelper.getTimeMultiplier(), scale * 3, scale));
+            approachCircle.registerEntityModifier(Modifiers.alpha(Math.min(fadeInDuration * 2, time / GameHelper.getSpeedMultiplier()), 0, 0.9f));
+            approachCircle.registerEntityModifier(Modifiers.scale(time / GameHelper.getSpeedMultiplier(), scale * 3, scale));
         }
 
         scene.attachChild(number, 0);

--- a/src/ru/nsu/ccfit/zuev/osu/game/ModernSpinner.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/ModernSpinner.java
@@ -183,11 +183,11 @@ public class ModernSpinner extends Spinner {
                 score++;
                 scene.attachChild(bonusScore);
                 ResourceManager.getInstance().getSound("spinnerbonus").play();
-                float timeMultiplier = GameHelper.getTimeMultiplier();
+                float speedMultiplier = GameHelper.getSpeedMultiplier();
                 glow.registerEntityModifier(
                     Modifiers.sequence(
-                        Modifiers.color(0.1f * timeMultiplier, 0f, 1f, 0.8f, 1f, 1f, 1f),
-                        Modifiers.color(0.1f * timeMultiplier, 1f, 0f, 1f, 0.8f, 1f, 1f)
+                        Modifiers.color(0.1f / speedMultiplier, 0f, 1f, 0.8f, 1f, 1f, 1f),
+                        Modifiers.color(0.1f / speedMultiplier, 1f, 0f, 1f, 0.8f, 1f, 1f)
                     )
                 );
                 float rate = 0.375f;

--- a/src/ru/nsu/ccfit/zuev/osu/game/Slider.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/Slider.java
@@ -246,8 +246,8 @@ public class Slider extends GameObject {
         float fadeInDuration;
 
         if (GameHelper.isHidden()) {
-            fadeInDuration = time * 0.4f * GameHelper.getTimeMultiplier();
-            float fadeOutDuration = time * 0.3f * GameHelper.getTimeMultiplier();
+            fadeInDuration = time * 0.4f / GameHelper.getSpeedMultiplier();
+            float fadeOutDuration = time * 0.3f / GameHelper.getSpeedMultiplier();
 
             number.registerEntityModifier(Modifiers.sequence(
                 Modifiers.fadeIn(fadeInDuration),
@@ -279,7 +279,7 @@ public class Slider extends GameObject {
             // This uniform speedup is hard to match 1:1, however we can at least make AR>10 (via mods) feel good by extending the upper linear function above.
             // Note that this doesn't exactly match the AR>10 visuals as they're classically known, but it feels good.
             // This adjustment is necessary for AR>10, otherwise TimePreempt can become smaller leading to hitcircles not fully fading in.
-            fadeInDuration = 0.4f * Math.min(1, time / ((float) GameHelper.ar2ms(10) / 1000)) * GameHelper.getTimeMultiplier();
+            fadeInDuration = 0.4f * Math.min(1, time / ((float) GameHelper.ar2ms(10) / 1000)) / GameHelper.getSpeedMultiplier();
 
             number.registerEntityModifier(Modifiers.fadeIn(fadeInDuration));
             startCircle.registerEntityModifier(Modifiers.fadeIn(fadeInDuration));
@@ -289,8 +289,8 @@ public class Slider extends GameObject {
         }
 
         if (approachCircle.isVisible()) {
-            approachCircle.registerEntityModifier(Modifiers.alpha(Math.min(fadeInDuration * 2, time * GameHelper.getTimeMultiplier()), 0, 0.9f));
-            approachCircle.registerEntityModifier(Modifiers.scale(time * GameHelper.getTimeMultiplier(), scale * 3, scale));
+            approachCircle.registerEntityModifier(Modifiers.alpha(Math.min(fadeInDuration * 2, time / GameHelper.getSpeedMultiplier()), 0, 0.9f));
+            approachCircle.registerEntityModifier(Modifiers.scale(time / GameHelper.getSpeedMultiplier(), scale * 3, scale));
         }
 
         scene.attachChild(number, 0);
@@ -434,11 +434,11 @@ public class Slider extends GameObject {
             if (GameHelper.isHidden()) {
                 abstractSliderBody.removeFromScene(scene);
             } else {
-                abstractSliderBody.removeFromScene(scene, 0.24f * GameHelper.getTimeMultiplier(), this);
+                abstractSliderBody.removeFromScene(scene, 0.24f / GameHelper.getSpeedMultiplier(), this);
             }
         }
 
-        ball.registerEntityModifier(Modifiers.fadeOut(0.1f * GameHelper.getTimeMultiplier()).setOnFinished(entity -> {
+        ball.registerEntityModifier(Modifiers.fadeOut(0.1f / GameHelper.getSpeedMultiplier()).setOnFinished(entity -> {
             Execution.updateThread(entity::detachSelf);
         }));
 
@@ -569,9 +569,9 @@ public class Slider extends GameObject {
             mIsAnimating = true;
 
             followCircle.clearEntityModifiers();
-            followCircle.registerEntityModifier(Modifiers.scale(0.2f * GameHelper.getTimeMultiplier(), followCircle.getScaleX(), followCircle.getScaleX() * 0.8f).setEaseFunction(EaseQuadOut.getInstance()));
+            followCircle.registerEntityModifier(Modifiers.scale(0.2f / GameHelper.getSpeedMultiplier(), followCircle.getScaleX(), followCircle.getScaleX() * 0.8f).setEaseFunction(EaseQuadOut.getInstance()));
             followCircle.registerEntityModifier(
-                Modifiers.alpha(0.2f * GameHelper.getTimeMultiplier(), followCircle.getAlpha(), 0f).setOnFinished(entity -> {
+                Modifiers.alpha(0.2f / GameHelper.getSpeedMultiplier(), followCircle.getAlpha(), 0f).setOnFinished(entity -> {
                     Execution.updateThread(() -> {
                         entity.detachSelf();
 
@@ -735,7 +735,7 @@ public class Slider extends GameObject {
             ball.setFps((float) (100 * GameHelper.getSpeed() * scale / timingControlPoint.msPerBeat));
             ball.setScale(scale);
             ball.setFlippedHorizontal(false);
-            ball.registerEntityModifier(Modifiers.fadeIn(0.1f * GameHelper.getTimeMultiplier()));
+            ball.registerEntityModifier(Modifiers.fadeIn(0.1f / GameHelper.getSpeedMultiplier()));
 
             followCircle.setAlpha(0);
             if (!Config.isAnimateFollowCircle()) {
@@ -767,7 +767,7 @@ public class Slider extends GameObject {
         tickTime += dt;
 
         if (Config.isAnimateFollowCircle()) {
-            float remainTime = (float) ((maxTime * GameHelper.getTimeMultiplier() * repeatCount) - passedTime);
+            float remainTime = (float) ((maxTime / GameHelper.getSpeedMultiplier() * repeatCount) - passedTime);
 
             if (inRadius && !mWasInRadius) {
                 mWasInRadius = true;
@@ -777,9 +777,9 @@ public class Slider extends GameObject {
                 float initialScale = followCircle.getAlpha() == 0 ? scale * 0.5f : followCircle.getScaleX();
 
                 followCircle.clearEntityModifiers();
-                followCircle.registerEntityModifier(Modifiers.alpha(Math.min(remainTime, 0.06f * GameHelper.getTimeMultiplier()), followCircle.getAlpha(), 1f));
+                followCircle.registerEntityModifier(Modifiers.alpha(Math.min(remainTime, 0.06f / GameHelper.getSpeedMultiplier()), followCircle.getAlpha(), 1f));
                 followCircle.registerEntityModifier(
-                    Modifiers.scale(Math.min(remainTime, 0.18f * GameHelper.getTimeMultiplier()), initialScale, scale)
+                    Modifiers.scale(Math.min(remainTime, 0.18f / GameHelper.getSpeedMultiplier()), initialScale, scale)
                         .setEaseFunction(EaseQuadOut.getInstance())
                         .setOnFinished(entity -> mIsAnimating = false)
                 );
@@ -788,9 +788,9 @@ public class Slider extends GameObject {
                 mIsAnimating = true;
 
                 followCircle.clearEntityModifiers();
-                followCircle.registerEntityModifier(Modifiers.scale(0.1f * GameHelper.getTimeMultiplier(), followCircle.getScaleX(), scale * 2f));
+                followCircle.registerEntityModifier(Modifiers.scale(0.1f / GameHelper.getSpeedMultiplier(), followCircle.getScaleX(), scale * 2f));
                 followCircle.registerEntityModifier(
-                    Modifiers.alpha(0.1f * GameHelper.getTimeMultiplier(), followCircle.getAlpha(), 0f).setOnFinished(entity -> {
+                    Modifiers.alpha(0.1f / GameHelper.getSpeedMultiplier(), followCircle.getAlpha(), 0f).setOnFinished(entity -> {
                         if (mIsOver) {
                             Execution.updateThread(entity::detachSelf);
                         }
@@ -814,7 +814,7 @@ public class Slider extends GameObject {
 
                 if (Config.isAnimateFollowCircle() && !mIsAnimating) {
                     followCircle.clearEntityModifiers();
-                    followCircle.registerEntityModifier(Modifiers.scale((float) Math.min(tickInterval / GameHelper.getTickRate(), 0.2f) * GameHelper.getTimeMultiplier(), scale * 1.1f, scale).setEaseFunction(EaseQuadOut.getInstance()));
+                    followCircle.registerEntityModifier(Modifiers.scale((float) Math.min(tickInterval / GameHelper.getTickRate(), 0.2f) / GameHelper.getSpeedMultiplier(), scale * 1.1f, scale).setEaseFunction(EaseQuadOut.getInstance()));
                 }
 
                 ticksGot++;
@@ -855,8 +855,8 @@ public class Slider extends GameObject {
 
         if (GameHelper.isHidden()) {
             // New duration from completed fade in to end (before fading out)
-            float realFadeInDuration = fadeInDuration / GameHelper.getTimeMultiplier();
-            float fadeOutDuration = (float) ((maxTime * repeatCount + preTime - realFadeInDuration) * GameHelper.getTimeMultiplier());
+            float realFadeInDuration = fadeInDuration / GameHelper.getSpeedMultiplier();
+            float fadeOutDuration = (float) ((maxTime * repeatCount + preTime - realFadeInDuration) / GameHelper.getSpeedMultiplier());
 
             abstractSliderBody.applyFadeAdjustments(fadeInDuration, fadeOutDuration);
         } else {

--- a/src/ru/nsu/ccfit/zuev/osu/game/Spinner.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/Spinner.java
@@ -268,9 +268,9 @@ public class Spinner extends GameObject {
         if (percentfill > 1 || clear) {
             percentfill = 1;
             if (!clear) {
-                float timeMultiplier = GameHelper.getTimeMultiplier();
-                clearText.registerEntityModifier(Modifiers.fadeIn(0.25f * timeMultiplier));
-                clearText.registerEntityModifier(Modifiers.scale(0.25f * timeMultiplier, 1.5f, 1));
+                float speedMultiplier = GameHelper.getSpeedMultiplier();
+                clearText.registerEntityModifier(Modifiers.fadeIn(0.25f / speedMultiplier));
+                clearText.registerEntityModifier(Modifiers.scale(0.25f / speedMultiplier, 1.5f, 1));
                 scene.attachChild(clearText);
                 clear = true;
             } else if (Math.abs(rotations) > 1) {


### PR DESCRIPTION
We have two properties that are very confusingly named:
- `GameScene.timeMultiplier`, which is the rate at which gameplay progresses in terms of time.
- `GameHelper.timeMultiplier`, which is the inverse of `GameScene.timeMultiplier`.

These namings can easily cause mistakes if not paid enough attention. In attempt to remedy this, I have unified them into a single property in `GameHelper.speedMultiplier`, which denotes the rate at which gameplay progresses in terms of time.