### PR TITLE
Add support for dynamic speed multiplier adjustment in gameplay via `ModTimeRamp`

### DIFF
--- a/src/com/rian/osu/mods/ModTimeRamp.kt
+++ b/src/com/rian/osu/mods/ModTimeRamp.kt
@@ -28,7 +28,7 @@ abstract class ModTimeRamp : Mod(), IModApplicableToBeatmap, IModApplicableToTra
 
         finalRateTime = Interpolation.linear(
             initialRateTime,
-            beatmap.hitObjects.objects.lastOrNull()?.startTime ?: 0.0,
+            beatmap.hitObjects.objects.lastOrNull()?.endTime ?: 0.0,
             FINAL_RATE_PROGRESS
         )
     }

--- a/src/com/rian/osu/mods/ModTimeRamp.kt
+++ b/src/com/rian/osu/mods/ModTimeRamp.kt
@@ -1,0 +1,48 @@
+package com.rian.osu.mods
+
+import com.rian.osu.beatmap.Beatmap
+import com.rian.osu.math.Interpolation
+import kotlin.math.max
+
+/**
+ * Represents a [Mod] that gradually adjusts the track's playback rate over time.
+ */
+abstract class ModTimeRamp : Mod(), IModApplicableToBeatmap, IModApplicableToTrackRate {
+    /**
+     * The starting speed of the track.
+     */
+    abstract var initialRate: Float
+
+    /**
+     * The final speed to ramp to.
+     */
+    abstract var finalRate: Float
+
+    final override val isValidForMultiplayerAsFreeMod = false
+
+    private var initialRateTime = 0.0
+    private var finalRateTime = 0.0
+
+    override fun applyToBeatmap(beatmap: Beatmap) {
+        initialRateTime = beatmap.hitObjects.objects.firstOrNull()?.startTime ?: 0.0
+
+        finalRateTime = Interpolation.linear(
+            initialRateTime,
+            beatmap.hitObjects.objects.lastOrNull()?.startTime ?: 0.0,
+            FINAL_RATE_PROGRESS
+        )
+    }
+
+    override fun applyToRate(time: Double, rate: Float): Float {
+        val amount = (time - initialRateTime) / max(1.0, finalRateTime - initialRateTime)
+
+        return rate * Interpolation.linear(initialRate, finalRate, amount.toFloat().coerceIn(0f, 1f))
+    }
+
+    companion object {
+        /**
+         * The point in the beatmap at which the final rate should be reached.
+         */
+        const val FINAL_RATE_PROGRESS = 0.75
+    }
+}

--- a/src/com/rian/osu/utils/ModUtils.kt
+++ b/src/com/rian/osu/utils/ModUtils.kt
@@ -125,6 +125,19 @@ object ModUtils {
     }
 
     /**
+     * Calculates the playback rate for the track with the selected [IModApplicableToTrackRate]s at [time].
+     *
+     * @param mods The list of selected [IModApplicableToTrackRate]s.
+     * @param time The time at which the playback rate is queried, in milliseconds. Defaults to 0.
+     * @return The rate with [IModApplicableToTrackRate]s.
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun calculateRateWithMods(mods: Iterable<IModApplicableToTrackRate>, time: Double = 0.0) = mods.fold(1f) {
+        rate, mod -> mod.applyToRate(time, rate)
+    }
+
+    /**
      * Applies the selected [Mod]s to a [BeatmapDifficulty].
      *
      * @param difficulty The [BeatmapDifficulty] to apply the [Mod]s to.

--- a/src/com/rian/osu/utils/ModUtils.kt
+++ b/src/com/rian/osu/utils/ModUtils.kt
@@ -133,6 +133,7 @@ object ModUtils {
      */
     @JvmStatic
     @JvmOverloads
+    @JvmName("calculateRateWithTrackRateMods")
     fun calculateRateWithMods(mods: Iterable<IModApplicableToTrackRate>, time: Double = 0.0) = mods.fold(1f) {
         rate, mod -> mod.applyToRate(time, rate)
     }

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -58,6 +58,7 @@ import com.rian.osu.difficulty.attributes.TimedDifficultyAttributes;
 import com.rian.osu.mods.*;
 import com.rian.osu.ui.FPSCounter;
 import com.rian.osu.utils.ModHashMap;
