### PR TITLE
Fix `HUDElement`s not detaching editor overlay and anchor line when being detached

### DIFF
--- a/src/com/reco1l/osu/hud/HUDElement.kt
+++ b/src/com/reco1l/osu/hud/HUDElement.kt
@@ -327,6 +327,13 @@ abstract class HUDElement : Container(), IGameplayEvents {
         updateConnectionLine()
     }
 
+    override fun detachSelf(): Boolean {
+        editorOverlay?.detachSelf()
+        connectionLine?.detachSelf()
+
+        return super.detachSelf()
+    }
+
     /**
      * Moves the element by the specified delta.
      */


### PR DESCRIPTION
`GameplayHUD` calls `IEntity.detachSelf()` when replacing the current `HUDElement`s with the saved ones. However, the editor overlay and anchor line of an `HUDElement` are attached to `GameplayHUD` and not the `HUDElement` itself. This causes the editor overlay and anchor line to not be detached during the operation, leading to `GameplayHUD` childrens growing continuously as `setSkinData` gets called (or from the user's side, each time they discard changes).

I could choose to change the detaching operation within `GameplayHUD` to call `HUDElement.remove()` instead, but that is not a fool-proof solution.