### PR TITLE
Add osu!droid difficulty calculation for Traceable mod

### DIFF
--- a/src/com/rian/osu/difficulty/DifficultyHitObject.kt
+++ b/src/com/rian/osu/difficulty/DifficultyHitObject.kt
@@ -173,7 +173,7 @@ abstract class DifficultyHitObject(
      * @param mods The mods used.
      * @return The opacity of the hit object at the given time.
      */
-    fun opacityAt(time: Double, mods: List<Mod>): Double {
+    open fun opacityAt(time: Double, mods: List<Mod>): Double {
         if (time > obj.startTime) {
             // Consider a hit object as being invisible when its start time is passed.
             // In reality the hit object will be visible beyond its start time up until its hittable window has passed,

--- a/src/com/rian/osu/difficulty/DifficultyHitObject.kt
+++ b/src/com/rian/osu/difficulty/DifficultyHitObject.kt
@@ -8,6 +8,7 @@ import com.rian.osu.beatmap.hitobject.sliderobject.SliderRepeat
 import com.rian.osu.beatmap.hitobject.sliderobject.SliderTick
 import com.rian.osu.math.Precision.almostEquals
 import com.rian.osu.math.Vector2
+import com.rian.osu.mods.Mod
 import com.rian.osu.mods.ModHidden
 import kotlin.math.*
 
@@ -169,10 +170,10 @@ abstract class DifficultyHitObject(
      * Calculates the opacity of the hit object at a given time.
      *
      * @param time The time to calculate the hit object's opacity at.
-     * @param isHidden Whether Hidden mod is used.
+     * @param mods The mods used.
      * @return The opacity of the hit object at the given time.
      */
-    fun opacityAt(time: Double, isHidden: Boolean): Double {
+    fun opacityAt(time: Double, mods: List<Mod>): Double {
         if (time > obj.startTime) {
             // Consider a hit object as being invisible when its start time is passed.
             // In reality the hit object will be visible beyond its start time up until its hittable window has passed,
@@ -184,7 +185,7 @@ abstract class DifficultyHitObject(
         val fadeInDuration = obj.timeFadeIn
         val nonHiddenOpacity = ((time - fadeInStartTime) / fadeInDuration).coerceIn(0.0, 1.0)
 
-        if (isHidden) {
+        if (mods.any { it is ModHidden }) {
             val fadeOutStartTime = fadeInStartTime + fadeInDuration
             val fadeOutDuration = obj.timePreempt * ModHidden.FADE_OUT_DURATION_MULTIPLIER
 

--- a/src/com/rian/osu/difficulty/DroidDifficultyHitObject.kt
+++ b/src/com/rian/osu/difficulty/DroidDifficultyHitObject.kt
@@ -2,6 +2,8 @@ package com.rian.osu.difficulty
 
 import com.rian.osu.GameMode
 import com.rian.osu.beatmap.hitobject.*
+import com.rian.osu.mods.Mod
+import com.rian.osu.mods.ModTraceable
 import kotlin.math.exp
 import kotlin.math.max
 import kotlin.math.min
@@ -96,6 +98,15 @@ class DroidDifficultyHitObject(
     override fun previous(backwardsIndex: Int) = if (index - backwardsIndex >= 0) difficultyHitObjects[index - backwardsIndex] else null
 
     override fun next(forwardsIndex: Int) = if (index + forwardsIndex + 2 < difficultyHitObjects.size) difficultyHitObjects[index + forwardsIndex + 2] else null
+
+    override fun opacityAt(time: Double, mods: List<Mod>): Double {
+        // Traceable hides the primary piece of a hit circle (that is, its body), so consider it as fully invisible.
+        if (obj is HitCircle && mods.any { it is ModTraceable }) {
+            return 0.0
+        }
+
+        return super.opacityAt(time, mods)
+    }
 
     /**
      * Determines whether this [DroidDifficultyHitObject] is considered overlapping with the [DroidDifficultyHitObject]

--- a/src/com/rian/osu/difficulty/calculator/DroidDifficultyCalculator.kt
+++ b/src/com/rian/osu/difficulty/calculator/DroidDifficultyCalculator.kt
@@ -22,7 +22,8 @@ import kotlinx.coroutines.ensureActive
  */
 class DroidDifficultyCalculator : DifficultyCalculator<DroidPlayableBeatmap, DroidDifficultyHitObject, DroidDifficultyAttributes>() {
     override val difficultyMultiplier = 0.18
-    override val difficultyAdjustmentMods = super.difficultyAdjustmentMods + setOf(ModPrecise(), ModScoreV2())
+    override val difficultyAdjustmentMods = super.difficultyAdjustmentMods +
+        setOf(ModPrecise(), ModScoreV2(), ModTraceable())
 
     private val maximumSectionDeltaTime = 2000
     private val minimumSectionObjectCount = 5

--- a/src/com/rian/osu/difficulty/evaluators/DroidFlashlightEvaluator.kt
+++ b/src/com/rian/osu/difficulty/evaluators/DroidFlashlightEvaluator.kt
@@ -3,6 +3,8 @@ package com.rian.osu.difficulty.evaluators
 import com.rian.osu.beatmap.hitobject.Slider
 import com.rian.osu.beatmap.hitobject.Spinner
 import com.rian.osu.difficulty.DroidDifficultyHitObject
+import com.rian.osu.mods.Mod
+import com.rian.osu.mods.ModHidden
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
@@ -28,11 +30,11 @@ object DroidFlashlightEvaluator {
      * * and whether Hidden mod is enabled.
      *
      * @param current The current object.
-     * @param isHiddenMod Whether the Hidden mod is enabled.
+     * @param mods The mods used.
      * @param withSliders Whether to take slider difficulty into account.
      */
     @JvmStatic
-    fun evaluateDifficultyOf(current: DroidDifficultyHitObject, isHiddenMod: Boolean, withSliders: Boolean): Double {
+    fun evaluateDifficultyOf(current: DroidDifficultyHitObject, mods: List<Mod>, withSliders: Boolean): Double {
         if (
             current.obj is Spinner ||
             // Exclude overlapping objects that can be tapped at once.
@@ -68,7 +70,7 @@ object DroidFlashlightEvaluator {
                 val stackNerf = min(1.0, currentObject.lazyJumpDistance / scalingFactor / 25)
 
                 // Bonus based on how visible the object is.
-                val opacityBonus = 1 + MAX_OPACITY_BONUS * (1 - current.opacityAt(currentObject.obj.startTime, isHiddenMod))
+                val opacityBonus = 1 + MAX_OPACITY_BONUS * (1 - current.opacityAt(currentObject.obj.startTime, mods))
                 result += stackNerf * opacityBonus * scalingFactor * jumpDistance / cumulativeStrainTime
 
                 // Objects further back in time should count less for the nerf.
@@ -84,8 +86,8 @@ object DroidFlashlightEvaluator {
         result = (smallDistNerf * result).pow(2)
 
         // Additional bonus for Hidden due to there being no approach circles.
-        if (isHiddenMod) {
-            result *= 1 + this.HIDDEN_BONUS
+        if (mods.any { it is ModHidden }) {
+            result *= 1 + HIDDEN_BONUS
         }
 
         // Nerf patterns with repeated angles.

--- a/src/com/rian/osu/difficulty/evaluators/DroidFlashlightEvaluator.kt
+++ b/src/com/rian/osu/difficulty/evaluators/DroidFlashlightEvaluator.kt
@@ -1,10 +1,12 @@
 package com.rian.osu.difficulty.evaluators
 
+import com.rian.osu.beatmap.hitobject.HitCircle
 import com.rian.osu.beatmap.hitobject.Slider
 import com.rian.osu.beatmap.hitobject.Spinner
 import com.rian.osu.difficulty.DroidDifficultyHitObject
 import com.rian.osu.mods.Mod
 import com.rian.osu.mods.ModHidden
+import com.rian.osu.mods.ModTraceable
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
@@ -16,6 +18,8 @@ import kotlin.math.pow
 object DroidFlashlightEvaluator {
     private const val MAX_OPACITY_BONUS = 0.4
     private const val HIDDEN_BONUS = 0.2
+    private const val TRACEABLE_CIRCLE_BONUS = 0.15
+    private const val TRACEABLE_OBJECT_BONUS = 0.1
     private const val MIN_VELOCITY = 0.5
     private const val SLIDER_MULTIPLIER = 1.3
     private const val MIN_ANGLE_MULTIPLIER = 0.2
@@ -23,11 +27,12 @@ object DroidFlashlightEvaluator {
     /**
      * Evaluates the difficulty of memorizing and hitting the current object, based on:
      *
-     * * distance between a number of previous objects and the current object,
-     * * the visual opacity of the current object,
-     * * the angle made by the current object,
-     * * length and speed of the current object (for sliders),
-     * * and whether Hidden mod is enabled.
+     * - distance between a number of previous objects and the current object,
+     * - the visual opacity of the current object,
+     * - the angle made by the current object,
+     * - length and speed of the current object (for sliders),
+     * - whether the Hidden mod is enabled,
+     * - and whether the Traceable mod is enabled.
      *
      * @param current The current object.
      * @param mods The mods used.
@@ -85,9 +90,16 @@ object DroidFlashlightEvaluator {
 
         result = (smallDistNerf * result).pow(2)
 
-        // Additional bonus for Hidden due to there being no approach circles.
         if (mods.any { it is ModHidden }) {
+            // Additional bonus for Hidden due to there being no approach circles.
             result *= 1 + HIDDEN_BONUS
+        } else if (mods.any { it is ModTraceable }) {
+            // Additional bonus for Traceable due to there being no primary or secondary object pieces.
+            result *= 1 +
+                // Additional bonus for hit circles due to there being no circle piece, which is the primary piece.
+                if (current.obj is HitCircle) TRACEABLE_CIRCLE_BONUS
+                // The rest of the objects only hide secondary pieces.
+                else TRACEABLE_OBJECT_BONUS
         }
 
         // Nerf patterns with repeated angles.

--- a/src/com/rian/osu/difficulty/evaluators/DroidVisualEvaluator.kt
+++ b/src/com/rian/osu/difficulty/evaluators/DroidVisualEvaluator.kt
@@ -3,6 +3,8 @@ package com.rian.osu.difficulty.evaluators
 import com.rian.osu.beatmap.hitobject.Slider
 import com.rian.osu.beatmap.hitobject.Spinner
 import com.rian.osu.difficulty.DroidDifficultyHitObject
+import com.rian.osu.mods.Mod
+import com.rian.osu.mods.ModHidden
 import kotlin.math.abs
 import kotlin.math.min
 import kotlin.math.pow
@@ -23,11 +25,11 @@ object DroidVisualEvaluator {
      * - and whether the Hidden mod is enabled.
      *
      * @param current The current object.
-     * @param isHiddenMod Whether the Hidden mod is enabled.
+     * @param mods The mods used.
      * @param withSliders Whether to take slider difficulty into account.
      */
     @JvmStatic
-    fun evaluateDifficultyOf(current: DroidDifficultyHitObject, isHiddenMod: Boolean, withSliders: Boolean): Double {
+    fun evaluateDifficultyOf(current: DroidDifficultyHitObject, mods: List<Mod>, withSliders: Boolean): Double {
         if (
             current.obj is Spinner ||
             // Exclude overlapping objects that can be tapped at once.
@@ -40,7 +42,7 @@ object DroidVisualEvaluator {
         // Start with base density and give global bonus for Hidden.
         // Add density caps for sanity.
         var strain =
-            if (isHiddenMod) min(30.0, current.noteDensity.pow(3))
+            if (mods.any { it is ModHidden }) min(30.0, current.noteDensity.pow(3))
             else min(20.0, current.noteDensity.pow(2))
 
         for (i in 0 until min(current.index, 10)) {
@@ -62,7 +64,7 @@ object DroidVisualEvaluator {
                 break
             }
 
-            strain += (1 - current.opacityAt(previous.obj.startTime, isHiddenMod)) / 4
+            strain += (1 - current.opacityAt(previous.obj.startTime, mods)) / 4
         }
 
         if (current.timePreempt < 400) {

--- a/src/com/rian/osu/difficulty/evaluators/StandardFlashlightEvaluator.kt
+++ b/src/com/rian/osu/difficulty/evaluators/StandardFlashlightEvaluator.kt
@@ -3,6 +3,8 @@ package com.rian.osu.difficulty.evaluators
 import com.rian.osu.beatmap.hitobject.Slider
 import com.rian.osu.beatmap.hitobject.Spinner
 import com.rian.osu.difficulty.StandardDifficultyHitObject
+import com.rian.osu.mods.Mod
+import com.rian.osu.mods.ModHidden
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
@@ -22,10 +24,10 @@ object StandardFlashlightEvaluator {
      *  * and whether Hidden mod is enabled.
      *
      * @param current The current object.
-     * @param isHiddenMod Whether the Hidden mod is enabled.
+     * @param mods The mods used.
      */
     @JvmStatic
-    fun evaluateDifficultyOf(current: StandardDifficultyHitObject, isHiddenMod: Boolean): Double {
+    fun evaluateDifficultyOf(current: StandardDifficultyHitObject, mods: List<Mod>): Double {
         // Exclude overlapping objects that can be tapped at once.
         if (current.obj is Spinner) {
             return 0.0
@@ -58,7 +60,7 @@ object StandardFlashlightEvaluator {
 
                 // Bonus based on how visible the object is.
                 val opacityBonus =
-                    1 + 0.4 * (1 - current.opacityAt(currentObject.obj.startTime, isHiddenMod))
+                    1 + 0.4 * (1 - current.opacityAt(currentObject.obj.startTime, mods))
                 result += stackNerf * opacityBonus * scalingFactor * jumpDistance / cumulativeStrainTime
 
                 // Objects further back in time should count less for the nerf.
@@ -74,7 +76,7 @@ object StandardFlashlightEvaluator {
         result = (smallDistNerf * result).pow(2.0)
 
         // Additional bonus for Hidden due to there being no approach circles.
-        if (isHiddenMod) {
+        if (mods.any { it is ModHidden }) {
             val hiddenBonus = 0.2
             result *= 1 + hiddenBonus
         }

--- a/src/com/rian/osu/difficulty/skills/DroidFlashlight.kt
+++ b/src/com/rian/osu/difficulty/skills/DroidFlashlight.kt
@@ -3,7 +3,6 @@ package com.rian.osu.difficulty.skills
 import com.rian.osu.difficulty.DroidDifficultyHitObject
 import com.rian.osu.difficulty.evaluators.DroidFlashlightEvaluator
 import com.rian.osu.mods.Mod
-import com.rian.osu.mods.ModHidden
 import kotlin.math.pow
 
 /**
@@ -29,13 +28,12 @@ class DroidFlashlight(
     private var currentStrain = 0.0
     private val skillMultiplier = 0.02
     private val strainDecayBase = 0.15
-    private val isHidden = mods.any { it is ModHidden }
 
     override fun difficultyValue() = currentStrainPeaks.sum() * starsPerDouble
 
     override fun strainValueAt(current: DroidDifficultyHitObject): Double {
         currentStrain *= strainDecay(current.deltaTime)
-        currentStrain += DroidFlashlightEvaluator.evaluateDifficultyOf(current, isHidden, withSliders) * skillMultiplier
+        currentStrain += DroidFlashlightEvaluator.evaluateDifficultyOf(current, mods, withSliders) * skillMultiplier
 
         objectStrains.add(currentStrain)
         return currentStrain

--- a/src/com/rian/osu/difficulty/skills/DroidVisual.kt
+++ b/src/com/rian/osu/difficulty/skills/DroidVisual.kt
@@ -3,7 +3,6 @@ package com.rian.osu.difficulty.skills
 import com.rian.osu.difficulty.DroidDifficultyHitObject
 import com.rian.osu.difficulty.evaluators.DroidVisualEvaluator
 import com.rian.osu.mods.Mod
-import com.rian.osu.mods.ModHidden
 import kotlin.math.pow
 
 /**
@@ -27,11 +26,10 @@ class DroidVisual(
     private var currentRhythm = 0.0
     private val skillMultiplier = 10
     private val strainDecayBase = 0.1
-    private val isHidden = mods.any { it is ModHidden }
 
     override fun strainValueAt(current: DroidDifficultyHitObject): Double {
         currentStrain *= strainDecay(current.deltaTime)
-        currentStrain += DroidVisualEvaluator.evaluateDifficultyOf(current, isHidden, withSliders) * skillMultiplier
+        currentStrain += DroidVisualEvaluator.evaluateDifficultyOf(current, mods, withSliders) * skillMultiplier
 
         currentRhythm = current.rhythmMultiplier
 

--- a/src/com/rian/osu/difficulty/skills/StandardFlashlight.kt
+++ b/src/com/rian/osu/difficulty/skills/StandardFlashlight.kt
@@ -3,7 +3,6 @@ package com.rian.osu.difficulty.skills
 import com.rian.osu.difficulty.StandardDifficultyHitObject
 import com.rian.osu.difficulty.evaluators.StandardFlashlightEvaluator.evaluateDifficultyOf
 import com.rian.osu.mods.Mod
-import com.rian.osu.mods.ModHidden
 import kotlin.math.pow
 
 /**
@@ -22,11 +21,10 @@ class StandardFlashlight(
     private var currentStrain = 0.0
     private val skillMultiplier = 0.05512
     private val strainDecayBase = 0.15
-    private val hasHidden = mods.any { it is ModHidden }
 
     override fun strainValueAt(current: StandardDifficultyHitObject): Double {
         currentStrain *= strainDecay(current.deltaTime)
-        currentStrain += evaluateDifficultyOf(current, hasHidden) * skillMultiplier
+        currentStrain += evaluateDifficultyOf(current, mods) * skillMultiplier
 
         return currentStrain
     }


### PR DESCRIPTION
- [x] Depends on #502

This adds difficulty calculation for the Traceable mod in osu!droid difficulty calculation. Unlike the osu!standard counterpart, no performance calculation is necessary as all difficulty assessments are done in difficulty calculation.