### PR TITLE
Improve old database system migration

### DIFF
--- a/src/com/edlplan/ui/fragment/PropsMenuFragment.kt
+++ b/src/com/edlplan/ui/fragment/PropsMenuFragment.kt
@@ -182,6 +182,6 @@ class PropsMenuFragment : BaseFragment(), IPropsMenu {
 
     fun saveProp() {
         item!!.isFavorite = beatmapProperties!!.isFavorite
-        DatabaseManager.beatmapOptionsTable.insert(beatmapProperties!!)
+        DatabaseManager.beatmapOptionsTable.update(beatmapProperties!!)
     }
 }

--- a/src/com/reco1l/osu/data/BeatmapCollections.kt
+++ b/src/com/reco1l/osu/data/BeatmapCollections.kt
@@ -29,7 +29,7 @@ interface IBeatmapCollectionsDAO {
     @Query("SELECT name FROM BeatmapSetCollection")
     fun getCollections(): List<String>
 
-    @Query("INSERT INTO BeatmapSetCollection (name) VALUES (:name)")
+    @Query("INSERT OR IGNORE INTO BeatmapSetCollection (name) VALUES (:name)")
     fun insertCollection(name: String): Long
 
     @Query("DELETE FROM BeatmapSetCollection WHERE name = :name")
@@ -45,7 +45,7 @@ interface IBeatmapCollectionsDAO {
     @Query("SELECT setDirectory FROM BeatmapSetCollection_BeatmapSetInfo WHERE collectionName = :collectionName")
     fun getBeatmaps(collectionName: String): List<String>?
 
-    @Query("INSERT INTO BeatmapSetCollection_BeatmapSetInfo (collectionName, setDirectory) VALUES (:collectionName, :setDirectory)")
+    @Query("INSERT OR IGNORE INTO BeatmapSetCollection_BeatmapSetInfo (collectionName, setDirectory) VALUES (:collectionName, :setDirectory)")
     fun addBeatmap(collectionName: String, setDirectory: String): Long
 
     @Query("DELETE FROM BeatmapSetCollection_BeatmapSetInfo WHERE collectionName = :collectionName AND setDirectory = :setDirectory")

--- a/src/com/reco1l/osu/data/BeatmapOptions.kt
+++ b/src/com/reco1l/osu/data/BeatmapOptions.kt
@@ -36,11 +36,8 @@ data class BeatmapOptions(
     @Query("SELECT * FROM BeatmapOptions WHERE setDirectory = :setDirectory")
     fun getOptions(setDirectory: String): BeatmapOptions?
 
-    @Update
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     fun insert(options: BeatmapOptions)
-
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertAll(options: List<BeatmapOptions>)
 
     @Query("DELETE FROM BeatmapOptions")
     fun deleteAll()

--- a/src/com/reco1l/osu/data/BeatmapOptions.kt
+++ b/src/com/reco1l/osu/data/BeatmapOptions.kt
@@ -39,6 +39,9 @@ data class BeatmapOptions(
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     fun insert(options: BeatmapOptions)
 
+    @Update(onConflict = OnConflictStrategy.REPLACE)
+    fun update(options: BeatmapOptions)
+
     @Query("DELETE FROM BeatmapOptions")
     fun deleteAll()
 

--- a/src/com/reco1l/osu/data/Database.kt
+++ b/src/com/reco1l/osu/data/Database.kt
@@ -93,7 +93,7 @@ object DatabaseManager {
 
                         for ((directory, properties) in ois.readObject() as Map<String, BeatmapProperties>) {
 
-                            val options = BeatmapOptions(
+                            beatmapOptionsTable.insert(BeatmapOptions(
                                 setDirectory = directory.let {
                                     if (it.endsWith('/')) {
                                         it.substring(0, it.length - 1).substringAfterLast('/')
@@ -103,9 +103,7 @@ object DatabaseManager {
                                 },
                                 isFavorite = properties.favorite,
                                 offset = properties.offset
-                            )
-
-                            beatmapOptionsTable.insert(options)
+                            ))
                         }
                     }
                 }

--- a/src/com/reco1l/osu/data/Database.kt
+++ b/src/com/reco1l/osu/data/Database.kt
@@ -91,10 +91,10 @@ object DatabaseManager {
                         // Ignoring first object which is intended to be the version.
                         ois.readObject()
 
-                        for ((directory, properties) in ois.readObject() as Map<String, BeatmapProperties>) {
+                        for ((path, properties) in ois.readObject() as Map<String, BeatmapProperties>) {
 
                             beatmapOptionsTable.insert(BeatmapOptions(
-                                setDirectory = directory.let {
+                                setDirectory = path.let {
                                     if (it.endsWith('/')) {
                                         it.substring(0, it.length - 1).substringAfterLast('/')
                                     } else {

--- a/src/com/reco1l/osu/data/Database.kt
+++ b/src/com/reco1l/osu/data/Database.kt
@@ -82,7 +82,6 @@ object DatabaseManager {
             val oldPropertiesFile = File(context.filesDir, "properties")
 
             if (oldPropertiesFile.exists()) {
-
                 GlobalManager.getInstance().info = "Migrating beatmap properties..."
 
                 oldPropertiesFile.inputStream().use { fis ->
@@ -92,10 +91,10 @@ object DatabaseManager {
                         // Ignoring first object which is intended to be the version.
                         ois.readObject()
 
-                        val options = (ois.readObject() as Map<String, BeatmapProperties>).map { (path, properties) ->
+                        for ((directory, properties) in ois.readObject() as Map<String, BeatmapProperties>) {
 
-                            BeatmapOptions(
-                                setDirectory = path.let {
+                            val options = BeatmapOptions(
+                                setDirectory = directory.let {
                                     if (it.endsWith('/')) {
                                         it.substring(0, it.length - 1).substringAfterLast('/')
                                     } else {
@@ -105,14 +104,13 @@ object DatabaseManager {
                                 isFavorite = properties.favorite,
                                 offset = properties.offset
                             )
+
+                            beatmapOptionsTable.insert(options)
                         }
-
-                        beatmapOptionsTable.insertAll(options)
                     }
-
                 }
 
-                oldPropertiesFile.renameTo(File(context.filesDir, "properties.old"))
+                oldPropertiesFile.renameTo(File(context.filesDir, "properties_old"))
             }
 
         } catch (e: IOException) {
@@ -124,15 +122,15 @@ object DatabaseManager {
             val oldFavoritesFile = File(Config.getCorePath(), "json/favorites.json")
 
             if (oldFavoritesFile.exists()) {
+                GlobalManager.getInstance().info = "Migrating beatmap collections..."
 
                 val json = JSONObject(oldFavoritesFile.readText())
-
-                GlobalManager.getInstance().info = "Migrating beatmap collections..."
 
                 for (collectionName in json.keys()) {
                     beatmapCollectionsTable.insertCollection(collectionName)
 
                     for (beatmapPath in json.getJSONArray(collectionName)) {
+
                         beatmapCollectionsTable.addBeatmap(
                             collectionName = collectionName,
                             setDirectory = beatmapPath.toString().let {
@@ -146,7 +144,7 @@ object DatabaseManager {
                     }
                 }
 
-                oldFavoritesFile.renameTo(File(Config.getCorePath(), "json/favorites.oldjson"))
+                oldFavoritesFile.renameTo(File(Config.getCorePath(), "json/favorites_old.json"))
             }
 
         } catch (e: IOException) {
@@ -158,7 +156,6 @@ object DatabaseManager {
             val oldDatabaseFile = File(Config.getCorePath(), "databases/osudroid_test.db")
 
             if (oldDatabaseFile.exists()) {
-
                 GlobalManager.getInstance().info = "Migrating score table..."
 
                 DBOpenHelper.getOrCreate(context).use { helper ->
@@ -172,8 +169,15 @@ object DatabaseManager {
                             while (it.moveToNext()) {
 
                                 try {
+                                    val id = it.getInt(it.getColumnIndexOrThrow("id")).toLong()
+
+                                    if (scoreInfoTable.scoreExists(id)) {
+                                        pendingScores--
+                                        continue
+                                    }
+
                                     val scoreInfo = ScoreInfo(
-                                        id = it.getInt(it.getColumnIndexOrThrow("id")).toLong(),
+                                        id = id,
                                         // "filename" can contain the full path, so we need to extract both filename and directory name refers
                                         // to the beatmap set directory. The pattern could be `/beatmapSetDirectory/beatmapFilename/` with or
                                         // without the trailing slash.
@@ -218,7 +222,6 @@ object DatabaseManager {
                                     )
 
                                     scoreInfoTable.insertScore(scoreInfo)
-                                    db.rawQuery("DELETE FROM scores WHERE id = ${scoreInfo.id}", null)
                                     pendingScores--
 
                                 } catch (e: Exception) {
@@ -227,7 +230,7 @@ object DatabaseManager {
                             }
 
                             if (pendingScores <= 0) {
-                                oldDatabaseFile.renameTo(File(Config.getCorePath(), "databases/osudroid_test.olddb"))
+                                oldDatabaseFile.renameTo(File(Config.getCorePath(), "databases/osudroid_old.db"))
                             }
                         }
                     }

--- a/src/com/reco1l/osu/data/Scores.kt
+++ b/src/com/reco1l/osu/data/Scores.kt
@@ -231,4 +231,7 @@ interface IScoreInfoDAO {
     @Query("DELETE FROM ScoreInfo WHERE id = :id")
     fun deleteScore(id: Int): Int
 
+    @Query("SELECT EXISTS(SELECT 1 FROM ScoreInfo WHERE id = :id)")
+    fun scoreExists(id: Long): Boolean
+
 }


### PR DESCRIPTION
### Reason
Score table migration was giving troubles with keeping old data as backup in case the process fails or it's aborted, so I decided to change the migration process.

### Explanation 
The new process will follow this path:

* First of all check if the old database file exists so we can start the migration.
* Iterate per each row and check if it was already migrated to the new system skipping those that had been.
* Once the entire process ends successfully we can proceed with renaming the file so next time it won't trigger the migration again.