### PR TITLE
Add pp for global beatmap leaderboard in song selection

### DIFF
--- a/res/values/options.xml
+++ b/res/values/options.xml
@@ -68,11 +68,11 @@
         <item>1</item>
         <item>2</item>
     </string-array>
-    <string-array name="beatmap_leaderboard_scoring_mode_names">
+    <string-array name="global_beatmap_leaderboard_scoring_mode_names">
         <item>Score</item>
         <item>Performance Points</item>
     </string-array>
-    <string-array name="beatmap_leaderboard_scoring_mode_values">
+    <string-array name="global_beatmap_leaderboard_scoring_mode_values">
         <item>0</item>
         <item>1</item>
     </string-array>
@@ -215,8 +215,8 @@
     <string name="opt_loadavatar_title">Load Avatar</string>
     <string name="opt_loadavatar_summary">Load avatar in online leaderboard</string>
 
-    <string name="opt_leaderboard_scoring_mode_title">Beatmap leaderboard scoring mode</string>
-    <string name="opt_leaderboard_scoring_mode_summary">Choose the scoring mode for the beatmap leaderboard</string>
+    <string name="opt_global_beatmap_leaderboard_scoring_mode_title">Global beatmap leaderboard scoring mode</string>
+    <string name="opt_global_beatmap_leaderboard_scoring_mode_summary">Choose the scoring mode for global beatmap leaderboards</string>
 
 
     <string name="opt_error_meter_display_title">Hit error meter</string>

--- a/res/values/options.xml
+++ b/res/values/options.xml
@@ -68,6 +68,14 @@
         <item>1</item>
         <item>2</item>
     </string-array>
+    <string-array name="beatmap_leaderboard_scoring_mode_names">
+        <item>Score</item>
+        <item>Performance Points</item>
+    </string-array>
+    <string-array name="beatmap_leaderboard_scoring_mode_values">
+        <item>0</item>
+        <item>1</item>
+    </string-array>
     <string-array name="placeholder_array">
         <item>placeholder</item>
     </string-array>
@@ -206,6 +214,9 @@
 
     <string name="opt_loadavatar_title">Load Avatar</string>
     <string name="opt_loadavatar_summary">Load avatar in online leaderboard</string>
+
+    <string name="opt_leaderboard_scoring_mode_title">Beatmap leaderboard scoring mode</string>
+    <string name="opt_leaderboard_scoring_mode_summary">Choose the scoring mode for the beatmap leaderboard</string>
 
 
     <string name="opt_error_meter_display_title">Hit error meter</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -90,6 +90,7 @@
 	<string name="favorite_manage">Manage Beatmap folder</string>
 
 	<string name="menu_score" formatted="false">Score: %s (%dx)</string>
+	<string name="menu_performance" formatted="false">Performance: %spp (%dx)</string>
 	<string name="menu_creator">Creator: %s</string>
 	<string name="menu_mod_back">Back</string>
 	<string name="menu_mod_title">Mod selection</string>

--- a/res/xml/settings_general.xml
+++ b/res/xml/settings_general.xml
@@ -21,11 +21,11 @@
 
         <com.reco1l.osu.ui.SelectPreference
             android:defaultValue="0"
-            android:entries="@array/beatmap_leaderboard_scoring_mode_names"
-            android:entryValues="@array/beatmap_leaderboard_scoring_mode_values"
+            android:entries="@array/global_beatmap_leaderboard_scoring_mode_names"
+            android:entryValues="@array/global_beatmap_leaderboard_scoring_mode_values"
             android:key="beatmapLeaderboardScoringMode"
-            android:summary="@string/opt_leaderboard_scoring_mode_summary"
-            android:title="@string/opt_leaderboard_scoring_mode_title"
+            android:summary="@string/opt_global_beatmap_leaderboard_scoring_mode_summary"
+            android:title="@string/opt_global_beatmap_leaderboard_scoring_mode_title"
             app:layout="@layout/settings_preference_bottom" />
 
     </PreferenceCategory>

--- a/res/xml/settings_general.xml
+++ b/res/xml/settings_general.xml
@@ -17,7 +17,16 @@
             android:key="loadAvatar"
             android:summary="@string/opt_loadavatar_summary"
             android:title="@string/opt_loadavatar_title"
