### PR TITLE
Add support for coroutine cancellation in beatmap parsing and difficulty calculation

### DIFF
--- a/src/com/rian/osu/beatmap/BeatmapConverter.kt
+++ b/src/com/rian/osu/beatmap/BeatmapConverter.kt
@@ -1,22 +1,28 @@
 package com.rian.osu.beatmap
 
+import com.rian.osu.GameMode
 import com.rian.osu.beatmap.hitobject.HitCircle
 import com.rian.osu.beatmap.hitobject.HitObject
 import com.rian.osu.beatmap.hitobject.Slider
 import com.rian.osu.beatmap.hitobject.Spinner
 import com.rian.osu.beatmap.sections.BeatmapHitObjects
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ensureActive
 
 /**
- * Converts a [Beatmap] for another mode.
- *
- * To be used in dpp integration.
+ * Converts a [Beatmap] for another [GameMode].
  */
-class BeatmapConverter(
+class BeatmapConverter @JvmOverloads constructor(
     /**
      * The [Beatmap] to convert.
      */
     @JvmField
-    val beatmap: Beatmap
+    val beatmap: Beatmap,
+
+    /**
+     * The [CoroutineScope] to use for coroutines.
+     */
+    private val scope: CoroutineScope? = null
 ) {
     /**
      * Converts [Beatmap].
@@ -26,11 +32,16 @@ class BeatmapConverter(
     fun convert() = beatmap.clone().also {
         // Shallow clone isn't enough to ensure we don't mutate some beatmap properties unexpectedly.
         it.difficulty = beatmap.difficulty.clone()
+
+        scope?.ensureActive()
+
         it.hitObjects = convertHitObjects().also { b -> b.objects.sortBy { o -> o.startTime } }
     }
 
     private fun convertHitObjects() = BeatmapHitObjects().also {
         beatmap.hitObjects.objects.forEach { obj ->
+            scope?.ensureActive()
+
             it.add(convertHitObject(obj))
         }
     }

--- a/src/com/rian/osu/beatmap/parser/sections/BeatmapColorParser.kt
+++ b/src/com/rian/osu/beatmap/parser/sections/BeatmapColorParser.kt
@@ -2,14 +2,19 @@ package com.rian.osu.beatmap.parser.sections
 
 import com.rian.osu.beatmap.Beatmap
 import com.rian.osu.beatmap.ComboColor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ensureActive
 import ru.nsu.ccfit.zuev.osu.RGBColor
 
 /**
  * A parser for parsing a beatmap's colors section.
  */
 object BeatmapColorParser : BeatmapKeyValueSectionParser() {
-    override fun parse(beatmap: Beatmap, line: String) = splitProperty(line)?.let { p ->
-        val s = p.second.split(COMMA_PROPERTY_REGEX).dropLastWhile { it.isEmpty() }.toTypedArray()
+    override fun parse(beatmap: Beatmap, line: String, scope: CoroutineScope?) = splitProperty(line, scope)?.let { p ->
+        val s = p.second.split(COMMA_PROPERTY_REGEX).dropLastWhile {
+            scope?.ensureActive()
+            it.isEmpty()
+        }.toTypedArray()
 
         if (s.size != 3 && s.size != 4) {
             throw UnsupportedOperationException("Color specified in incorrect format (should be R,G,B or R,G,B,A)")
@@ -26,6 +31,8 @@ object BeatmapColorParser : BeatmapKeyValueSectionParser() {
 
             beatmap.colors.comboColors.apply {
                 add(ComboColor(index, color))
+
+                scope?.ensureActive()
                 
                 sortBy { it.index }
             }

--- a/src/com/rian/osu/beatmap/parser/sections/BeatmapControlPointsParser.kt
+++ b/src/com/rian/osu/beatmap/parser/sections/BeatmapControlPointsParser.kt
@@ -6,14 +6,19 @@ import com.rian.osu.beatmap.timings.DifficultyControlPoint
 import com.rian.osu.beatmap.timings.EffectControlPoint
 import com.rian.osu.beatmap.timings.SampleControlPoint
 import com.rian.osu.beatmap.timings.TimingControlPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ensureActive
 
 /**
  * A parser for parsing a beatmap's timing points section.
  */
 object BeatmapControlPointsParser : BeatmapSectionParser() {
-    override fun parse(beatmap: Beatmap, line: String) = line
+    override fun parse(beatmap: Beatmap, line: String, scope: CoroutineScope?) = line
         .split(COMMA_PROPERTY_REGEX)
-        .dropLastWhile { it.isEmpty() }
+        .dropLastWhile {
+            scope?.ensureActive()
+            it.isEmpty()
+        }
         .let {
             if (it.size < 2) {
                 throw UnsupportedOperationException("Malformed timing point")
@@ -40,6 +45,8 @@ object BeatmapControlPointsParser : BeatmapSectionParser() {
             if (sampleSet == SampleBank.None) {
                 sampleSet = SampleBank.Normal
             }
+
+            scope?.ensureActive()
 
             beatmap.controlPoints.apply {
                 if (timingChange) {

--- a/src/com/rian/osu/beatmap/parser/sections/BeatmapDifficultyParser.kt
+++ b/src/com/rian/osu/beatmap/parser/sections/BeatmapDifficultyParser.kt
@@ -1,12 +1,13 @@
 package com.rian.osu.beatmap.parser.sections
 
 import com.rian.osu.beatmap.Beatmap
+import kotlinx.coroutines.CoroutineScope
 
 /**
  * A parser for parsing a beatmap's difficulty section.
  */
 object BeatmapDifficultyParser : BeatmapKeyValueSectionParser() {
-    override fun parse(beatmap: Beatmap, line: String) = splitProperty(line)?.let {
+    override fun parse(beatmap: Beatmap, line: String, scope: CoroutineScope?) = splitProperty(line, scope)?.let {
         when (it.first) {
             "CircleSize" -> {
                 val value = parseFloat(it.second)

--- a/src/com/rian/osu/beatmap/parser/sections/BeatmapEventsParser.kt
+++ b/src/com/rian/osu/beatmap/parser/sections/BeatmapEventsParser.kt
@@ -4,6 +4,8 @@ import com.rian.osu.beatmap.Beatmap
 import com.rian.osu.beatmap.timings.BreakPeriod
 import ru.nsu.ccfit.zuev.osu.RGBColor
 import kotlin.math.max
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ensureActive
 
 /**
  * A parser for parsing a beatmap's events section.
@@ -11,9 +13,12 @@ import kotlin.math.max
 object BeatmapEventsParser : BeatmapSectionParser() {
     private val splitRegex = "\\s*,\\s*".toRegex()
 
-    override fun parse(beatmap: Beatmap, line: String) = line
+    override fun parse(beatmap: Beatmap, line: String, scope: CoroutineScope?) = line
         .split(splitRegex)
-        .dropLastWhile { it.isEmpty() }
+        .dropLastWhile {
+            scope?.ensureActive()
+            it.isEmpty()
+        }
         .let {
             if (it.size >= 3) {
                 if (line.startsWith("0,0")) {

--- a/src/com/rian/osu/beatmap/parser/sections/BeatmapGeneralParser.kt
+++ b/src/com/rian/osu/beatmap/parser/sections/BeatmapGeneralParser.kt
@@ -3,12 +3,13 @@ package com.rian.osu.beatmap.parser.sections
 import com.rian.osu.beatmap.Beatmap
 import com.rian.osu.beatmap.constants.BeatmapCountdown
 import com.rian.osu.beatmap.constants.SampleBank
+import kotlinx.coroutines.CoroutineScope
 
 /**
  * A parser for parsing a beatmap's general section.
  */
 object BeatmapGeneralParser : BeatmapKeyValueSectionParser() {
-    override fun parse(beatmap: Beatmap, line: String) = splitProperty(line)?.let {
+    override fun parse(beatmap: Beatmap, line: String, scope: CoroutineScope?) = splitProperty(line, scope)?.let {
         when (it.first) {
             "AudioFilename" -> beatmap.general.audioFilename = it.second
             "AudioLeadIn" -> beatmap.general.audioLeadIn = parseInt(it.second)

--- a/src/com/rian/osu/beatmap/parser/sections/BeatmapKeyValueSectionParser.kt
+++ b/src/com/rian/osu/beatmap/parser/sections/BeatmapKeyValueSectionParser.kt
@@ -2,6 +2,8 @@ package com.rian.osu.beatmap.parser.sections
 
 import android.text.TextUtils
 import java.util.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ensureActive
 
 /**
  * A parser for parsing beatmap sections that store properties in a key-value pair.
@@ -12,13 +14,16 @@ abstract class BeatmapKeyValueSectionParser : BeatmapSectionParser() {
      *
      * For example, `ApproachRate:9` will be split into `["ApproachRate", "9"]`.
      *
-     * Will return `null` in invalid lines.
-     *
      * @param line The line.
+     * @param scope The [CoroutineScope] to use for coroutines.
+     * @return A [Pair] containing the properties, or `null` if the line is invalid.
      */
-    protected fun splitProperty(line: String): Pair<String, String>? =
+    protected fun splitProperty(line: String, scope: CoroutineScope? = null): Pair<String, String>? =
          line.split(COLON_PROPERTY_REGEX)
-             .dropLastWhile { it.isEmpty() }
+             .dropLastWhile {
+                 scope?.ensureActive()
+                 it.isEmpty()
+             }
              .toTypedArray()
              .let { s ->
                  if (s.isEmpty()) {

--- a/src/com/rian/osu/beatmap/parser/sections/BeatmapMetadataParser.kt
+++ b/src/com/rian/osu/beatmap/parser/sections/BeatmapMetadataParser.kt
@@ -1,12 +1,13 @@
 package com.rian.osu.beatmap.parser.sections
 
 import com.rian.osu.beatmap.Beatmap
+import kotlinx.coroutines.CoroutineScope
 
 /**
  * A parser for parsing a beatmap's metadata section.
  */
 object BeatmapMetadataParser : BeatmapKeyValueSectionParser() {
-    override fun parse(beatmap: Beatmap, line: String) = splitProperty(line)?.let {
+    override fun parse(beatmap: Beatmap, line: String, scope: CoroutineScope?) = splitProperty(line, scope)?.let {
         when (it.first) {
             "Title" -> beatmap.metadata.title = it.second
             "TitleUnicode" -> beatmap.metadata.titleUnicode = it.second

--- a/src/com/rian/osu/beatmap/parser/sections/BeatmapSectionParser.kt
+++ b/src/com/rian/osu/beatmap/parser/sections/BeatmapSectionParser.kt
@@ -1,6 +1,7 @@
 package com.rian.osu.beatmap.parser.sections
 
 import com.rian.osu.beatmap.Beatmap
+import kotlinx.coroutines.CoroutineScope
 
 /**
  * A parser for parsing a specific beatmap section.
@@ -11,10 +12,11 @@ abstract class BeatmapSectionParser {
      *
      * @param beatmap The beatmap to fill.
      * @param line The line to parse.
+     * @param scope The [CoroutineScope] to use for coroutines.
      * @throws UnsupportedOperationException When the performed operation for the line is not supported.
      */
     @Throws(UnsupportedOperationException::class)
-    abstract fun parse(beatmap: Beatmap, line: String)
+    abstract fun parse(beatmap: Beatmap, line: String, scope: CoroutineScope? = null)
 
     /**
      * Attempts to parse a string into an integer.

--- a/src/com/rian/osu/difficulty/BeatmapDifficultyCalculator.kt
+++ b/src/com/rian/osu/difficulty/BeatmapDifficultyCalculator.kt
@@ -13,6 +13,7 @@ import ru.nsu.ccfit.zuev.osu.scoring.Replay.MoveArray
 import ru.nsu.ccfit.zuev.osu.scoring.Replay.ReplayObjectData
 import ru.nsu.ccfit.zuev.osu.scoring.StatisticV2
 import kotlin.math.min
+import kotlinx.coroutines.CoroutineScope
 
 /**
  * A helper class for operations relating to difficulty and performance calculation.
@@ -89,24 +90,27 @@ object BeatmapDifficultyCalculator {
      *
      * @param beatmap The [Beatmap] to calculate.
      * @param stat The [StatisticV2] to calculate.
+     * @param scope The [CoroutineScope] to use for coroutines.
      * @return A structure describing the osu!droid difficulty of the [Beatmap] relating to the [StatisticV2].
      */
     @JvmStatic
-    fun calculateDroidDifficulty(beatmap: Beatmap, stat: StatisticV2) =
-        calculateDroidDifficulty(beatmap, constructDifficultyParameters(stat))
+    @JvmOverloads
+    fun calculateDroidDifficulty(beatmap: Beatmap, stat: StatisticV2, scope: CoroutineScope? = null) =
+        calculateDroidDifficulty(beatmap, constructDifficultyParameters(stat), scope)
 
     /**
      * Calculates the difficulty of a [Beatmap].
      *
      * @param beatmap The [Beatmap] to calculate.
      * @param parameters The parameters of the calculation. Can be `null`.
+     * @param scope The [CoroutineScope] to use for coroutines.
      * @return A structure describing the osu!droid difficulty of the [Beatmap] relating to the calculation parameters.
      */
     @JvmStatic
     @JvmOverloads
-    fun calculateDroidDifficulty(beatmap: Beatmap, parameters: DifficultyCalculationParameters? = null) =
+    fun calculateDroidDifficulty(beatmap: Beatmap, parameters: DifficultyCalculationParameters? = null, scope: CoroutineScope? = null) =
         difficultyCacheManager[beatmap.md5]?.getDroidDifficultyCache(parameters) ?:
-        droidDifficultyCalculator.calculate(beatmap, parameters).also { addCache(beatmap, parameters, it) }
+        droidDifficultyCalculator.calculate(beatmap, parameters, scope).also { addCache(beatmap, parameters, it) }
 
     /**
      * Calculates the difficulty of a [Beatmap], returning a set of [TimedDifficultyAttributes]
@@ -114,25 +118,28 @@ object BeatmapDifficultyCalculator {
      *
      * @param beatmap The [Beatmap] to calculate.
      * @param parameters The parameters of the calculation. Can be `null`.
+     * @param scope The [CoroutineScope] to use for coroutines.
      * @return A set of [TimedDifficultyAttributes] describing the difficulty of
      * the [Beatmap] at any relevant time relating to the calculation parameters.
      */
     @JvmStatic
     @JvmOverloads
-    fun calculateDroidTimedDifficulty(beatmap: Beatmap, parameters: DifficultyCalculationParameters? = null) =
+    fun calculateDroidTimedDifficulty(beatmap: Beatmap, parameters: DifficultyCalculationParameters? = null, scope: CoroutineScope? = null) =
         difficultyCacheManager[beatmap.md5]?.getDroidTimedDifficultyCache(parameters) ?:
-        droidDifficultyCalculator.calculateTimed(beatmap, parameters).also { addCache(beatmap, parameters, it) }
+        droidDifficultyCalculator.calculateTimed(beatmap, parameters, scope).also { addCache(beatmap, parameters, it) }
 
     /**
      * Calculates the osu!standard difficulty of a [Beatmap].
      *
      * @param beatmap The [Beatmap] to calculate.
      * @param stat The [StatisticV2] to calculate for.
+     * @param scope The [CoroutineScope] to use for coroutines.
      * @return A structure describing the osu!standard difficulty of the [Beatmap] relating to the [StatisticV2].
      */
     @JvmStatic
-    fun calculateStandardDifficulty(beatmap: Beatmap, stat: StatisticV2) =
-        calculateStandardDifficulty(beatmap, constructDifficultyParameters(stat))
+    @JvmOverloads
+    fun calculateStandardDifficulty(beatmap: Beatmap, stat: StatisticV2, scope: CoroutineScope? = null) =
+        calculateStandardDifficulty(beatmap, constructDifficultyParameters(stat), scope)
 
     /**
      * Calculates the difficulty of a [Beatmap].
@@ -143,9 +150,9 @@ object BeatmapDifficultyCalculator {
      */
     @JvmStatic
     @JvmOverloads
-    fun calculateStandardDifficulty(beatmap: Beatmap, parameters: DifficultyCalculationParameters? = null) =
+    fun calculateStandardDifficulty(beatmap: Beatmap, parameters: DifficultyCalculationParameters? = null, scope: CoroutineScope? = null) =
         difficultyCacheManager[beatmap.md5]?.getStandardDifficultyCache(parameters) ?:
-        standardDifficultyCalculator.calculate(beatmap, parameters).also { addCache(beatmap, parameters, it) }
+        standardDifficultyCalculator.calculate(beatmap, parameters, scope).also { addCache(beatmap, parameters, it) }
 
     /**
      * Calculates the difficulty of a [Beatmap], returning a set of [TimedDifficultyAttributes]
@@ -153,14 +160,15 @@ object BeatmapDifficultyCalculator {
      *
      * @param beatmap The [Beatmap] to calculate.
      * @param parameters The parameters of the calculation. Can be `null`.
+     * @param scope The [CoroutineScope] to use for coroutines.
      * @return A set of [TimedDifficultyAttributes] describing the difficulty of
      * the [Beatmap] at any relevant time relating to the calculation parameters.
      */
     @JvmStatic
     @JvmOverloads
-    fun calculateStandardTimedDifficulty(beatmap: Beatmap, parameters: DifficultyCalculationParameters? = null) =
+    fun calculateStandardTimedDifficulty(beatmap: Beatmap, parameters: DifficultyCalculationParameters? = null, scope: CoroutineScope? = null) =
         difficultyCacheManager[beatmap.md5]?.getStandardTimedDifficultyCache(parameters) ?:
-        standardDifficultyCalculator.calculateTimed(beatmap, parameters).also { addCache(beatmap, parameters, it) }
+        standardDifficultyCalculator.calculateTimed(beatmap, parameters, scope).also { addCache(beatmap, parameters, it) }
 
     /**
      * Calculates the performance of a [DroidDifficultyAttributes].

--- a/src/com/rian/osu/difficulty/calculator/DifficultyCalculator.kt
+++ b/src/com/rian/osu/difficulty/calculator/DifficultyCalculator.kt
@@ -11,6 +11,8 @@ import com.rian.osu.difficulty.attributes.TimedDifficultyAttributes
 import com.rian.osu.difficulty.skills.Skill
 import com.rian.osu.mods.*
 import kotlin.math.sqrt
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ensureActive
 
 /**
  * A difficulty calculator for calculating star rating.
@@ -53,20 +55,24 @@ abstract class DifficultyCalculator<TObject : DifficultyHitObject, TAttributes :
      *
      * @param beatmap The [Beatmap] whose difficulty is to be calculated.
      * @param parameters The calculation parameters that should be applied to the [Beatmap].
+     * @param scope The [CoroutineScope] to use for coroutines.
      * @return A structure describing the difficulty of the [Beatmap].
      */
     @JvmOverloads
     fun calculate(
         beatmap: Beatmap,
-        parameters: DifficultyCalculationParameters? = null
+        parameters: DifficultyCalculationParameters? = null,
+        scope: CoroutineScope? = null
     ): TAttributes {
         // Always operate on a clone of the original beatmap when needed, to not modify it game-wide
-        val beatmapToCalculate = beatmap.createPlayableBeatmap(mode, parameters?.mods, parameters?.customSpeedMultiplier ?: 1f)
+        val beatmapToCalculate = beatmap.createPlayableBeatmap(mode, parameters?.mods, parameters?.customSpeedMultiplier ?: 1f, scope)
         val skills = createSkills(beatmapToCalculate, parameters)
+
         val objects = createDifficultyHitObjects(beatmapToCalculate, parameters)
 
         for (obj in objects) {
             for (skill in skills) {
+                scope?.ensureActive()
                 skill.process(obj)
             }
         }
@@ -80,15 +86,17 @@ abstract class DifficultyCalculator<TObject : DifficultyHitObject, TAttributes :
      *
      * @param beatmap The [Beatmap] whose difficulty is to be calculated.
      * @param parameters The calculation parameters that should be applied to the [Beatmap].
+     * @param scope The [CoroutineScope] to use for coroutines.
      * @return The set of [TimedDifficultyAttributes].
      */
     @JvmOverloads
     fun calculateTimed(
         beatmap: Beatmap,
-        parameters: DifficultyCalculationParameters? = null
+        parameters: DifficultyCalculationParameters? = null,
+        scope: CoroutineScope? = null
     ): List<TimedDifficultyAttributes<TAttributes>> {
         // Always operate on a clone of the original beatmap when needed, to not modify it game-wide
-        val beatmapToCalculate = beatmap.createPlayableBeatmap(mode, parameters?.mods, parameters?.customSpeedMultiplier ?: 1f)
+        val beatmapToCalculate = beatmap.createPlayableBeatmap(mode, parameters?.mods, parameters?.customSpeedMultiplier ?: 1f, scope)
         val skills = createSkills(beatmapToCalculate, parameters)
         val attributes = mutableListOf<TimedDifficultyAttributes<TAttributes>>()
 
@@ -108,6 +116,7 @@ abstract class DifficultyCalculator<TObject : DifficultyHitObject, TAttributes :
 
             while (currentIndex < difficultyObjects.size && difficultyObjects[currentIndex].obj.endTime <= obj.endTime) {
                 for (skill in skills) {
+                    scope?.ensureActive()
                     skill.process(difficultyObjects[currentIndex])
                 }
 
@@ -139,9 +148,10 @@ abstract class DifficultyCalculator<TObject : DifficultyHitObject, TAttributes :
      *
      * @param beatmap The [Beatmap] providing the hit objects to generate from.
      * @param parameters The difficulty calculation parameter being used.
+     * @param scope The [CoroutineScope] to use for coroutines.
      * @return The generated [DifficultyHitObject]s.
      */
-    protected abstract fun createDifficultyHitObjects(beatmap: Beatmap, parameters: DifficultyCalculationParameters?): List<TObject>
+    protected abstract fun createDifficultyHitObjects(beatmap: Beatmap, parameters: DifficultyCalculationParameters?, scope: CoroutineScope? = null): List<TObject>
 
     /**
      * Calculates the rating of a [Skill] based on its difficulty.

--- a/src/com/rian/osu/difficulty/calculator/DifficultyCalculator.kt
+++ b/src/com/rian/osu/difficulty/calculator/DifficultyCalculator.kt
@@ -68,7 +68,7 @@ abstract class DifficultyCalculator<TObject : DifficultyHitObject, TAttributes :
         val beatmapToCalculate = beatmap.createPlayableBeatmap(mode, parameters?.mods, parameters?.customSpeedMultiplier ?: 1f, scope)
         val skills = createSkills(beatmapToCalculate, parameters)
 
-        val objects = createDifficultyHitObjects(beatmapToCalculate, parameters)
+        val objects = createDifficultyHitObjects(beatmapToCalculate, parameters, scope)
 
         for (obj in objects) {
             for (skill in skills) {
@@ -108,7 +108,7 @@ abstract class DifficultyCalculator<TObject : DifficultyHitObject, TAttributes :
             difficulty.apply(beatmapToCalculate.difficulty)
         }
 
-        val difficultyObjects = createDifficultyHitObjects(beatmapToCalculate, parameters)
+        val difficultyObjects = createDifficultyHitObjects(beatmapToCalculate, parameters, scope)
         var currentIndex = 0
 
         for (obj in beatmapToCalculate.hitObjects.objects) {

--- a/src/com/rian/osu/difficulty/calculator/DroidDifficultyCalculator.kt
+++ b/src/com/rian/osu/difficulty/calculator/DroidDifficultyCalculator.kt
@@ -13,6 +13,8 @@ import kotlin.math.cbrt
 import kotlin.math.ceil
 import kotlin.math.max
 import kotlin.math.pow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ensureActive
 
 /**
  * A difficulty calculator for calculating osu!droid star rating.
@@ -231,7 +233,8 @@ class DroidDifficultyCalculator : DifficultyCalculator<DroidDifficultyHitObject,
 
     override fun createDifficultyHitObjects(
         beatmap: Beatmap,
-        parameters: DifficultyCalculationParameters?
+        parameters: DifficultyCalculationParameters?,
+        scope: CoroutineScope?
     ) = mutableListOf<DroidDifficultyHitObject>().apply {
         val clockRate = parameters?.totalSpeedMultiplier?.toDouble() ?: 1.0
         val greatWindow = (
@@ -241,6 +244,8 @@ class DroidDifficultyCalculator : DifficultyCalculator<DroidDifficultyHitObject,
 
         beatmap.hitObjects.objects.let {
             for (i in 0 until it.size) {
+                scope?.ensureActive()
+
                 add(
                     DroidDifficultyHitObject(
                         it[i],

--- a/src/com/rian/osu/difficulty/calculator/StandardDifficultyCalculator.kt
+++ b/src/com/rian/osu/difficulty/calculator/StandardDifficultyCalculator.kt
@@ -16,6 +16,8 @@ import com.rian.osu.mods.ModRelax
 import kotlin.math.cbrt
 import kotlin.math.max
 import kotlin.math.pow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ensureActive
 
 /**
  * A difficulty calculator for calculating osu!standard star rating.
@@ -97,13 +99,16 @@ class StandardDifficultyCalculator : DifficultyCalculator<StandardDifficultyHitO
 
     override fun createDifficultyHitObjects(
         beatmap: Beatmap,
-        parameters: DifficultyCalculationParameters?
+        parameters: DifficultyCalculationParameters?,
+        scope: CoroutineScope?
     ) = mutableListOf<StandardDifficultyHitObject>().apply {
         val clockRate = parameters?.totalSpeedMultiplier?.toDouble() ?: 1.0
         val greatWindow = StandardHitWindow(beatmap.difficulty.od).greatWindow.toDouble() / clockRate
 
         beatmap.hitObjects.objects.let {
             for (i in 1 until it.size) {
+                scope?.ensureActive()
+
                 add(
                     StandardDifficultyHitObject(
                         it[i],


### PR DESCRIPTION
A step towards solving #408, given that functions from `Execution` do not provide a `CoroutineScope` to the running function.

This PR adds support for coroutine job cancellation to beatmap parsing and difficulty calculation operations.