+import com.rian.osu.utils.ModUtils;
 
 import org.anddev.andengine.engine.Engine;
 import org.anddev.andengine.engine.camera.Camera;
@@ -170,6 +171,7 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
     private LinePath[] sliderRenderPaths = null;
     private int sliderIndex = 0;
     private ExtendedSprite unrankedSprite;
+    private final ArrayList<Mod> rateAdjustingMods = new ArrayList<>();
 
     private StoryboardSprite storyboardSprite;
 
@@ -424,6 +426,14 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
         }
 
         playableBeatmap = parsedBeatmap.createDroidPlayableBeatmap(mods.values());
+
+        rateAdjustingMods.clear();
+
+        for (var mod : mods.values()) {
+            if (mod instanceof IModApplicableToTrackRate) {
+                rateAdjustingMods.add(mod);
+            }
+        }
 
         // TODO skin manager
         BeatmapSkinManager.getInstance().loadBeatmapSkin(playableBeatmap.getBeatmapsetPath());
@@ -1008,6 +1018,12 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
         }
 
         final float mSecPassed = elapsedTime * 1000;
+
+        GameHelper.setSpeedMultiplier(ModUtils.calculateRateWithMods(rateAdjustingMods, mSecPassed));
+
+        if (musicStarted) {
+            GlobalManager.getInstance().getSongService().setSpeed(GameHelper.getSpeedMultiplier());
+        }
 
         if (Config.isEnableStoryboard()) {
             if (storyboardSprite != null) {

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -171,7 +171,7 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
     private LinePath[] sliderRenderPaths = null;
     private int sliderIndex = 0;
     private ExtendedSprite unrankedSprite;
-    private final ArrayList<Mod> rateAdjustingMods = new ArrayList<>();
+    private final ArrayList<IModApplicableToTrackRate> rateAdjustingMods = new ArrayList<>();
 
     private StoryboardSprite storyboardSprite;
 
@@ -430,8 +430,8 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
         rateAdjustingMods.clear();
 
         for (var mod : mods.values()) {
-            if (mod instanceof IModApplicableToTrackRate) {
-                rateAdjustingMods.add(mod);
+            if (mod instanceof IModApplicableToTrackRate rateMod) {
+                rateAdjustingMods.add(rateMod);
             }
         }
 

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -1018,7 +1018,7 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
         }
 
         final float mSecPassed = elapsedTime * 1000;
-        float currentSpeedMultiplier = ModUtils.calculateRateWithMods(rateAdjustingMods, mSecPassed);
+        float currentSpeedMultiplier = ModUtils.calculateRateWithTrackRateMods(rateAdjustingMods, mSecPassed);
 
         if (currentSpeedMultiplier != GameHelper.getSpeedMultiplier()) {
             GameHelper.setSpeedMultiplier(currentSpeedMultiplier);

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -1018,11 +1018,14 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
         }
 
         final float mSecPassed = elapsedTime * 1000;
+        float currentSpeedMultiplier = ModUtils.calculateRateWithMods(rateAdjustingMods, mSecPassed);
 
-        GameHelper.setSpeedMultiplier(ModUtils.calculateRateWithMods(rateAdjustingMods, mSecPassed));
+        if (currentSpeedMultiplier != GameHelper.getSpeedMultiplier()) {
+            GameHelper.setSpeedMultiplier(currentSpeedMultiplier);
 
-        if (musicStarted) {
-            GlobalManager.getInstance().getSongService().setSpeed(GameHelper.getSpeedMultiplier());
+            if (musicStarted) {
+                GlobalManager.getInstance().getSongService().setSpeed(currentSpeedMultiplier);
+            }
         }
 
         if (Config.isEnableStoryboard()) {


### PR DESCRIPTION
This PR adds support for dynamically adjusting speed multiplier in gameplay via `ModTimeRamp`.

Of note, I only PR'd this because I do not need to touch `GameMod` (which will be replaced in the upcoming mods storage rework). I have the implementation of `ModWindUp` ready from this PR, but I will not PR (and not recommend anyone) to test it until the rework is done and merged.