### PR TITLE
Impose maximum hit range restriction to circles and sliders

### DIFF
--- a/src/ru/nsu/ccfit/zuev/osu/game/GameObject.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameObject.java
@@ -5,6 +5,11 @@ import android.graphics.PointF;
 import ru.nsu.ccfit.zuev.osu.scoring.Replay;
 
 public abstract class GameObject {
+    /**
+     * The maximum allowable time difference from the start time of an object
+     * to its hit time to be considered a hit, in seconds.
+     */
+    protected static final float objectHittableRange = 0.4f;
 
     protected boolean endsCombo;
     protected boolean autoPlay = false;

--- a/src/ru/nsu/ccfit/zuev/osu/game/HitCircle.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/HitCircle.java
@@ -166,6 +166,10 @@ public class HitCircle extends GameObject {
         scene = null;
     }
 
+    private boolean canBeHit() {
+        return passedTime >= Math.max(0, timePreempt - objectHittableRange);
+    }
+
     private boolean isHit() {
         for (int i = 0, count = listener.getCursorsCount(); i < count; i++) {
 
@@ -224,7 +228,7 @@ public class HitCircle extends GameObject {
                 removeFromScene();
                 return;
             }
-        } else if (passedTime * 2 > timePreempt && isHit()) {
+        } else if (canBeHit() && isHit()) {
             float signAcc = passedTime - timePreempt;
             if (Config.isFixFrameOffset()) {
                 signAcc += (float) hitOffsetToPreviousFrame() / 1000f;
@@ -285,7 +289,7 @@ public class HitCircle extends GameObject {
 
     @Override
     public void tryHit(final float dt) {
-        if (passedTime * 2 > timePreempt && isHit()) {
+        if (canBeHit() && isHit()) {
             float signAcc = passedTime - timePreempt;
             if (Config.isFixFrameOffset()) {
                 signAcc += (float) hitOffsetToPreviousFrame() / 1000f;

--- a/src/ru/nsu/ccfit/zuev/osu/game/Slider.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/Slider.java
@@ -563,6 +563,10 @@ public class Slider extends GameObject {
         removeFromScene();
     }
 
+    private boolean canBeHit() {
+        return passedTime >= -objectHittableRange;
+    }
+
     private boolean isHit() {
         float radius = Utils.sqr((float) beatmapSlider.getGameplayRadius());
         for (int i = 0, count = listener.getCursorsCount(); i < count; i++) {
@@ -613,16 +617,23 @@ public class Slider extends GameObject {
                 currentNestedObjectIndex++;
                 ticksGot++;
                 listener.onSliderHit(id, 30, null, pos, false, bodyColor, GameObjectListener.SLIDER_START);
-            } else if (isHit() && -passedTime < GameHelper.getDifficultyHelper().hitWindowFor50(GameHelper.getOverallDifficulty())) {
+            } else if (canBeHit() && isHit()) {
                 // if we clicked
                 listener.registerAccuracy(passedTime);
                 startHit = true;
-                playCurrentNestedObjectHitSound();
-                currentNestedObjectIndex++;
                 ticksGot++;
                 firstHitAccuracy = (int) (passedTime * 1000);
-                listener.onSliderHit(id, 30, null, pos,
+
+                if (-passedTime < GameHelper.getDifficultyHelper().hitWindowFor50(GameHelper.getOverallDifficulty())) {
+                    playCurrentNestedObjectHitSound();
+                    listener.onSliderHit(id, 30, null, pos,
                         false, bodyColor, GameObjectListener.SLIDER_START);
+                } else {
+                    listener.onSliderHit(id, -1, null, pos,
+                        false, bodyColor, GameObjectListener.SLIDER_START);
+                }
+
+                currentNestedObjectIndex++;
             }
         }
 
@@ -927,15 +938,22 @@ public class Slider extends GameObject {
             return;
         }
 
-        if (isHit() && -passedTime < GameHelper.getDifficultyHelper().hitWindowFor50(GameHelper.getOverallDifficulty())) {
+        if (canBeHit() && isHit()) {
             listener.registerAccuracy(passedTime);
             startHit = true;
-            playCurrentNestedObjectHitSound();
-            currentNestedObjectIndex++;
             ticksGot++;
             firstHitAccuracy = (int) (passedTime * 1000);
-            listener.onSliderHit(id, 30, null, pos,
+
+            if (-passedTime < GameHelper.getDifficultyHelper().hitWindowFor50(GameHelper.getOverallDifficulty())) {
+                playCurrentNestedObjectHitSound();
+                listener.onSliderHit(id, 30, null, pos,
                     false, bodyColor, GameObjectListener.SLIDER_START);
+            } else {
+                listener.onSliderHit(id, -1, null, pos,
+                        false, bodyColor, GameObjectListener.SLIDER_START);
+            }
+
+            currentNestedObjectIndex++;
         }
 
         if (passedTime < 0 && startHit) {


### PR DESCRIPTION
Currently, circles and sliders have a period during which the object cannot be hit even though it has started their lifetime (that is, it is considered an active object within `GameScene`). The period for both objects are different:

- For circles, the period starts from when the circle spawns until the approach circle is halfway into the circle. This is problematic as it means that AR imposes an additional hit window that can be stricter than the hit window imposed by OD. For example, if the player plays a beatmap with AR10 (450ms approach time) and OD0 (100ms for great, 200ms for good, 300ms for meh), the most lenient hit offset is 225ms due to the hit window imposed by AR, even though the most lenient hit offset in terms of OD is 300ms.
- For sliders, the period starts from when the slider spawns until the most lenient hit offset imposed by OD. While this is not as problematic as circles, this means it is impossible to slider break for hitting the slider too early.

To solve these problems, I have changed the period to always be 400ms before the start time of the circle or slider. Do note that this period does not apply to RX as the mod is designed to hit as accurate as possible.