### PR TITLE
Fix GL_STACK_UNDERFLOW on glPopMatrix

### DIFF
--- a/AndEngine/src/org/anddev/andengine/entity/scene/CameraScene.java
+++ b/AndEngine/src/org/anddev/andengine/entity/scene/CameraScene.java
@@ -98,6 +98,7 @@ public class CameraScene extends Scene {
 
 				super.onManagedDraw(pGL, pCamera);
 
+				pGL.glMatrixMode(GL10.GL_MODELVIEW);
 				pGL.glPopMatrix();
 			}
 			pGL.glMatrixMode(GL10.GL_PROJECTION);


### PR DESCRIPTION
Fixes the GL_STACK_UNDERFLOW error on glPopMatrix due to pushing and popping with different matrix modes.