### PR TITLE
Corrections after 1.8.1 release

### DIFF
--- a/andnext_markdown/src/main/java/club/andnext/markdown/MarkdownWebView.java
+++ b/andnext_markdown/src/main/java/club/andnext/markdown/MarkdownWebView.java
@@ -47,7 +47,7 @@ public class MarkdownWebView extends WebView {
 
     @SuppressLint("SetJavaScriptEnabled")
     void init(Context context) {
-        this.setBackgroundColor(Color.TRANSPARENT);
+        this.setBackgroundColor(Color.WHITE);
 
         this.getSettings().setBlockNetworkLoads(true);
         this.getSettings().setLoadWithOverviewMode(true);

--- a/res/layout/dialog_progress.xml
+++ b/res/layout/dialog_progress.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/frg_background"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#80000000"
+    android:elevation="1dp">
+
+    <LinearLayout
+        android:id="@+id/frg_body"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:layout_marginBottom="20dp"
+        android:background="@drawable/rounded_rect"
+        android:backgroundTint="#1E1E2E"
+        android:divider="@drawable/divider"
+        android:gravity="center"
+        android:minWidth="200dp"
+        android:orientation="vertical"
+        android:showDividers="middle">
+
+        <TextView
+            android:id="@+id/title"
+            style="@style/settings_tab_divider"
+            android:paddingVertical="12dp"
+            android:text="Title" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:orientation="horizontal"
+            android:padding="12dp">
+
+            <com.google.android.material.progressindicator.CircularProgressIndicator
+                android:id="@+id/progress"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:indeterminate="true"
+                android:padding="10dp"
+                app:indicatorColor="@color/colorAccent"
+                app:indicatorDirectionCircular="counterclockwise"
+                app:trackCornerRadius="12dp"
+                tools:indeterminate="false"
+                tools:progress="50" />
+
+            <TextView
+                android:id="@+id/message"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="12dp"
+                android:maxWidth="400dp"
+                android:textColor="#FFF"
+                tools:text="Message" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</RelativeLayout>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -13,6 +13,7 @@
         <item name="windowNoTitle">true</item>
         <item name="android:windowFullscreen">true</item>
         <item name="android:windowBackground">#000</item>
+        <item name="android:windowIsTranslucent">true</item>
         <item name="android:forceDarkAllowed" tools:targetApi="q">false</item>
 
         <item name="checkboxStyle">@style/checkbox</item>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -13,7 +13,6 @@
         <item name="windowNoTitle">true</item>
         <item name="android:windowFullscreen">true</item>
         <item name="android:windowBackground">#000</item>
-        <item name="android:windowIsTranslucent">true</item>
         <item name="android:forceDarkAllowed" tools:targetApi="q">false</item>
 
         <item name="checkboxStyle">@style/checkbox</item>

--- a/src/com/edlplan/ui/fragment/BaseFragment.kt
+++ b/src/com/edlplan/ui/fragment/BaseFragment.kt
@@ -10,27 +10,32 @@ import androidx.fragment.app.Fragment
 import com.edlplan.framework.easing.Easing
 import com.edlplan.ui.ActivityOverlay
 import com.edlplan.ui.EasingHelper
-import com.reco1l.osu.*
 import ru.nsu.ccfit.zuev.osuplus.R
 
 abstract class BaseFragment : Fragment(), BackPressListener {
     var root: View? = null
         private set
-    private var background: View? = null
     var onDismissListener: OnDismissListener? = null
     var isDismissOnBackgroundClick = false
-    var isCreated = false
-        private set
     var isDismissOnBackPress = true
 
+    /**
+     * Whether the fragment is created. This is set to true after [onCreateView] is called.
+     */
+    var isCreated = false
+        private set
 
     /**
      * If true, the fragment will intercept back press event when it's received.
      */
     var interceptBackPress = true
 
+    /**
+     * Whether the fragment is loaded. This is set to true after [onLoadView] is called.
+     */
+    var isLoaded = false
+        private set
 
-    private var isLoaded = false
 
     private var isDismissCalled = false
 

--- a/src/com/edlplan/ui/fragment/MarkdownFragment.java
+++ b/src/com/edlplan/ui/fragment/MarkdownFragment.java
@@ -64,7 +64,7 @@ public class MarkdownFragment extends BaseFragment {
     }
 
     protected void playOnLoadAnim() {
-        View body = findViewById(R.id.frg_body);
+        View body = findViewById(R.id.fullLayout);
         body.setTranslationY(500);
         body.animate().cancel();
         body.animate()
@@ -76,7 +76,7 @@ public class MarkdownFragment extends BaseFragment {
     }
 
     protected void playOnDismissAnim(Runnable runnable) {
-        View body = findViewById(R.id.frg_body);
+        View body = findViewById(R.id.fullLayout);
         body.animate().cancel();
         body.animate()
                 .translationY(500)

--- a/src/com/reco1l/framework/net/FileRequest.kt
+++ b/src/com/reco1l/framework/net/FileRequest.kt
@@ -13,7 +13,7 @@ class FileRequest(val file: File, url: HttpUrl): WebRequest(url) {
     /**
      * The download observer.
      */
-    var observer: IDownloaderObserver? = null
+    var observer: IFileRequestObserver? = null
 
     /**
      * Whether the download is in progress, this is set to true once [execute] is called.
@@ -116,13 +116,9 @@ class FileRequest(val file: File, url: HttpUrl): WebRequest(url) {
 }
 
 
-interface IDownloaderObserver
-{
-    fun onDownloadEnd(downloader: FileRequest) = Unit
-
-    fun onDownloadCancel(downloader: FileRequest) = Unit
-
-    fun onDownloadUpdate(downloader: FileRequest) = Unit
-
-    fun onDownloadFail(downloader: FileRequest, exception: Exception) = Unit
+interface IFileRequestObserver {
+    fun onDownloadEnd(request: FileRequest) = Unit
+    fun onDownloadCancel(request: FileRequest) = Unit
+    fun onDownloadUpdate(request: FileRequest) = Unit
+    fun onDownloadFail(request: FileRequest, exception: Exception) = Unit
 }

--- a/src/com/reco1l/osu/UpdateManager.kt
+++ b/src/com/reco1l/osu/UpdateManager.kt
@@ -62,7 +62,7 @@ object UpdateManager: IFileRequestObserver
     /**
      * Check for new game updates.
      * 
-     * @param silently If `true` no announce will be shown unless there's new updates.
+     * @param silently If `true`, no prompts will be shown unless there's new updates.
      */
     @JvmStatic
     fun checkNewUpdates(silently: Boolean) {

--- a/src/com/reco1l/osu/beatmaplisting/BeatmapDownloader.kt
+++ b/src/com/reco1l/osu/beatmaplisting/BeatmapDownloader.kt
@@ -4,7 +4,7 @@ import android.os.Environment.DIRECTORY_DOWNLOADS
 import android.view.View
 import com.osudroid.resources.R.*
 import com.reco1l.framework.net.FileRequest
-import com.reco1l.framework.net.IDownloaderObserver
+import com.reco1l.framework.net.IFileRequestObserver
 import com.reco1l.osu.mainThread
 import com.reco1l.osu.multiplayer.Multiplayer
 import com.reco1l.osu.multiplayer.RoomScene
@@ -18,7 +18,7 @@ import ru.nsu.ccfit.zuev.osu.helper.FileUtils
 import ru.nsu.ccfit.zuev.osu.helper.StringTable
 import java.io.IOException
 
-object BeatmapDownloader : IDownloaderObserver {
+object BeatmapDownloader : IFileRequestObserver {
 
 
     private lateinit var fragment: DownloadFragment

--- a/src/com/reco1l/osu/beatmaplisting/BeatmapListing.kt
+++ b/src/com/reco1l/osu/beatmaplisting/BeatmapListing.kt
@@ -2,7 +2,6 @@ package com.reco1l.osu.beatmaplisting
 
 import android.graphics.BitmapFactory
 import android.graphics.Color
-import android.graphics.drawable.ColorDrawable
 import android.util.Log
 import android.view.Choreographer
 import android.view.Choreographer.FrameCallback
@@ -34,7 +33,7 @@ import com.edlplan.ui.fragment.BaseFragment
 import com.google.android.material.progressindicator.CircularProgressIndicator
 import com.reco1l.*
 import com.reco1l.framework.bass.URLBassStream
-import com.reco1l.framework.net.IDownloaderObserver
+import com.reco1l.framework.net.IFileRequestObserver
 import com.reco1l.framework.net.JsonArrayRequest
 import com.reco1l.osu.*
 import com.reco1l.osu.beatmaplisting.BeatmapMirrorSearchRequestModel.OrderType
@@ -42,7 +41,6 @@ import com.reco1l.osu.beatmaplisting.BeatmapMirrorSearchRequestModel.SortType
 import com.reco1l.osu.ui.Option
 import com.reco1l.osu.ui.SelectDialog
 import com.reco1l.osu.ui.SelectDropdown
-import com.reco1l.toolkt.android.backgroundColor
 import com.reco1l.toolkt.android.cornerRadius
 import com.reco1l.toolkt.android.dp
 import com.reco1l.toolkt.android.drawableLeft
@@ -67,7 +65,7 @@ import ru.nsu.ccfit.zuev.osu.RankedStatus
 
 
 class BeatmapListing : BaseFragment(),
-    IDownloaderObserver,
+    IFileRequestObserver,
     OnEditorActionListener,
     OnKeyListener,
     FrameCallback {

--- a/src/com/reco1l/osu/beatmaplisting/BeatmapListing.kt
+++ b/src/com/reco1l/osu/beatmaplisting/BeatmapListing.kt
@@ -796,9 +796,13 @@ class BeatmapListingFiltersFragment(private val beatmapListing: BeatmapListing) 
 
             statusButton.setOnClickListener {
 
+                val options = RankedStatus.entries.map { status ->
+                    Option(requireContext().getString(status.stringId), status)
+                }.toMutableList()
+                options.add(0, Option("All", null))
+
                 SelectDropdown(statusButton)
-                    .addOption(Option("All", null))
-                    .setOptions(RankedStatus.entries.map { status -> Option(requireContext().getString(status.stringId), status) }, false)
+                    .setOptions(options)
                     .setSelected(rankedStatus)
                     .setOnSelectListener {
                         it as RankedStatus?

--- a/src/com/reco1l/osu/multiplayer/LobbyRoomList.kt
+++ b/src/com/reco1l/osu/multiplayer/LobbyRoomList.kt
@@ -43,10 +43,7 @@ class LobbyRoomList : ScrollableList() {
             setTitle(room.name)
             setMessage("Please enter the room password:")
             setAllowDismiss(false)
-
-            setOnTextInputBind {
-                it.inputType = EditorInfo.TYPE_TEXT_VARIATION_PASSWORD
-            }
+            setInputType(EditorInfo.TYPE_TEXT_VARIATION_PASSWORD)
 
             addButton("Join") {
                 val password = (it as PromptDialog).input

--- a/src/com/reco1l/osu/ui/Dialog.kt
+++ b/src/com/reco1l/osu/ui/Dialog.kt
@@ -7,13 +7,10 @@ import android.view.ContextThemeWrapper
 import android.view.Gravity.*
 import android.view.View
 import android.widget.Button
-import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.core.text.HtmlCompat
 import androidx.core.text.HtmlCompat.FROM_HTML_MODE_LEGACY
-import androidx.core.view.isVisible
-import androidx.core.widget.doOnTextChanged
 import com.edlplan.framework.easing.Easing
 import com.edlplan.ui.EasingHelper
 import com.edlplan.ui.fragment.BaseFragment
@@ -53,7 +50,7 @@ open class MessageDialog : BaseFragment() {
     /**
      * The message to be displayed in the dialog.
      */
-    var message: CharSequence = ""
+    open var message: CharSequence = ""
         set(value) {
             field = value
             if (isCreated) {
@@ -183,6 +180,7 @@ open class MessageDialog : BaseFragment() {
     @JvmOverloads
     open fun addButton(text: String, tint: Int = Color.WHITE, clickListener: (MessageDialog) -> Unit): MessageDialog {
         buttons.add(DialogButton(text, tint, clickListener))
+        buttons = buttons
         return this
     }
 
@@ -197,101 +195,6 @@ open class MessageDialog : BaseFragment() {
         onDismiss?.invoke()
         super.dismiss()
     }
-}
-
-
-open class PromptDialog : MessageDialog() {
-
-    override val layoutID = R.layout.dialog_input_fragment
-
-
-    /**
-     * The text input by user.
-     */
-    var input: String? = null
-        set(value) {
-            field = value
-            if (isCreated) {
-                findViewById<EditText>(R.id.input)?.apply {
-                    if (text.toString() != value) {
-                        setText(value)
-                    }
-                }
-            }
-        }
-
-    /**
-     * The text to be show displayed in the input hint.
-     */
-    var hint: String? = null
-        set(value) {
-            field = value
-            if (isCreated) {
-                findViewById<EditText>(R.id.input)?.hint = value
-            }
-        }
-
-
-    private var onTextChanged: ((PromptDialog) -> Unit)? = null
-
-    private var onTextInputBind: ((EditText) -> Unit)? = null
-
-
-    override fun onLoadView() {
-
-        super.onLoadView()
-
-        findViewById<TextView>(R.id.message)!!.isVisible = message.isNotBlank()
-        findViewById<EditText>(R.id.input)!!.apply {
-
-            setText(input)
-
-            doOnTextChanged { text, _, _, _ ->
-                input = text.toString()
-                onTextChanged?.invoke(this@PromptDialog)
-            }
-
-            onTextInputBind?.invoke(this)
-        }
-
-    }
-
-
-    /**
-     * The text input by user.
-     */
-    fun setInput(text: String?): PromptDialog {
-        input = text
-        return this
-    }
-
-    /**
-     * The text to be show displayed in the input hint.
-     */
-    fun setHint(text: String): PromptDialog {
-        hint = text
-        return this
-    }
-
-    /**
-     * The function to be called when the text input is changed.
-     */
-    fun setOnTextChanged(action: (PromptDialog) -> Unit): PromptDialog {
-        onTextChanged = action
-        return this
-    }
-
-    /**
-     * The function to be called when the EditText is created.
-     */
-    fun setOnTextInputBind(action: (EditText) -> Unit): PromptDialog {
-        onTextInputBind = action
-        return this
-    }
-
-
-    override fun addButton(text: String, tint: Int, clickListener: (MessageDialog) -> Unit) = super.addButton(text, tint, clickListener) as PromptDialog
-
 }
 
 

--- a/src/com/reco1l/osu/ui/Dialog.kt
+++ b/src/com/reco1l/osu/ui/Dialog.kt
@@ -24,12 +24,30 @@ import com.reco1l.toolkt.animation.toScaleY
 import ru.nsu.ccfit.zuev.osuplus.R
 
 
+/**
+ * A button to be displayed in a dialog.
+ */
 data class DialogButton(
+
+    /**
+     * The text to be displayed in the button.
+     */
     val text: String,
+
+    /**
+     * The color of the button text and icon.
+     */
     val tint: Int = Color.WHITE,
+
+    /**
+     * The function to be called when the button is clicked.
+     */
     val clickListener: (MessageDialog) -> Unit
 )
 
+/**
+ * A dialog that displays a message to the user.
+ */
 open class MessageDialog : BaseFragment() {
 
 

--- a/src/com/reco1l/osu/ui/Dialog.kt
+++ b/src/com/reco1l/osu/ui/Dialog.kt
@@ -123,9 +123,15 @@ open class MessageDialog : BaseFragment() {
             }
         }
 
-    protected var allowDismiss = true
+    /**
+     * Whether the dialog is cancelable or not.
+     */
+    var allowDismiss = true
 
-    protected var onDismiss: (() -> Unit)? = null
+    /**
+     * The function to be called when the dialog is dismissed.
+     */
+    var onDismiss: (() -> Unit)? = null
 
 
     override fun onLoadView() {

--- a/src/com/reco1l/osu/ui/ListDialog.kt
+++ b/src/com/reco1l/osu/ui/ListDialog.kt
@@ -56,29 +56,29 @@ open class SelectDialog : MessageDialog() {
 
             field = value
 
-            if (::recyclerView.isInitialized) {
-                recyclerView.adapter!!.notifyDataSetChanged()
+            if (isLoaded) {
+                findViewById<RecyclerView>(R.id.list)!!.adapter!!.notifyDataSetChanged()
             }
         }
 
 
     protected var selected: Any? = null
+        set(value) {
+            field = value
+            if (isLoaded) {
+                findViewById<RecyclerView>(R.id.list)!!.adapter!!.notifyDataSetChanged()
+            }
+        }
 
     protected var onSelect: ((Any?) -> Unit)? = null
-
-
-    private lateinit var recyclerView: RecyclerView
 
 
     override fun onLoadView() {
         super.onLoadView()
 
-        recyclerView = findViewById<RecyclerView>(R.id.list)!!.apply {
-
-            layoutManager = LinearLayoutManager(context)
-            adapter = Adapter()
-
-        }
+        val recyclerView = findViewById<RecyclerView>(R.id.list)!!
+        recyclerView.layoutManager = LinearLayoutManager(context)
+        recyclerView.adapter = Adapter()
     }
 
 
@@ -88,7 +88,7 @@ open class SelectDialog : MessageDialog() {
      * @param replace If true, the current options will be replaced with the new ones.
      */
     @JvmOverloads
-    fun setOptions(options: List<Option>, replace: Boolean = false): SelectDialog {
+    fun setOptions(options: List<Option>, replace: Boolean = true): SelectDialog {
         if (replace) {
             this.options = options.toMutableList()
         } else {
@@ -123,7 +123,9 @@ open class SelectDialog : MessageDialog() {
 
 
     private fun unselectAll() {
-        recyclerView.forEach { (recyclerView.getChildViewHolder(it) as ViewHolder).unselect() }
+        findViewById<RecyclerView>(R.id.list)!!.apply {
+            forEach { (getChildViewHolder(it) as ViewHolder).unselect() }
+        }
     }
 
 

--- a/src/com/reco1l/osu/ui/ListDialog.kt
+++ b/src/com/reco1l/osu/ui/ListDialog.kt
@@ -40,7 +40,9 @@ data class Option(
     val icon: Drawable? = null
 )
 
-
+/**
+ * A dialog that allows the user to select an option.
+ */
 open class SelectDialog : MessageDialog() {
 
 

--- a/src/com/reco1l/osu/ui/ListDialog.kt
+++ b/src/com/reco1l/osu/ui/ListDialog.kt
@@ -47,6 +47,9 @@ open class SelectDialog : MessageDialog() {
     override val layoutID = R.layout.dialog_select_fragment
 
 
+    /**
+     * The options to be displayed in the dialog.
+     */
     var options = mutableListOf<Option>()
         protected set(value) {
 
@@ -61,8 +64,10 @@ open class SelectDialog : MessageDialog() {
             }
         }
 
-
-    protected var selected: Any? = null
+    /**
+     * The selected value.
+     */
+    var selected: Any? = null
         set(value) {
             field = value
             if (isLoaded) {
@@ -70,7 +75,10 @@ open class SelectDialog : MessageDialog() {
             }
         }
 
-    protected var onSelect: ((Any?) -> Unit)? = null
+    /**
+     * The function to be called when an option is selected.
+     */
+    var onSelect: ((Any?) -> Unit)? = null
 
 
     override fun onLoadView() {
@@ -84,16 +92,9 @@ open class SelectDialog : MessageDialog() {
 
     /**
      * Set the options to be displayed in the dialog.
-     *
-     * @param replace If true, the current options will be replaced with the new ones.
      */
-    @JvmOverloads
-    fun setOptions(options: List<Option>, replace: Boolean = true): SelectDialog {
-        if (replace) {
-            this.options = options.toMutableList()
-        } else {
-            this.options.addAll(options)
-        }
+    fun setOptions(value: List<Option>): SelectDialog {
+        options = value.toMutableList()
         return this
     }
 
@@ -122,13 +123,6 @@ open class SelectDialog : MessageDialog() {
     }
 
 
-    private fun unselectAll() {
-        findViewById<RecyclerView>(R.id.list)!!.apply {
-            forEach { (getChildViewHolder(it) as ViewHolder).unselect() }
-        }
-    }
-
-
     private inner class Adapter : RecyclerView.Adapter<ViewHolder>() {
 
 
@@ -146,10 +140,13 @@ open class SelectDialog : MessageDialog() {
             holder.bind(options[position])
         }
 
+        override fun getItemCount(): Int {
+            return options.size
+        }
 
-        override fun getItemCount() = options.size
-
-        override fun getItemId(position: Int) = position.toLong()
+        override fun getItemId(position: Int): Long {
+            return position.toLong()
+        }
 
     }
 
@@ -162,7 +159,11 @@ open class SelectDialog : MessageDialog() {
 
             text.setOnClickListener {
 
-                unselectAll()
+                findViewById<RecyclerView>(R.id.list)!!.apply {
+                    forEach {
+                        (getChildViewHolder(it) as ViewHolder).unselect()
+                    }
+                }
 
                 selected = option.value
                 select()

--- a/src/com/reco1l/osu/ui/ProgressDialog.kt
+++ b/src/com/reco1l/osu/ui/ProgressDialog.kt
@@ -1,0 +1,80 @@
+package com.reco1l.osu.ui
+
+import com.google.android.material.progressindicator.CircularProgressIndicator
+import ru.nsu.ccfit.zuev.osuplus.R
+
+
+class ProgressDialog : MessageDialog() {
+
+
+    override val layoutID = R.layout.dialog_progress
+
+
+    /**
+     * The progress of the dialog.
+     */
+    var progress: Int = 0
+        set(value) {
+            field = value
+            if (isCreated) {
+                findViewById<CircularProgressIndicator>(R.id.progress)!!.progress = value
+            }
+        }
+
+    /**
+     * Whether the progress is indeterminate or not.
+     */
+    var indeterminate: Boolean = false
+        set(value) {
+            field = value
+            if (isCreated) {
+                findViewById<CircularProgressIndicator>(R.id.progress)!!.isIndeterminate = value
+            }
+        }
+
+    /**
+     * The maximum value of the progress.
+     */
+    var max: Int = 0
+        set(value) {
+            field = value
+            if (isCreated) {
+                findViewById<CircularProgressIndicator>(R.id.progress)!!.max = value
+            }
+        }
+
+
+    override fun onLoadView() {
+        super.onLoadView()
+
+        max = max
+        progress = progress
+        indeterminate = indeterminate
+    }
+
+
+    /**
+     * Sets the progress of the dialog.
+     */
+    fun setProgress(value: Int): ProgressDialog {
+        progress = value
+        return this
+    }
+
+    /**
+     * Sets whether the progress is indeterminate or not.
+     */
+    fun setIndeterminate(value: Boolean): ProgressDialog {
+        indeterminate = value
+        return this
+    }
+
+    /**
+     * Sets the maximum value of the progress.
+     */
+    fun setMax(value: Int): ProgressDialog {
+        max = value
+        return this
+    }
+
+}

--- a/src/com/reco1l/osu/ui/ProgressDialog.kt
+++ b/src/com/reco1l/osu/ui/ProgressDialog.kt
@@ -4,6 +4,9 @@ import com.google.android.material.progressindicator.CircularProgressIndicator
 import ru.nsu.ccfit.zuev.osuplus.R
 
 
+/**
+ * A dialog that shows a progress bar.
+ */
 class ProgressDialog : MessageDialog() {
 
 

--- a/src/com/reco1l/osu/ui/PromptDialog.kt
+++ b/src/com/reco1l/osu/ui/PromptDialog.kt
@@ -1,0 +1,120 @@
+package com.reco1l.osu.ui
+
+import android.text.InputType
+import android.widget.EditText
+import android.widget.TextView
+import androidx.core.view.isVisible
+import androidx.core.widget.doOnTextChanged
+import ru.nsu.ccfit.zuev.osuplus.R
+
+open class PromptDialog : MessageDialog() {
+
+
+    override val layoutID = R.layout.dialog_input_fragment
+
+
+    override var message: CharSequence = ""
+        set(value) {
+            field = value
+            super.message = value
+            if (isCreated) {
+                findViewById<TextView>(R.id.message)!!.isVisible = value.isNotBlank()
+            }
+        }
+
+
+    /**
+     * The text input by user.
+     */
+    var input: String? = null
+        set(value) {
+            field = value
+            if (isCreated) {
+                val inputView = findViewById<EditText>(R.id.input)!!
+                if (inputView.text.toString() != value) {
+                    inputView.setText(value)
+                }
+            }
+        }
+
+    /**
+     * The text to be show displayed in the input hint.
+     */
+    var hint: String? = null
+        set(value) {
+            field = value
+            if (isCreated) {
+                findViewById<EditText>(R.id.input)?.hint = value
+            }
+        }
+
+    /**
+     * The function to be called when the text input is changed.
+     */
+    var onTextChanged: ((PromptDialog) -> Unit)? = null
+
+    /**
+     * The input type of the EditText.
+     */
+    var inputType: Int = InputType.TYPE_NULL
+        set(value) {
+            field = value
+            if (isCreated) {
+                findViewById<EditText>(R.id.input)?.inputType = value
+            }
+        }
+
+
+    override fun onLoadView() {
+        super.onLoadView()
+
+        hint = hint
+        input = input
+        message = message
+        inputType = inputType
+
+        findViewById<EditText>(R.id.input)!!.doOnTextChanged { text, _, _, _ ->
+            input = text.toString()
+            onTextChanged?.invoke(this@PromptDialog)
+        }
+    }
+
+
+    /**
+     * The text input by user.
+     */
+    fun setInput(text: String?): PromptDialog {
+        input = text
+        return this
+    }
+
+    /**
+     * The text to be show displayed in the input hint.
+     */
+    fun setHint(text: String): PromptDialog {
+        hint = text
+        return this
+    }
+
+    /**
+     * The function to be called when the text input is changed.
+     */
+    fun setOnTextChanged(action: (PromptDialog) -> Unit): PromptDialog {
+        onTextChanged = action
+        return this
+    }
+
+    /**
+     * The input type of the EditText.
+     */
+    fun setInputType(type: Int): PromptDialog {
+        inputType = type
+        return this
+    }
+
+
+    override fun addButton(text: String, tint: Int, clickListener: (MessageDialog) -> Unit): PromptDialog {
+        return super.addButton(text, tint, clickListener) as PromptDialog
+    }
+
+}

--- a/src/com/reco1l/osu/ui/PromptDialog.kt
+++ b/src/com/reco1l/osu/ui/PromptDialog.kt
@@ -7,6 +7,9 @@ import androidx.core.view.isVisible
 import androidx.core.widget.doOnTextChanged
 import ru.nsu.ccfit.zuev.osuplus.R
 
+/**
+ * A dialog that prompts the user for input.
+ */
 open class PromptDialog : MessageDialog() {
 
 

--- a/src/com/reco1l/osu/ui/PromptDialog.kt
+++ b/src/com/reco1l/osu/ui/PromptDialog.kt
@@ -41,7 +41,7 @@ open class PromptDialog : MessageDialog() {
         }
 
     /**
-     * The text to be show displayed in the input hint.
+     * The text to display in the input hint.
      */
     var hint: String? = null
         set(value) {
@@ -52,7 +52,7 @@ open class PromptDialog : MessageDialog() {
         }
 
     /**
-     * The function to be called when the text input is changed.
+     * The function to call when the text input is changed.
      */
     var onTextChanged: ((PromptDialog) -> Unit)? = null
 
@@ -92,7 +92,7 @@ open class PromptDialog : MessageDialog() {
     }
 
     /**
-     * The text to be show displayed in the input hint.
+     * The text to display in the input hint.
      */
     fun setHint(text: String): PromptDialog {
         hint = text
@@ -100,7 +100,7 @@ open class PromptDialog : MessageDialog() {
     }
 
     /**
-     * The function to be called when the text input is changed.
+     * The function to call when the text input is changed.
      */
     fun setOnTextChanged(action: (PromptDialog) -> Unit): PromptDialog {
         onTextChanged = action

--- a/src/ru/nsu/ccfit/zuev/osu/Config.java
+++ b/src/ru/nsu/ccfit/zuev/osu/Config.java
@@ -843,6 +843,14 @@ public class Config {
         sharedPreferences.edit().putInt(key, value).commit();
     }
 
+    public static long getLong(String key, long defaultValue) {
+        return sharedPreferences.getLong(key, defaultValue);
+    }
+
+    public static void setLong(String key, long value) {
+        sharedPreferences.edit().putLong(key, value).commit();
+    }
+
     public static String getString(String key, String defaultValue) {
         return sharedPreferences.getString(key, defaultValue);
     }

--- a/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
+++ b/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
@@ -304,7 +304,7 @@ public class MainActivity extends BaseGameActivity implements
 
             Execution.delayed(2500, () -> {
 
-                UpdateManager.onActivityStart(this);
+                UpdateManager.onActivityStart();
                 GlobalManager.getInstance().setInfo("");
                 GlobalManager.getInstance().setLoadingProgress(100);
                 ResourceManager.getInstance().loadFont("font", null, 28, Color.WHITE);
@@ -368,7 +368,7 @@ public class MainActivity extends BaseGameActivity implements
         this.mRenderSurfaceView.setRenderer(this.mEngine);
 
         RelativeLayout layout = new RelativeLayout(this);
-        layout.setBackgroundColor(Color.argb(255, 0, 0, 0));
+        layout.setBackgroundColor(Color.BLACK);
         layout.addView(
                 mRenderSurfaceView,
                 new RelativeLayout.LayoutParams(
@@ -378,12 +378,8 @@ public class MainActivity extends BaseGameActivity implements
                 }});
 
         FrameLayout frameLayout = new FrameLayout(this);
-        frameLayout.setId(0x28371);
+        frameLayout.setId(View.generateViewId());
         layout.addView(frameLayout, new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
-
-        View c = new View(this);
-        c.setBackgroundColor(Color.argb(0, 0, 0, 0));
-        layout.addView(c, new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
 
         this.setContentView(
                 layout,

--- a/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
+++ b/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
@@ -304,7 +304,7 @@ public class MainActivity extends BaseGameActivity implements
 
             Execution.delayed(2500, () -> {
 
-                UpdateManager.INSTANCE.onActivityStart();
+                UpdateManager.onActivityStart(this);
                 GlobalManager.getInstance().setInfo("");
                 GlobalManager.getInstance().setLoadingProgress(100);
                 ResourceManager.getInstance().loadFont("font", null, 28, Color.WHITE);

--- a/src/ru/nsu/ccfit/zuev/osu/ToastLogger.java
+++ b/src/ru/nsu/ccfit/zuev/osu/ToastLogger.java
@@ -33,7 +33,7 @@ public class ToastLogger {
                 showlong ? Toast.LENGTH_LONG : Toast.LENGTH_SHORT).show());
     }
 
-    public static void showTextId(@StringRes final int resID, final boolean showlong) {
+    public static void showText(@StringRes final int resID, final boolean showlong) {
         showText(StringTable.get(resID), showlong);
     }
 

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -2340,9 +2340,13 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
                     scene.setTimeMultiplier(decreasedSpeed);
 
                     if (video != null) {
-                        // Aparently MediaPlayer API doesn't support setting playback speed
-                        // below 0.01 causing an IllegalStateException.
-                        video.setPlaybackSpeed(Math.max(0.01f, decreasedSpeed));
+                        // In some devices this can throw an exception, unfortunately there's no
+                        // documentation that explains how to avoid that scenario. Thanks Google.
+                        try {
+                            video.setPlaybackSpeed(decreasedSpeed);
+                        } catch (Exception e) {
+                            Log.e("GameScene", "Failed to change video playback speed during game over animation.", e);
+                        }
                     }
 
                     songService.setFrequencyForcefully(decreasedFrequency);

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -379,7 +379,7 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
 
     private boolean loadGame(final BeatmapInfo beatmapInfo, final String rFile, final CoroutineScope scope) {
         if (!SecurityUtils.verifyFileIntegrity(GlobalManager.getInstance().getMainActivity())) {
-            ToastLogger.showTextId(com.osudroid.resources.R.string.file_integrity_tampered, true);
+            ToastLogger.showText(com.osudroid.resources.R.string.file_integrity_tampered, true);
             return false;
         }
 
@@ -390,7 +390,7 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
                     MD5Calculator.getStringMD5(rFile) + ".odr";
             Debug.i("ReplayFile = " + replayFilePath);
             if (!OnlineFileOperator.downloadFile(rFile, this.replayFilePath)) {
-                ToastLogger.showTextId(com.osudroid.resources.R.string.replay_cantdownload, true);
+                ToastLogger.showText(com.osudroid.resources.R.string.replay_cantdownload, true);
                 return false;
             }
         } else
@@ -421,7 +421,7 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
         }
 
         if (!parsedBeatmap.getMd5().equals(beatmapInfo.getMD5())) {
-            ToastLogger.showTextId(com.osudroid.resources.R.string.file_integrity_tampered, true);
+            ToastLogger.showText(com.osudroid.resources.R.string.file_integrity_tampered, true);
             return false;
         }
 
@@ -567,7 +567,7 @@ public class GameScene implements IUpdateHandler, GameObjectListener,
         if (replayFilePath != null) {
             replaying = replay.load(replayFilePath, true);
             if (!replaying) {
-                ToastLogger.showTextId(com.osudroid.resources.R.string.replay_invalid, true);
+                ToastLogger.showText(com.osudroid.resources.R.string.replay_invalid, true);
                 return false;
             }
             GameHelper.setReplayVersion(replay.replayVersion);

--- a/src/ru/nsu/ccfit/zuev/osu/menu/ModMenu.java
+++ b/src/ru/nsu/ccfit/zuev/osu/menu/ModMenu.java
@@ -528,7 +528,7 @@ public class ModMenu implements IModSwitcher {
         }
 
         if (modsRemoved) {
-            ToastLogger.showTextId(com.osudroid.resources.R.string.force_diffstat_mod_unpickable, false);
+            ToastLogger.showText(com.osudroid.resources.R.string.force_diffstat_mod_unpickable, false);
         }
 
         return modsRemoved;

--- a/src/ru/nsu/ccfit/zuev/osu/menu/PauseMenu.java
+++ b/src/ru/nsu/ccfit/zuev/osu/menu/PauseMenu.java
@@ -99,7 +99,7 @@ public class PauseMenu implements IOnMenuItemClickListener {
         switch (pMenuItem.getID()) {
             case ITEM_SAVE_REPLAY:
                 if(fail && !replaySaved && !game.getReplaying() && game.saveFailedReplay()){
-                    ToastLogger.showTextId(com.osudroid.resources.R.string.message_save_replay_successful, true);
+                    ToastLogger.showText(com.osudroid.resources.R.string.message_save_replay_successful, true);
                     replaySaved = true;
                 }
                 return true;

--- a/src/ru/nsu/ccfit/zuev/osu/menu/SongMenu.java
+++ b/src/ru/nsu/ccfit/zuev/osu/menu/SongMenu.java
@@ -1229,7 +1229,7 @@ public class SongMenu implements IUpdateHandler, MenuItemListener,
     public void openScore(final int id, boolean showOnline, final String playerName) {
         if (showOnline) {
             engine.setScene(new LoadingScreen().getScene());
-            ToastLogger.showTextId(com.osudroid.resources.R.string.online_loadrecord, false);
+            ToastLogger.showText(com.osudroid.resources.R.string.online_loadrecord, false);
 
             cancelCalculationJobs();
             cancelMapStatusLoadingJob();

--- a/src/ru/nsu/ccfit/zuev/osu/scoring/Replay.java
+++ b/src/ru/nsu/ccfit/zuev/osu/scoring/Replay.java
@@ -281,10 +281,10 @@ public class Replay {
         } catch (EOFException e) {
             Debug.e("O_o eof...");
             Debug.e(e);
-            ToastLogger.showTextId(com.osudroid.resources.R.string.replay_corrupted, true);
+            ToastLogger.showText(com.osudroid.resources.R.string.replay_corrupted, true);
             return false;
         } catch (Exception e) {
-            ToastLogger.showTextId(com.osudroid.resources.R.string.replay_corrupted, true);
+            ToastLogger.showText(com.osudroid.resources.R.string.replay_corrupted, true);
             Debug.e("Cannot load replay: " + e.getMessage(), e);
             return false;
         }

--- a/src/ru/nsu/ccfit/zuev/osu/scoring/ScoringScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/scoring/ScoringScene.java
@@ -487,7 +487,7 @@ public class ScoringScene {
             // Do not save and submit score if note count does not match, since it indicates a corrupted score
             // (potentially from bugging the gameplay by any unnecessary means).
             if (totalNotes != beatmap.getTotalHitObjectCount()) {
-                ToastLogger.showTextId(com.osudroid.resources.R.string.replay_corrupted, true);
+                ToastLogger.showText(com.osudroid.resources.R.string.replay_corrupted, true);
                 return;
             }
 


### PR DESCRIPTION
## Relevant changes
- Fixed an issue where the game could potentially crash when running the game over animation with video background is enabled.
- `UpdateManager` will now use game's dialogs instead of Android native.
- `UpdateManager` will no longer cache update builds, forcing re-download just in case.
- Fixed a bug where the changelog is not showing after updating, as well the `UpdateManager` will use local changelog.