### PR TITLE
Abstractify `HUDStatisticCounter`

### DIFF
--- a/src/com/reco1l/osu/hud/elements/HUDNotesPerSecondCounter.kt
+++ b/src/com/reco1l/osu/hud/elements/HUDNotesPerSecondCounter.kt
@@ -1,33 +1,13 @@
 package com.reco1l.osu.hud.elements
 
-import com.reco1l.andengine.text.ExtendedText
-import com.reco1l.osu.hud.HUDElement
-import com.reco1l.osu.playfield.SpriteFont
 import com.rian.osu.beatmap.hitobject.HitObject
-import kotlin.collections.ArrayDeque
 import ru.nsu.ccfit.zuev.osu.GlobalManager.getInstance as getGlobal
-import ru.nsu.ccfit.zuev.osu.ResourceManager
-import ru.nsu.ccfit.zuev.skins.OsuSkin
 
-class HUDNotesPerSecondCounter : HUDElement() {
+class HUDNotesPerSecondCounter : HUDStatisticCounter("Notes/sec") {
 
     override val name = "Notes per second counter"
 
-    private val label = ExtendedText().apply {
-        font = ResourceManager.getInstance().getFont("smallFont")
-        text = "Notes/sec"
-    }
-
-    private val value = SpriteFont(OsuSkin.get().scorePrefix).apply {
-        text = "0"
-    }
-
     private val objects = ArrayDeque<HitObject>()
-
-    init {
-        attachChild(label)
-        attachChild(value)
-    }
 
     override fun onHitObjectLifetimeStart(obj: HitObject) {
         objects.add(obj)
@@ -46,9 +26,7 @@ class HUDNotesPerSecondCounter : HUDElement() {
             objects.removeFirst()
         }
 
-        value.text = objects.size.toString()
-        value.y = label.drawHeight
-
+        valueText.text = objects.size.toString()
         super.onManagedUpdate(pSecondsElapsed)
     }
 }

--- a/src/com/reco1l/osu/hud/elements/HUDStatisticsCounters.kt
+++ b/src/com/reco1l/osu/hud/elements/HUDStatisticsCounters.kt
@@ -11,31 +11,18 @@ import ru.nsu.ccfit.zuev.osu.scoring.StatisticV2
 import ru.nsu.ccfit.zuev.skins.*
 
 @Suppress("LeakingThis")
-sealed class HUDStatisticCounter(
-    label: String,
-    tint: ColorARGB,
-    private val dataSupplier: StatisticV2.() -> String
-) : HUDElement() {
+sealed class HUDStatisticCounter(label: String) : HUDElement() {
 
-    private val labelText = ExtendedText().apply {
+    protected val labelText = ExtendedText().apply {
         font = ResourceManager.getInstance().getFont("smallFont")
         text = label
-        color = tint
     }
 
-    private val valueText = SpriteFont(OsuSkin.get().scorePrefix).apply {
-        color = tint
-    }
-
+    protected val valueText = SpriteFont(OsuSkin.get().scorePrefix)
 
     init {
         attachChild(labelText)
         attachChild(valueText)
-    }
-
-
-    override fun onGameplayUpdate(gameScene: GameScene, statistics: StatisticV2, secondsElapsed: Float) {
-        valueText.text = statistics.dataSupplier()
     }
 
     override fun onManagedUpdate(pSecondsElapsed: Float) {
@@ -56,8 +43,23 @@ sealed class HUDStatisticCounter(
     }
 }
 
+sealed class HUDHitStatisticCounter(
+    label: String,
+    tint: ColorARGB,
+    private val dataSupplier: StatisticV2.() -> String
+) : HUDStatisticCounter(label) {
 
-class HUDGreatCounter : HUDStatisticCounter("Great", ColorARGB(0xFF46b4dc),  { hit300.toString() })
-class HUDOkCounter : HUDStatisticCounter("Ok", ColorARGB(0xFF64DC28), { hit100.toString() })
-class HUDMehCounter : HUDStatisticCounter("Meh", ColorARGB(0xFFc8b46e), { hit50.toString() })
-class HUDMissCounter : HUDStatisticCounter("Miss", ColorARGB.Red, { misses.toString() })
+    init {
+        labelText.color = tint
+        valueText.color = tint
+    }
+
+    override fun onGameplayUpdate(gameScene: GameScene, statistics: StatisticV2, secondsElapsed: Float) {
+        valueText.text = statistics.dataSupplier()
+    }
+}
+
+class HUDGreatCounter : HUDHitStatisticCounter("Great", ColorARGB(0xFF46b4dc),  { hit300.toString() })
+class HUDOkCounter : HUDHitStatisticCounter("Ok", ColorARGB(0xFF64DC28), { hit100.toString() })
+class HUDMehCounter : HUDHitStatisticCounter("Meh", ColorARGB(0xFFc8b46e), { hit50.toString() })
+class HUDMissCounter : HUDHitStatisticCounter("Miss", ColorARGB.Red, { misses.toString() })

--- a/src/com/reco1l/osu/hud/elements/HUDTapsPerSecondCounter.kt
+++ b/src/com/reco1l/osu/hud/elements/HUDTapsPerSecondCounter.kt
@@ -1,34 +1,15 @@
 package com.reco1l.osu.hud.elements
 
-import com.reco1l.andengine.text.ExtendedText
-import com.reco1l.osu.hud.HUDElement
-import com.reco1l.osu.playfield.SpriteFont
 import com.reco1l.osu.updateThread
-import ru.nsu.ccfit.zuev.osu.ResourceManager
 import ru.nsu.ccfit.zuev.osu.game.GameHelper
 import ru.nsu.ccfit.zuev.osu.game.GameScene
 import ru.nsu.ccfit.zuev.osu.scoring.StatisticV2
-import ru.nsu.ccfit.zuev.skins.OsuSkin
 
-class HUDTapsPerSecondCounter : HUDElement() {
+class HUDTapsPerSecondCounter : HUDStatisticCounter("Taps/sec") {
 
     override val name = "Taps per second counter"
 
-    private val label = ExtendedText().apply {
-        font = ResourceManager.getInstance().getFont("smallFont")
-        text = "Taps/sec"
-    }
-
-    private val value = SpriteFont(OsuSkin.get().scorePrefix).apply {
-        text = "0"
-    }
-
     private val timestamps = ArrayDeque<Float>(50)
-
-    init {
-        attachChild(label)
-        attachChild(value)
-    }
 
     override fun onGameplayTouchDown(time: Float) {
         // Queue to the update thread to avoid the timestamp queue potentially resizing itself in the main thread.
@@ -42,11 +23,6 @@ class HUDTapsPerSecondCounter : HUDElement() {
             timestamps.removeFirst()
         }
 
-        value.text = timestamps.size.toString()
-    }
-
-    override fun onManagedUpdate(pSecondsElapsed: Float) {
-        value.y = label.drawHeight
-        super.onManagedUpdate(pSecondsElapsed)
+        valueText.text = timestamps.size.toString()
     }
 }


### PR DESCRIPTION
This abstracts `HUDStatisticCounter` so that it can also be used by other statistic-like counters that do not rely on `StatisticV2`, allowing the reuse of auto-anchor logic that was introduced in #504.