-            app:layout="@layout/settings_preference_checkbox_bottom" />
+            app:layout="@layout/settings_preference_checkbox" />
+
+        <com.reco1l.osu.ui.SelectPreference
+            android:defaultValue="0"
+            android:entries="@array/beatmap_leaderboard_scoring_mode_names"
+            android:entryValues="@array/beatmap_leaderboard_scoring_mode_values"
+            android:key="beatmapLeaderboardScoringMode"
+            android:summary="@string/opt_leaderboard_scoring_mode_summary"
+            android:title="@string/opt_leaderboard_scoring_mode_title"
+            app:layout="@layout/settings_preference_bottom" />
 
     </PreferenceCategory>
 

--- a/src/ru/nsu/ccfit/zuev/osu/Config.java
+++ b/src/ru/nsu/ccfit/zuev/osu/Config.java
@@ -85,6 +85,7 @@ public class Config {
         RES_HEIGHT,
         errorMeter,
         spinnerStyle,
+        beatmapLeaderboardScoringMode,
         metronomeSwitch;
     
     private static float soundVolume,
@@ -251,6 +252,7 @@ public class Config {
         onlinePassword = prefs.getString("onlinePassword", null);
         stayOnline = prefs.getBoolean("stayOnline", false);
         loadAvatar = prefs.getBoolean("loadAvatar",false);
+        beatmapLeaderboardScoringMode = Integer.parseInt(prefs.getString("beatmapLeaderboardScoringMode", "0"));
     }
 
     public static void setSize() {
@@ -518,6 +520,10 @@ public class Config {
 
     public static void setStayOnline(boolean stayOnline) {
         Config.stayOnline = stayOnline;
+    }
+
+    public static int getBeatmapLeaderboardScoringMode() {
+        return beatmapLeaderboardScoringMode;
     }
 
     public static boolean getLoadAvatar() {

--- a/src/ru/nsu/ccfit/zuev/osu/Config.java
+++ b/src/ru/nsu/ccfit/zuev/osu/Config.java
@@ -23,6 +23,7 @@ import net.margaritov.preference.colorpicker.ColorPickerPreference;
 import org.anddev.andengine.util.Debug;
 
 import ru.nsu.ccfit.zuev.osu.helper.FileUtils;
+import ru.nsu.ccfit.zuev.osu.scoring.BeatmapLeaderboardScoringMode;
 
 public class Config {
     private static String corePath,
@@ -85,7 +86,6 @@ public class Config {
         RES_HEIGHT,
         errorMeter,
         spinnerStyle,
-        beatmapLeaderboardScoringMode,
         metronomeSwitch;
     
     private static float soundVolume,
@@ -97,6 +97,8 @@ public class Config {
         cursorSize;
 
     private static DifficultyAlgorithm difficultyAlgorithm;
+
+    private static BeatmapLeaderboardScoringMode beatmapLeaderboardScoringMode;
 
     private static Map<String, String> skins;
 
@@ -252,7 +254,7 @@ public class Config {
         onlinePassword = prefs.getString("onlinePassword", null);
         stayOnline = prefs.getBoolean("stayOnline", false);
         loadAvatar = prefs.getBoolean("loadAvatar",false);
-        beatmapLeaderboardScoringMode = Integer.parseInt(prefs.getString("beatmapLeaderboardScoringMode", "0"));
+        beatmapLeaderboardScoringMode = BeatmapLeaderboardScoringMode.parse(Integer.parseInt(prefs.getString("beatmapLeaderboardScoringMode", "0")));
     }
 
     public static void setSize() {
@@ -522,7 +524,7 @@ public class Config {
         Config.stayOnline = stayOnline;
     }
 
-    public static int getBeatmapLeaderboardScoringMode() {
+    public static BeatmapLeaderboardScoringMode getBeatmapLeaderboardScoringMode() {
         return beatmapLeaderboardScoringMode;
     }
 

--- a/src/ru/nsu/ccfit/zuev/osu/menu/ScoreBoard.java
+++ b/src/ru/nsu/ccfit/zuev/osu/menu/ScoreBoard.java
@@ -22,6 +22,7 @@ import ru.nsu.ccfit.zuev.osu.*;
 import ru.nsu.ccfit.zuev.osu.game.GameHelper;
 import ru.nsu.ccfit.zuev.osu.helper.StringTable;
 import ru.nsu.ccfit.zuev.osu.online.OnlineManager;
+import ru.nsu.ccfit.zuev.osu.scoring.BeatmapLeaderboardScoringMode;
 import ru.nsu.ccfit.zuev.osuplus.R;
 
 import java.io.File;
@@ -190,6 +191,12 @@ public class ScoreBoard extends Entity implements ScrollDetector.IScrollDetector
         return sb.toString();
     }
 
+    private String formatPP(StringBuilder sb, int pp) {
+        sb.setLength(0);
+        sb.append(pp);
+        return sb.toString();
+    }
+
     private void initFromOnline(BeatmapInfo beatmapInfo) {
         loadingText.setText("Loading scores...");
 
@@ -218,62 +225,69 @@ public class ScoreBoard extends Entity implements ScrollDetector.IScrollDetector
 
                 loadingText.setText(OnlineManager.getInstance().getFailMessage());
 
+                boolean isPPScoringMode = Config.getBeatmapLeaderboardScoringMode() == BeatmapLeaderboardScoringMode.PP;
                 var username = OnlineManager.getInstance().getUsername();
                 var items = new ArrayList<ScoreBoardItem>(scores.size());
                 var sb = new StringBuilder();
 
-                int nextTotalScore = 0;
+                float nextTotal = 0;
 
                 for (int i = 0; i < scores.size() && isActive(); ++i) {
 
                     var data = scores.get(i).split("\\s+");
 
-                    if (data.length < 8 || data.length > 9) {
+                    if (data.length < 9 || data.length > 10) {
                         continue;
                     }
 
-                    var isInLeaderboard = data.length == 8;
-                    var isPersonalBest = data.length == 9 || data[1].equals(username);
+                    var isInLeaderboard = data.length == 9;
+                    var isPersonalBest = data.length == 10 || data[1].equals(username);
 
                     var scoreID = Integer.parseInt(data[0]);
                     var playerName = isPersonalBest ? username : data[1];
-                    var currentTotalScore = Integer.parseInt(data[2]);
-                    var combo = Integer.parseInt(data[3]);
-                    var mark = data[4];
-                    var mods = data[5];
-                    var accuracy = GameHelper.Round(Float.parseFloat(data[6]) * 100, 2);
-                    var avatarURL = data[7];
-                    var beatmapRank = isPersonalBest && !isInLeaderboard ? Integer.parseInt(data[8]) : (i + 1);
+                    var score = Integer.parseInt(data[2]);
+                    var pp = Float.parseFloat(data[3]);
+                    var combo = Integer.parseInt(data[4]);
+                    var mark = data[5];
+                    var mods = data[6];
+                    var accuracy = Float.parseFloat(data[7]);
+                    var avatarURL = data[8];
+                    var beatmapRank = isPersonalBest && !isInLeaderboard ? Integer.parseInt(data[9]) : (i + 1);
 
                     sb.setLength(0);
-                    var totalScore = formatScore(sb, currentTotalScore);
+                    var scoreStr = isPPScoringMode ?
+                        // For display purposes, we round the pp.
+                        formatPP(sb, Math.round(pp)) :
+                        formatScore(sb, score);
 
                     sb.setLength(0);
                     var titleStr = sb.append('#').append(beatmapRank).append(' ').append(playerName)
                             .append('\n')
-                            .append(StringTable.format(R.string.menu_score, totalScore, combo))
+                            .append(StringTable.format(
+                                isPPScoringMode ? R.string.menu_performance : R.string.menu_score, scoreStr, combo))
                             .toString();
 
                     if (i < scores.size() - 1) {
                         String[] nextData = scores.get(i + 1).split("\\s+");
 
-                        if (nextData.length == 8 || nextData.length == 9) {
-                            nextTotalScore = Integer.parseInt(nextData[2]);
+                        if (nextData.length == 9 || nextData.length == 10) {
+                            nextTotal = isPPScoringMode ? Float.parseFloat(nextData[3]) : Integer.parseInt(nextData[2]);
                         }
                     } else {
-                        nextTotalScore = 0;
+                        nextTotal = 0;
                     }
 
                     sb.setLength(0);
                     var modString = convertModString(sb, mods);
-                    var diffTotalScore = currentTotalScore - nextTotalScore;
+                    var currentTotal = isPPScoringMode ? pp : score;
+                    var diffTotal = Math.round(currentTotal) - Math.round(nextTotal);
 
                     sb.setLength(0);
                     var accStr = sb.append(modString)
                             .append('\n')
                             .append(StringTable.format("%.2f", GameHelper.Round(accuracy * 100, 2))).append('%')
                             .append('\n')
-                            .append(nextTotalScore == 0 ? "-" : ((diffTotalScore != 0 ? "+" : "") + diffTotalScore))
+                            .append(nextTotal == 0 ? "-" : ((diffTotal != 0 ? "+" : "") + diffTotal))
                             .toString();
 
                     if (!isActive()) {
@@ -288,7 +302,7 @@ public class ScoreBoard extends Entity implements ScrollDetector.IScrollDetector
                         attachChild(new ScoreItem(avatarExecutor, titleStr, accStr, mark, true, scoreID, avatarURL, playerName, false));
 
                         var item = new ScoreBoardItem();
-                        item.set(beatmapRank, playerName, combo, currentTotalScore, scoreID);
+                        item.set(beatmapRank, playerName, combo, score, scoreID);
                         items.add(item);
                     }
                 }

--- a/src/ru/nsu/ccfit/zuev/osu/online/OnlineManager.java
+++ b/src/ru/nsu/ccfit/zuev/osu/online/OnlineManager.java
@@ -28,6 +28,7 @@ import org.json.JSONObject;
 import ru.nsu.ccfit.zuev.osu.*;
 import ru.nsu.ccfit.zuev.osu.helper.MD5Calculator;
 import ru.nsu.ccfit.zuev.osu.online.PostBuilder.RequestException;
+import ru.nsu.ccfit.zuev.osu.scoring.BeatmapLeaderboardScoringMode;
 
 public class OnlineManager {
     public static final String hostname = "osudroid.moe";
@@ -292,6 +293,12 @@ public class OnlineManager {
         post.addParam("filename", beatmapFile.getName());
         post.addParam("hash", hash);
         post.addParam("uid", String.valueOf(userId));
+
+        if (Config.getBeatmapLeaderboardScoringMode() == BeatmapLeaderboardScoringMode.PP) {
+            post.addParam("type", "pp");
+        } else {
+            post.addParam("type", "score");
+        }
 
         ArrayList<String> response = sendRequest(post, endpoint + "getrank.php");
 

--- a/src/ru/nsu/ccfit/zuev/osu/online/OnlineScoring.java
+++ b/src/ru/nsu/ccfit/zuev/osu/online/OnlineScoring.java
@@ -186,17 +186,6 @@ public class OnlineScoring {
         });
     }
 
-    public ArrayList<String> getTop(final File beatmapFile, final String hash) {
-        synchronized (onlineMutex) {
-            try {
-                return OnlineManager.getInstance().getTop(beatmapFile, hash);
-            } catch (OnlineManager.OnlineManagerException e) {
-                Debug.e("Cannot load scores " + e.getMessage());
-                return new ArrayList<>();
-            }
-        }
-    }
-
     public void loadAvatar(final boolean both) {
         if (!OnlineManager.getInstance().isStayOnline()) return;
         final String avatarUrl = OnlineManager.getInstance().getAvatarURL();

--- a/src/ru/nsu/ccfit/zuev/osu/scoring/BeatmapLeaderboardScoringMode.java
+++ b/src/ru/nsu/ccfit/zuev/osu/scoring/BeatmapLeaderboardScoringMode.java
@@ -1,7 +1,7 @@
 package ru.nsu.ccfit.zuev.osu.scoring;
 
 /**
- * Represents the scoring mode used in beatmap leaderboard.
+ * Represents the scoring mode used in online beatmap leaderboard.
  */
 public enum BeatmapLeaderboardScoringMode {
     SCORE,

--- a/src/ru/nsu/ccfit/zuev/osu/scoring/BeatmapLeaderboardScoringMode.java
+++ b/src/ru/nsu/ccfit/zuev/osu/scoring/BeatmapLeaderboardScoringMode.java
@@ -1,0 +1,19 @@
+package ru.nsu.ccfit.zuev.osu.scoring;
+
+/**
+ * Represents the scoring mode used in beatmap leaderboard.
+ */
+public enum BeatmapLeaderboardScoringMode {
+    SCORE,
+    PP;
+
+    /**
+     * Parses an integer value to a {@link BeatmapLeaderboardScoringMode}.
+     *
+     * @param value The integer value to parse.
+     * @return The parsed {@link BeatmapLeaderboardScoringMode}.
+     */
+    public static BeatmapLeaderboardScoringMode parse(int value) {
+        return value == 1 ? PP : SCORE;
+    }
+}


### PR DESCRIPTION
This only works for global beatmap leaderboard in song selection. Players can switch between score and pp in main menu options.

To make this work for local scores, the pp values of them will need to be calculated, which can be expensive. Another option is to calculate the pp value of the score during database migration (and store it inside the table), but this is a bit more involved due to slower migration time, rebalance handling, etc., and as such is more suitable for an upcoming PR if needed.

![image](https://github.com/user-attachments/assets/c16c1cb8-ab08-459e-bdaa-58c6e6a3427e)
