### PR TITLE
Use coroutine in background difficulty calculation

### DIFF
--- a/src/com/reco1l/osu/DifficultyCalculation.kt
+++ b/src/com/reco1l/osu/DifficultyCalculation.kt
@@ -1,5 +1,3 @@
-@file:OptIn(DelicateCoroutinesApi::class)
-
 package com.reco1l.osu
 
 import android.util.Log
@@ -49,7 +47,7 @@ object DifficultyCalculationManager {
             }
         }
 
-        job = GlobalScope.launch {
+        job = async {
             val threadCount = Runtime.getRuntime().availableProcessors()
             val threadPool = Executors.newFixedThreadPool(threadCount)
 

--- a/src/com/reco1l/osu/DifficultyCalculation.kt
+++ b/src/com/reco1l/osu/DifficultyCalculation.kt
@@ -1,3 +1,5 @@
+@file:OptIn(DelicateCoroutinesApi::class)
+
 package com.reco1l.osu
 
 import android.util.Log
@@ -16,19 +18,19 @@ import ru.nsu.ccfit.zuev.osuplus.R
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlin.math.max
+import kotlinx.coroutines.*
 
 object DifficultyCalculationManager {
 
 
-    private var isRunning = false
+    private var job: Job? = null
 
     private var badge: LoadingBadgeFragment? = null
 
 
     @JvmStatic
     fun calculateDifficulties() {
-
-        if (isRunning) {
+        if (job?.isActive == true) {
             return
         }
 
@@ -39,7 +41,6 @@ object DifficultyCalculationManager {
             return
         }
 
-        isRunning = true
         mainThread {
             badge = LoadingBadgeFragment().apply {
                 text = "Calculating beatmap difficulties..."
@@ -48,96 +49,92 @@ object DifficultyCalculationManager {
             }
         }
 
-        object : Thread() {
+        job = GlobalScope.launch {
+            val threadCount = Runtime.getRuntime().availableProcessors()
+            val threadPool = Executors.newFixedThreadPool(threadCount)
 
-            override fun run() {
+            var calculated = totalBeatmaps - pendingBeatmaps.size
 
-                val threadCount = Runtime.getRuntime().availableProcessors()
-                val threadPool = Executors.newFixedThreadPool(threadCount)
+            pendingBeatmaps.chunked(max(pendingBeatmaps.size / threadCount, 1)).fastForEach { chunk ->
+                ensureActive()
 
-                var calculated = totalBeatmaps - pendingBeatmaps.size
+                threadPool.submit {
 
-                pendingBeatmaps.chunked(max(pendingBeatmaps.size / threadCount, 1)).fastForEach { chunk ->
+                    // .indices to avoid creating an iterator.
+                    for (i in chunk.indices) {
+                        ensureActive()
 
-                    threadPool.submit {
+                        val beatmapInfo = chunk[i]
 
-                        // .indices to avoid creating an iterator.
-                        for (i in chunk.indices) {
+                        try {
+                            val msStartTime = System.currentTimeMillis()
 
-                            if (!isRunning) {
-                                break
+                            BeatmapParser(beatmapInfo.path, this).use { parser ->
+
+                                val data = parser.parse(true)!!
+                                val newInfo = BeatmapInfo(data, beatmapInfo.dateImported, true, this)
+                                beatmapInfo.apply(newInfo)
+
+                                ensureActive()
+
+                                DatabaseManager.beatmapInfoTable.update(newInfo)
                             }
 
-                            val beatmapInfo = chunk[i]
-
-                            try {
-                                val msStartTime = System.currentTimeMillis()
-
-                                BeatmapParser(beatmapInfo.path).use { parser ->
-
-                                    val data = parser.parse(true)!!
-                                    val newInfo = BeatmapInfo(data, beatmapInfo.dateImported, true)
-                                    beatmapInfo.apply(newInfo)
-
-                                    DatabaseManager.beatmapInfoTable.update(newInfo)
-                                }
-
-                                if (BuildConfig.DEBUG) {
-                                    Log.i("DifficultyCalculation", "Calculated difficulty for ${beatmapInfo.path}, took ${System.currentTimeMillis() - msStartTime}ms.")
-                                }
-
-                                calculated++
-                                mainThread {
-                                    badge?.apply {
-                                        isIndeterminate = false
-                                        progress = calculated * 100 / totalBeatmaps
-                                        text = "Calculating beatmap difficulties... (${progress}%)"
-                                    }
-                                }
-
-                            } catch (e: Exception) {
-                                Log.e("DifficultyCalculation", "Error while calculating difficulty.", e)
+                            if (BuildConfig.DEBUG) {
+                                Log.i("DifficultyCalculation", "Calculated difficulty for ${beatmapInfo.path}, took ${System.currentTimeMillis() - msStartTime}ms.")
                             }
 
+                            calculated++
+                            mainThread {
+                                badge?.apply {
+                                    isIndeterminate = false
+                                    progress = calculated * 100 / totalBeatmaps
+                                    text = "Calculating beatmap difficulties... (${progress}%)"
+                                }
+                            }
+
+                        } catch (e: Exception) {
+                            Log.e("DifficultyCalculation", "Error while calculating difficulty.", e)
                         }
+
                     }
                 }
-
-                threadPool.shutdown()
-                try {
-
-                    val isTimeout = threadPool.awaitTermination(1, TimeUnit.HOURS)
-
-                    if (isRunning) {
-                        if (isTimeout) {
-                            ToastLogger.showText("Background difficulty calculation has finished.", true)
-                        } else {
-                            ToastLogger.showText("Something went wrong during background difficulty calculation.", true)
-                        }
-                    } else {
-                        ToastLogger.showText("Difficulty calculation has been paused.", false)
-                    }
-
-                    mainThread {
-                        badge?.dismiss()
-                        badge = null
-                    }
-                    GlobalManager.getInstance().songMenu?.onDifficultyCalculationEnd()
-
-                } catch (e: InterruptedException) {
-                    Log.e("DifficultyCalculation", "Failed while waiting for executor termination.", e)
-                }
-
-                isRunning = false
             }
 
-        }.start()
+            threadPool.shutdown()
+            try {
+
+                val isTimeout = threadPool.awaitTermination(1, TimeUnit.HOURS)
+
+                if (isActive) {
+                    if (isTimeout) {
+                        ToastLogger.showText("Background difficulty calculation has finished.", true)
+                    } else {
+                        ToastLogger.showText("Something went wrong during background difficulty calculation.", true)
+                    }
+                } else {
+                    ToastLogger.showText("Difficulty calculation has been paused.", false)
+                }
+
+                mainThread {
+                    badge?.dismiss()
+                    badge = null
+                }
+                GlobalManager.getInstance().songMenu?.onDifficultyCalculationEnd()
+
+            } catch (e: InterruptedException) {
+                Log.e("DifficultyCalculation", "Failed while waiting for executor termination.", e)
+            }
+
+            job = null
+        }
     }
 
 
     @JvmStatic
     fun stopCalculation() {
-        isRunning = false
+        job?.cancel()
+        job = null
     }
 
 }

--- a/src/com/reco1l/osu/data/Beatmaps.kt
+++ b/src/com/reco1l/osu/data/Beatmaps.kt
@@ -10,6 +10,8 @@ import ru.nsu.ccfit.zuev.osu.game.GameHelper
 import kotlin.math.max
 import kotlin.math.min
 import com.rian.osu.beatmap.Beatmap
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ensureActive
 
 
 /// Ported from rimu! project
@@ -294,13 +296,15 @@ data class BeatmapInfo(
 /**
  * Represents a beatmap information.
  */
-fun BeatmapInfo(data: Beatmap, lastModified: Long, calculateDifficulty: Boolean): BeatmapInfo {
+@JvmOverloads
+fun BeatmapInfo(data: Beatmap, lastModified: Long, calculateDifficulty: Boolean, scope: CoroutineScope? = null): BeatmapInfo {
 
     var bpmMin = Float.MAX_VALUE
     var bpmMax = 0f
 
     // Timing points
     data.controlPoints.timing.getControlPoints().fastForEach {
+        scope?.ensureActive()
 
         val bpm = it.bpm.toFloat()
 
@@ -312,8 +316,8 @@ fun BeatmapInfo(data: Beatmap, lastModified: Long, calculateDifficulty: Boolean)
     var standardStarRating: Float? = null
 
     if (calculateDifficulty) {
-        val droidAttributes = BeatmapDifficultyCalculator.calculateDroidDifficulty(data)
-        val standardAttributes = BeatmapDifficultyCalculator.calculateStandardDifficulty(data)
+        val droidAttributes = BeatmapDifficultyCalculator.calculateDroidDifficulty(data, scope = scope)
+        val standardAttributes = BeatmapDifficultyCalculator.calculateStandardDifficulty(data, scope = scope)
 
         droidStarRating = GameHelper.Round(droidAttributes.starRating, 2)
         standardStarRating = GameHelper.Round(standardAttributes.starRating, 2)


### PR DESCRIPTION
- [x] Depends on #416 
- [x] Depends on `ToolKt` adding support to assess `CoroutineScope` in `Execution` functions (will replace the `GlobalScope.launch` call)

This PR is an example of working implementation of #416.