### PR TITLE
Fix regressions from past pull request

### DIFF
--- a/src/com/reco1l/osu/DifficultyCalculation.kt
+++ b/src/com/reco1l/osu/DifficultyCalculation.kt
@@ -42,7 +42,7 @@ object DifficultyCalculationManager {
         isRunning = true
         mainThread {
             badge = LoadingBadgeFragment().apply {
-                text = "Calculating beatmap difficulties... (0%)"
+                text = "Calculating beatmap difficulties..."
                 isIndeterminate = true
                 show()
             }

--- a/src/com/reco1l/osu/data/Scores.kt
+++ b/src/com/reco1l/osu/data/Scores.kt
@@ -201,7 +201,7 @@ fun ScoreInfo(json: JSONObject): ScoreInfo {
 @Dao
 interface IScoreInfoDAO {
 
-    @Query("SELECT * FROM ScoreInfo WHERE beatmapSetDirectory = :beatmapSetDirectory AND beatmapFilename = :beatmapFilename")
+    @Query("SELECT * FROM ScoreInfo WHERE beatmapSetDirectory = :beatmapSetDirectory AND beatmapFilename = :beatmapFilename ORDER BY score DESC")
     fun getBeatmapScores(beatmapSetDirectory: String, beatmapFilename: String): List<ScoreInfo>
 
     @Query("SELECT * FROM ScoreInfo WHERE id = :id")

--- a/src/com/reco1l/osu/graphics/AnimatedSprite.kt
+++ b/src/com/reco1l/osu/graphics/AnimatedSprite.kt
@@ -10,7 +10,7 @@ open class AnimatedSprite(frames: List<TextureRegion>) : ExtendedSprite() {
 
 
     @JvmOverloads
-    constructor(texturePrefix: StringSkinData? = null, textureName: String?, frameCount: Int) : this(List(frameCount) {
+    constructor(texturePrefix: StringSkinData? = null, textureName: String?, frameCount: Int) : this(List(frameCount.coerceAtLeast(1)) {
 
         if (texturePrefix == null) {
             ResourceManager.getInstance().getTexture(textureName + it)

--- a/src/com/reco1l/osu/graphics/Modifiers.kt
+++ b/src/com/reco1l/osu/graphics/Modifiers.kt
@@ -190,7 +190,6 @@ class UniversalModifier @JvmOverloads constructor(private val pool: Pool<Univers
         this.easeFunction = easeFunction
     }
 
-
     @JvmOverloads
     constructor(type: ModifierType, duration: Float, values: FloatArray, listener: IModifierListener<IEntity>? = null, easeFunction: IEaseFunction = DefaultEaseFunction) : this(null) {
         this.type = type
@@ -337,6 +336,7 @@ class UniversalModifier @JvmOverloads constructor(private val pool: Pool<Univers
             usedSec = deltaSec - remainingSec
 
         } else {
+            usedSec = min(duration - elapsedSec, deltaSec)
 
             val percentage = easeFunction.getPercentage(elapsedSec + usedSec, duration)
 
@@ -385,9 +385,6 @@ class UniversalModifier @JvmOverloads constructor(private val pool: Pool<Univers
 
                 else -> Unit
             }
-
-            usedSec = min(duration - elapsedSec, deltaSec)
-
         }
 
         elapsedSec += usedSec

--- a/src/com/reco1l/osu/multiplayer/RoomScene.kt
+++ b/src/com/reco1l/osu/multiplayer/RoomScene.kt
@@ -323,6 +323,10 @@ object RoomScene : Scene(), IRoomEventListener, IPlayerEventListener
             var dx = 0f
             var dy = 0f
 
+            init {
+                adjustSizeWithTexture = false
+            }
+
             override fun onAreaTouched(event: TouchEvent, localX: Float, localY: Float): Boolean
             {
                 if (event.isActionDown)
@@ -373,6 +377,7 @@ object RoomScene : Scene(), IRoomEventListener, IPlayerEventListener
 
             init {
                 textureRegion = getResources().getTextureIfLoaded("selection-mods")
+                adjustSizeWithTexture = false
             }
 
             override fun onAreaTouched(event: TouchEvent, localX: Float, localY: Float): Boolean

--- a/src/ru/nsu/ccfit/zuev/osu/game/FollowTrack.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/FollowTrack.java
@@ -5,15 +5,16 @@ import android.graphics.PointF;
 import com.reco1l.framework.Pool;
 import com.reco1l.osu.graphics.AnimatedSprite;
 import com.reco1l.osu.graphics.ExtendedSprite;
+import com.rian.osu.math.Vector2;
 
 import org.anddev.andengine.entity.scene.Scene;
 import org.anddev.andengine.opengl.texture.region.TextureRegion;
+import org.anddev.andengine.util.MathUtils;
 
 import java.util.ArrayList;
 
 import ru.nsu.ccfit.zuev.osu.ResourceManager;
 import ru.nsu.ccfit.zuev.skins.SkinManager;
-import ru.nsu.ccfit.zuev.osu.Utils;
 
 public class FollowTrack extends GameObject {
 
@@ -42,14 +43,14 @@ public class FollowTrack extends GameObject {
     }
 
     public void init(final GameObjectListener listener, final Scene scene,
-                     final PointF start, final PointF end, final float time,
+                     final Vector2 start, final Vector2 end, final float time,
                      final float approachtime, final float scale) {
         this.listener = listener;
         this.approach = approachtime;
         timeLeft = time;
         this.time = 0;
 
-        final float dist = Utils.distance(start, end);
+        final float dist = MathUtils.distance(start.x, start.y, end.x, end.y);
         final float angle = (float) Math.atan2(end.y - start.y, end.x - start.x);
         TextureRegion region = ResourceManager.getInstance().getTexture(FRAME_COUNT > 1 ? "followpoint-0" : "followpoint");
         if (region == null) {

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameObject.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameObject.java
@@ -17,7 +17,7 @@ public abstract class GameObject {
     protected int id = -1;
     protected Replay.ReplayObjectData replayObjectData = null;
     protected boolean startHit = false;
-    protected PointF pos = new PointF();
+    protected PointF position = new PointF();
 
     public Replay.ReplayObjectData getReplayData() {
         return replayObjectData;
@@ -55,7 +55,9 @@ public abstract class GameObject {
 
     public void tryHit(float dt) {}
 
-    public PointF getPos() {return pos;}
+    public PointF getPosition() {
+        return position;
+    }
 
     public void stopAuxiliarySamples() {}
 }

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -284,12 +284,12 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
         }
 
         // storyboard sprite will draw background and dimRectangle if needed, so skip here
-        if (storyboardSprite == null || !storyboardSprite.isStoryboardAvailable()) {
-            if (bgSprite == null && beatmap.events.backgroundFilename != null) {
-                var tex = Config.isSafeBeatmapBg() ?
-                        ResourceManager.getInstance().getTexture("menu-background")
-                        :
-                        ResourceManager.getInstance().getTextureIfLoaded("::background");
+        if (!Config.isEnableStoryboard() || storyboardSprite == null || !storyboardSprite.isStoryboardAvailable()) {
+            if (bgSprite == null) {
+
+                var tex = Config.isSafeBeatmapBg() || beatmap.events.backgroundFilename == null
+                        ? ResourceManager.getInstance().getTexture("menu-background")
+                        : ResourceManager.getInstance().getTextureIfLoaded("::background");
 
                 if (tex != null)
                     bgSprite = new Sprite(0, 0, tex);

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -1296,9 +1296,7 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
 
                 if (nextObj != null && !obj.isLastInCombo()) {
                     final FollowTrack track = GameObjectPool.getInstance().getTrack();
-                    track.init(this, bgScene, obj.getGameplayStackedPosition().toPointF(),
-                        nextObj.getGameplayStackedPosition().toPointF(),
-                        (float) nextObj.startTime / 1000 - secPassed, objectTimePreempt, scale);
+                    track.init(this, bgScene, obj.getGameplayStackedPosition(), nextObj.getGameplayStackedPosition(), (float) nextObj.startTime / 1000 - secPassed, objectTimePreempt, scale);
                 }
 
                 if (GameHelper.isAuto()) {
@@ -1339,10 +1337,7 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
 
                 if (nextObj != null && !obj.isLastInCombo()) {
                     final FollowTrack track = GameObjectPool.getInstance().getTrack();
-
-                    track.init(this, bgScene, parsedSlider.getGameplayStackedEndPosition().toPointF(),
-                        nextObj.getGameplayStackedPosition().toPointF(),
-                        (float) nextObj.startTime / 1000 - secPassed, objectTimePreempt, scale);
+                    track.init(this, bgScene, parsedSlider.getGameplayStackedEndPosition(), nextObj.getGameplayStackedPosition(), (float) nextObj.startTime / 1000 - secPassed, objectTimePreempt, scale);
                 }
                 if (GameHelper.isAuto()) {
                     slider.setAutoPlay();

--- a/src/ru/nsu/ccfit/zuev/osu/game/HitCircle.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/HitCircle.java
@@ -46,7 +46,10 @@ public class HitCircle extends GameObject {
         // Storing parameters into fields
         this.replayObjectData = null;
         this.beatmapCircle = beatmapCircle;
-        this.pos = beatmapCircle.getGameplayStackedPosition().toPointF();
+
+        var stackedPosition = beatmapCircle.getGameplayStackedPosition();
+        position.set(stackedPosition.x, stackedPosition.y);
+
         this.endsCombo = beatmapCircle.isLastInCombo();
         this.listener = listener;
         this.scene = pScene;
@@ -69,7 +72,7 @@ public class HitCircle extends GameObject {
         circlePiece.setCircleColor(comboColor.r(), comboColor.g(), comboColor.b());
         circlePiece.setScale(scale);
         circlePiece.setAlpha(fadeInProgress);
-        circlePiece.setPosition(pos.x, pos.y);
+        circlePiece.setPosition(this.position.x, this.position.y);
 
         int comboNum = beatmapCircle.getIndexInCurrentCombo() + 1;
         if (OsuSkin.get().isLimitComboTextLength()) {
@@ -81,7 +84,7 @@ public class HitCircle extends GameObject {
         approachCircle.setColor(comboColor.r(), comboColor.g(), comboColor.b());
         approachCircle.setScale(scale * (3 - 2 * fadeInProgress));
         approachCircle.setAlpha(0.9f * fadeInProgress);
-        approachCircle.setPosition(pos.x, pos.y);
+        approachCircle.setPosition(this.position.x, this.position.y);
 
         if (GameHelper.isHidden()) {
             approachCircle.setVisible(Config.isShowFirstApproachCircle() && beatmapCircle.isFirstNote());
@@ -167,7 +170,7 @@ public class HitCircle extends GameObject {
     private boolean isHit() {
         for (int i = 0, count = listener.getCursorsCount(); i < count; i++) {
 
-            var inPosition = Utils.squaredDistance(pos, listener.getMousePos(i)) <= radiusSquared;
+            var inPosition = Utils.squaredDistance(position, listener.getMousePos(i)) <= radiusSquared;
             if (GameHelper.isRelaxMod() && passedTime - timePreempt >= 0 && inPosition) {
                 return true;
             }
@@ -186,7 +189,7 @@ public class HitCircle extends GameObject {
         // 因为这里是阻塞队列, 所以提前点的地方会影响判断
         for (int i = 0, count = listener.getCursorsCount(); i < count; i++) {
 
-            var inPosition = Utils.squaredDistance(pos, listener.getMousePos(i)) <= radiusSquared;
+            var inPosition = Utils.squaredDistance(position, listener.getMousePos(i)) <= radiusSquared;
             if (GameHelper.isRelaxMod() && passedTime - timePreempt >= 0 && inPosition) {
                 return 0;
             }
@@ -219,7 +222,7 @@ public class HitCircle extends GameObject {
                 listener.registerAccuracy(replayObjectData.accuracy / 1000f);
                 passedTime = -1;
                 // Remove circle and register hit in update thread
-                listener.onCircleHit(id, replayObjectData.accuracy / 1000f, pos,endsCombo, replayObjectData.result, comboColor);
+                listener.onCircleHit(id, replayObjectData.accuracy / 1000f, position,endsCombo, replayObjectData.result, comboColor);
                 removeFromScene();
                 return;
             }
@@ -237,7 +240,7 @@ public class HitCircle extends GameObject {
             // Remove circle and register hit in update thread
             float finalSignAcc = signAcc;
             startHit = true;
-            listener.onCircleHit(id, finalSignAcc, pos, endsCombo, (byte) 0, comboColor);
+            listener.onCircleHit(id, finalSignAcc, position, endsCombo, (byte) 0, comboColor);
             removeFromScene();
             return;
         }
@@ -265,7 +268,7 @@ public class HitCircle extends GameObject {
             playSound();
             passedTime = -1;
             // Remove circle and register hit in update thread
-            listener.onCircleHit(id, 0, pos, endsCombo, ResultType.HIT300.getId(), comboColor);
+            listener.onCircleHit(id, 0, position, endsCombo, ResultType.HIT300.getId(), comboColor);
             removeFromScene();
         } else {
             approachCircle.clearEntityModifiers();
@@ -277,7 +280,7 @@ public class HitCircle extends GameObject {
                 final byte forcedScore = (replayObjectData == null) ? 0 : replayObjectData.result;
 
                 removeFromScene();
-                listener.onCircleHit(id, 10, pos, false, forcedScore, comboColor);
+                listener.onCircleHit(id, 10, position, false, forcedScore, comboColor);
             }
         }
     } // update(float dt)
@@ -297,7 +300,7 @@ public class HitCircle extends GameObject {
             passedTime = -1;
             // Remove circle and register hit in update thread
             float finalSignAcc = signAcc;
-            listener.onCircleHit(id, finalSignAcc, pos, endsCombo, (byte) 0, comboColor);
+            listener.onCircleHit(id, finalSignAcc, position, endsCombo, (byte) 0, comboColor);
             removeFromScene();
         }
     }

--- a/src/ru/nsu/ccfit/zuev/osu/game/HitCircle.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/HitCircle.java
@@ -145,6 +145,9 @@ public class HitCircle extends GameObject {
     }
 
     private void removeFromScene() {
+        if (scene == null) {
+            return;
+        }
 
         circlePiece.clearEntityModifiers();
         approachCircle.clearEntityModifiers();

--- a/src/ru/nsu/ccfit/zuev/osu/game/HitCircle.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/HitCircle.java
@@ -145,9 +145,6 @@ public class HitCircle extends GameObject {
     }
 
     private void removeFromScene() {
-        if (scene == null) {
-            return;
-        }
 
         circlePiece.clearEntityModifiers();
         approachCircle.clearEntityModifiers();
@@ -206,6 +203,7 @@ public class HitCircle extends GameObject {
     public void update(final float dt) {
         // PassedTime < 0 means circle logic is over
         if (passedTime < 0) {
+            removeFromScene();
             return;
         }
         // If we have clicked circle

--- a/src/ru/nsu/ccfit/zuev/osu/game/Slider.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/Slider.java
@@ -442,9 +442,6 @@ public class Slider extends GameObject {
     }
 
     private void removeFromScene() {
-        if (scene == null) {
-            return;
-        }
 
         if (GameHelper.isHidden()) {
             sliderBody.detachSelf();

--- a/src/ru/nsu/ccfit/zuev/osu/game/Slider.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/Slider.java
@@ -442,6 +442,9 @@ public class Slider extends GameObject {
     }
 
     private void removeFromScene() {
+        if (scene == null) {
+            return;
+        }
 
         if (GameHelper.isHidden()) {
             sliderBody.detachSelf();

--- a/src/ru/nsu/ccfit/zuev/osu/game/Slider.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/Slider.java
@@ -145,7 +145,10 @@ public class Slider extends GameObject {
         this.listener = listener;
         this.scene = scene;
         this.beatmapSlider = beatmapSlider;
-        this.pos = beatmapSlider.getGameplayStackedPosition().toPointF();
+
+        var stackedPosition = beatmapSlider.getGameplayStackedPosition();
+        position.set(stackedPosition.x, stackedPosition.y);
+
         endsCombo = beatmapSlider.isLastInCombo();
         passedTime = secPassed - (float) beatmapSlider.startTime / 1000;
         slidingSamplesPlaying = false;
@@ -180,7 +183,7 @@ public class Slider extends GameObject {
         headCirclePiece.setScale(scale);
         headCirclePiece.setCircleColor(comboColor.r(), comboColor.g(), comboColor.b());
         headCirclePiece.setAlpha(0);
-        headCirclePiece.setPosition(pos.x, pos.y);
+        headCirclePiece.setPosition(this.position.x, this.position.y);
         int comboNum = beatmapSlider.getIndexInCurrentCombo() + 1;
         if (OsuSkin.get().isLimitComboTextLength()) {
             comboNum %= 10;
@@ -191,7 +194,7 @@ public class Slider extends GameObject {
         approachCircle.setColor(comboColor.r(), comboColor.g(), comboColor.b());
         approachCircle.setScale(scale * 3);
         approachCircle.setAlpha(0);
-        approachCircle.setPosition(pos.x, pos.y);
+        approachCircle.setPosition(this.position.x, this.position.y);
 
         if (GameHelper.isHidden()) {
             approachCircle.setVisible(Config.isShowFirstApproachCircle() && beatmapSlider.isFirstNote());
@@ -206,7 +209,7 @@ public class Slider extends GameObject {
         tailCirclePiece.setAlpha(0);
 
         if (Config.isSnakingInSliders()) {
-            tailCirclePiece.setPosition(pos.x, pos.y);
+            tailCirclePiece.setPosition(this.position.x, this.position.y);
         } else {
             tailCirclePiece.setPosition(curveEndPos.x, curveEndPos.y);
         }
@@ -216,8 +219,8 @@ public class Slider extends GameObject {
         if (spanCount > 2) {
             startArrow.setAlpha(0);
             startArrow.setScale(scale);
-            startArrow.setRotation(MathUtils.radToDeg(Utils.direction(pos.x, pos.y, path.getX(1), path.getY(1))));
-            startArrow.setPosition(pos.x, pos.y);
+            startArrow.setRotation(MathUtils.radToDeg(Utils.direction(this.position.x, this.position.y, path.getX(1), path.getY(1))));
+            startArrow.setPosition(this.position.x, this.position.y);
 
             scene.attachChild(startArrow, 0);
         }
@@ -257,7 +260,7 @@ public class Slider extends GameObject {
             endArrow.setRotation(MathUtils.radToDeg(Utils.direction(curveEndPos.x, curveEndPos.y, path.getX(path.pointCount - 2), path.getY(path.pointCount - 2))));
 
             if (Config.isSnakingInSliders()) {
-                endArrow.setPosition(pos.x, pos.y);
+                endArrow.setPosition(this.position.x, this.position.y);
             } else {
                 endArrow.setPosition(curveEndPos.x, curveEndPos.y);
             }
@@ -374,7 +377,7 @@ public class Slider extends GameObject {
 
     private PointF getPositionAt(final float percentage, final boolean updateBallAngle, final boolean updateEndArrowRotation) {
         if (path.pointCount == 0) {
-            tmpPoint.set(pos);
+            tmpPoint.set(position);
             return tmpPoint;
         }
 
@@ -384,15 +387,15 @@ public class Slider extends GameObject {
         } else if (percentage <= 0) {
             if (path.pointCount >= 2) {
                 if (updateBallAngle) {
-                    ballAngle = MathUtils.radToDeg(Utils.direction(path.getX(1), path.getY(1), pos.x, pos.y));
+                    ballAngle = MathUtils.radToDeg(Utils.direction(path.getX(1), path.getY(1), position.x, position.y));
                 }
 
                 if (updateEndArrowRotation) {
-                    endArrow.setRotation(MathUtils.radToDeg(Utils.direction(pos.x, pos.y, path.getX(1), path.getY(1))));
+                    endArrow.setRotation(MathUtils.radToDeg(Utils.direction(position.x, position.y, path.getX(1), path.getY(1))));
                 }
             }
 
-            tmpPoint.set(pos);
+            tmpPoint.set(position);
             return tmpPoint;
         }
 
@@ -525,7 +528,7 @@ public class Slider extends GameObject {
 
             if (stillHasSpan) {
                 listener.onSliderHit(id, 30, null,
-                        reverse ? pos : curveEndPos,
+                        reverse ? position : curveEndPos,
                         false, bodyColor, GameObjectListener.SLIDER_REPEAT);
             }
         } else {
@@ -533,7 +536,7 @@ public class Slider extends GameObject {
 
             if (stillHasSpan) {
                 listener.onSliderHit(id, -1, null,
-                        reverse ? pos : curveEndPos,
+                        reverse ? position : curveEndPos,
                         false, bodyColor, GameObjectListener.SLIDER_REPEAT);
             }
         }
@@ -575,7 +578,7 @@ public class Slider extends GameObject {
             }
 
             ((GameScene) listener).onSliderReverse(
-                    !reverse ? pos : curveEndPos,
+                    !reverse ? position : curveEndPos,
                     reverse ? endArrow.getRotation() : startArrow.getRotation(),
                     bodyColor);
 
@@ -621,9 +624,9 @@ public class Slider extends GameObject {
         // If slider was in reverse mode, we should swap start and end points
         if (reverse) {
             Slider.this.listener.onSliderHit(id, score,
-                    curveEndPos, pos, endsCombo, bodyColor, GameObjectListener.SLIDER_END);
+                    curveEndPos, position, endsCombo, bodyColor, GameObjectListener.SLIDER_END);
         } else {
-            Slider.this.listener.onSliderHit(id, score, pos,
+            Slider.this.listener.onSliderHit(id, score, position,
                     curveEndPos, endsCombo, bodyColor, GameObjectListener.SLIDER_END);
         }
         if (!startHit) {
@@ -664,7 +667,7 @@ public class Slider extends GameObject {
         float radius = Utils.sqr((float) beatmapSlider.getGameplayRadius());
         for (int i = 0, count = listener.getCursorsCount(); i < count; i++) {
 
-            var inPosition = Utils.squaredDistance(pos, listener.getMousePos(i)) <= radius;
+            var inPosition = Utils.squaredDistance(position, listener.getMousePos(i)) <= radius;
             if (GameHelper.isRelaxMod() && passedTime >= 0 && inPosition) {
                 return true;
             }
@@ -694,14 +697,14 @@ public class Slider extends GameObject {
             if (passedTime > GameHelper.getDifficultyHelper().hitWindowFor50(GameHelper.getOverallDifficulty())) {
                 startHit = true;
                 currentNestedObjectIndex++;
-                listener.onSliderHit(id, -1, null, pos, false, bodyColor, GameObjectListener.SLIDER_START);
+                listener.onSliderHit(id, -1, null, position, false, bodyColor, GameObjectListener.SLIDER_START);
                 firstHitAccuracy = (int) (passedTime * 1000);
             } else if (autoPlay && passedTime >= 0) {
                 startHit = true;
                 playCurrentNestedObjectHitSound();
                 currentNestedObjectIndex++;
                 ticksGot++;
-                listener.onSliderHit(id, 30, null, pos, false, bodyColor, GameObjectListener.SLIDER_START);
+                listener.onSliderHit(id, 30, null, position, false, bodyColor, GameObjectListener.SLIDER_START);
             } else if (replayObjectData != null &&
                     Math.abs(replayObjectData.accuracy / 1000f) <= GameHelper.getDifficultyHelper().hitWindowFor50(GameHelper.getOverallDifficulty()) &&
                     passedTime + dt / 2 > replayObjectData.accuracy / 1000f) {
@@ -709,7 +712,7 @@ public class Slider extends GameObject {
                 playCurrentNestedObjectHitSound();
                 currentNestedObjectIndex++;
                 ticksGot++;
-                listener.onSliderHit(id, 30, null, pos, false, bodyColor, GameObjectListener.SLIDER_START);
+                listener.onSliderHit(id, 30, null, position, false, bodyColor, GameObjectListener.SLIDER_START);
             } else if (isHit() && canBeHit()) {
                 listener.registerAccuracy(passedTime);
                 startHit = true;
@@ -718,10 +721,10 @@ public class Slider extends GameObject {
 
                 if (-passedTime < GameHelper.getDifficultyHelper().hitWindowFor50(GameHelper.getOverallDifficulty())) {
                     playCurrentNestedObjectHitSound();
-                    listener.onSliderHit(id, 30, null, pos,
+                    listener.onSliderHit(id, 30, null, position,
                             false, bodyColor, GameObjectListener.SLIDER_START);
                 } else {
-                    listener.onSliderHit(id, -1, null, pos,
+                    listener.onSliderHit(id, -1, null, position,
                             false, bodyColor, GameObjectListener.SLIDER_START);
                 }
 
@@ -1032,10 +1035,10 @@ public class Slider extends GameObject {
 
             if (-passedTime < GameHelper.getDifficultyHelper().hitWindowFor50(GameHelper.getOverallDifficulty())) {
                 playCurrentNestedObjectHitSound();
-                listener.onSliderHit(id, 30, null, pos,
+                listener.onSliderHit(id, 30, null, position,
                         false, bodyColor, GameObjectListener.SLIDER_START);
             } else {
-                listener.onSliderHit(id, -1, null, pos,
+                listener.onSliderHit(id, -1, null, position,
                         false, bodyColor, GameObjectListener.SLIDER_START);
             }
 

--- a/src/ru/nsu/ccfit/zuev/osu/game/Spinner.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/Spinner.java
@@ -54,8 +54,8 @@ public class Spinner extends GameObject {
 
     public Spinner() {
         ResourceManager.getInstance().checkSpinnerTextures();
-        this.pos = new PointF((float) Constants.MAP_WIDTH / 2, (float) Constants.MAP_HEIGHT / 2);
-        center = Utils.trackToRealCoords(pos);
+        this.position = new PointF((float) Constants.MAP_WIDTH / 2, (float) Constants.MAP_HEIGHT / 2);
+        center = Utils.trackToRealCoords(position);
 
         background = new ExtendedSprite();
         background.setOrigin(Origin.Center);

--- a/src/ru/nsu/ccfit/zuev/osu/game/cursor/main/AutoCursor.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/cursor/main/AutoCursor.java
@@ -68,8 +68,8 @@ public class AutoCursor extends CursorEntity implements ISliderListener {
             return;
         }
 
-        float movePositionX = object.getPos().x;
-        float movePositionY = object.getPos().y;
+        float movePositionX = object.getPosition().x;
+        float movePositionY = object.getPosition().y;
         float deltaT = object.getHitTime() - secPassed;
 
         if (object instanceof Spinner) {

--- a/src/ru/nsu/ccfit/zuev/osu/menu/LoadingScreen.java
+++ b/src/ru/nsu/ccfit/zuev/osu/menu/LoadingScreen.java
@@ -33,7 +33,6 @@ public class LoadingScreen implements IUpdateHandler {
         }
 
         scene = new LoadingScene();
-        scene.registerEntityModifier(new FadeOutModifier(0.4f));
 
         final TextureRegion tex = ResourceManager.getInstance().getTexture("menu-background");
         if (tex != null) {

--- a/src/ru/nsu/ccfit/zuev/osu/menu/SongMenu.java
+++ b/src/ru/nsu/ccfit/zuev/osu/menu/SongMenu.java
@@ -341,6 +341,8 @@ public class SongMenu implements IUpdateHandler, MenuItemListener,
                 if (layoutBackButton != null) {
                     scaleWhenHold = layoutBackButton.property.optBoolean("scaleWhenHold", true);
                 }
+
+                setAdjustSizeWithTexture(false);
             }
 
             @Override
@@ -388,6 +390,7 @@ public class SongMenu implements IUpdateHandler, MenuItemListener,
 
                 {
                     setTextureRegion(ResourceManager.getInstance().getTextureIfLoaded("selection-mods"));
+                    setAdjustSizeWithTexture(false);
                 }
 
                 @Override
@@ -425,6 +428,7 @@ public class SongMenu implements IUpdateHandler, MenuItemListener,
 
             {
                 setTextureRegion(ResourceManager.getInstance().getTextureIfLoaded("selection-options"));
+                setAdjustSizeWithTexture(false);
             }
 
             @Override
@@ -465,6 +469,7 @@ public class SongMenu implements IUpdateHandler, MenuItemListener,
 
             {
                 setTextureRegion(ResourceManager.getInstance().getTextureIfLoaded("selection-random"));
+                setAdjustSizeWithTexture(false);
             }
 
             @Override


### PR DESCRIPTION
### What's fixed:
* Animated sprites fails to retrieve textures when the frame count is 1.
[Fixed](https://github.com/osudroid/osu-droid/commit/ee8c4a476bb8223f16901de65507e59c0d167319)
* Local leaderboard is sorted by insert date rather than score in the song menu.
[Fixed](https://github.com/osudroid/osu-droid/pull/410/commits/498900e2dffb79e50a57a6329352d8a661c22f27)
* Hit circles can potentially get stuck on screen if they're never hit in some maps (e.g. Der Wald by Rocker [Aspire difficulty]).
[Fixed](https://github.com/osudroid/osu-droid/pull/410/commits/70441a4e12f9092c96253d04ef4f47eb44802016)
* Song's menu buttons do not get affected by skin layout configurations.
[Fixed](https://github.com/osudroid/osu-droid/pull/410/commits/56c30974b95e414ccc18006143efe2c73e3b12a9)
* When the beatmap background is missing and safe background is enabled it will show a black background instead of the default background.
[Fixed](https://github.com/osudroid/osu-droid/pull/410/commits/d4e09375508c49b5bfeb7489d1841a10917f978c)
* Animations can potentially never reach the final value.
[Fixed](https://github.com/osudroid/osu-droid/pull/410/commits/b5a2e4ddec8a9b96dcef6bb8574822572ba7e848)

### Additionally
* Difficulty calculation will resume with the percentage that it had before being paused.
* Removed incorrect loading screen fade out.