### PR TITLE
Partially match stacking behavior with osu!stable

### DIFF
--- a/res/values/strings_temporary_for_locals.xml
+++ b/res/values/strings_temporary_for_locals.xml
@@ -13,5 +13,6 @@
     <string name="mod_section_difficulty_automation">Automation</string>
     <string name="mod_section_difficulty_conversion">Conversion</string>
     <string name="mod_section_fun">Fun</string>
+    <string name="mod_section_system">System</string>
 
 </resources>

--- a/src/com/edlplan/replay/OsuDroidReplayPack.java
+++ b/src/com/edlplan/replay/OsuDroidReplayPack.java
@@ -124,7 +124,7 @@ public class OsuDroidReplayPack {
             // Additionally, it uses the legacy mods format and needs to be converted.
             var oldMods = replayData.getString("mod");
 
-            replayData.put("mods", LegacyModConverter.convert(oldMods).serializeMods().toString());
+            replayData.put("mods", LegacyModConverter.convert(oldMods).serializeMods(false).toString());
             replayData.remove("mod");
         }
 

--- a/src/com/osudroid/ui/v2/modmenu/ModMenu.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModMenu.kt
@@ -195,7 +195,7 @@ object ModMenu : ExtendedScene() {
 
                     ModType.entries.forEach { type ->
                         val sectionName = StringTable.get(type.stringId)
-                        val sectionMods = mods.filter { it !is IMigratableMod && it.type == type }
+                        val sectionMods = mods.filter { it !is IMigratableMod && it.isUserPlayable && it.type == type }
 
                         if (sectionMods.isNotEmpty()) {
                             +ModMenuSection(sectionName, sectionMods)

--- a/src/com/rian/osu/beatmap/Beatmap.kt
+++ b/src/com/rian/osu/beatmap/Beatmap.kt
@@ -124,7 +124,7 @@ open class Beatmap(
 
         mods?.filterIsInstance<IModApplicableToBeatmap>()?.forEach {
             scope?.ensureActive()
-            it.applyToBeatmap(converted)
+            it.applyToBeatmap(converted, scope)
         }
 
         return converted

--- a/src/com/rian/osu/beatmap/hitobject/HitObject.kt
+++ b/src/com/rian/osu/beatmap/hitobject/HitObject.kt
@@ -150,7 +150,7 @@ abstract class HitObject(
     /**
      * The multiplier used to calculate stack offset.
      */
-    open var stackOffsetMultiplier = 0f
+    open var stackOffsetMultiplier = -6.4f
         set(value) {
             field = value
 
@@ -336,11 +336,6 @@ abstract class HitObject(
         // Note that this doesn't exactly match the AR>10 visuals as they're classically known, but it feels good.
         // This adjustment is necessary for AR>10, otherwise timePreempt can become smaller leading to hit circles not fully fading in.
         timeFadeIn = 400 * min(1.0, timePreempt / PREEMPT_MIN)
-
-        stackOffsetMultiplier = when (mode) {
-            GameMode.Droid -> 4f
-            GameMode.Standard -> -6.4f
-        }
 
         difficultyScale = when (mode) {
             GameMode.Droid -> {

--- a/src/com/rian/osu/beatmap/hitobject/HitObject.kt
+++ b/src/com/rian/osu/beatmap/hitobject/HitObject.kt
@@ -150,7 +150,7 @@ abstract class HitObject(
     /**
      * The multiplier used to calculate stack offset.
      */
-    open var stackOffsetMultiplier = -6.4f
+    open var stackOffsetMultiplier = 0f
         set(value) {
             if (field != value) {
                 field = value
@@ -342,6 +342,11 @@ abstract class HitObject(
         // Note that this doesn't exactly match the AR>10 visuals as they're classically known, but it feels good.
         // This adjustment is necessary for AR>10, otherwise timePreempt can become smaller leading to hit circles not fully fading in.
         timeFadeIn = 400 * min(1.0, timePreempt / PREEMPT_MIN)
+
+        stackOffsetMultiplier = when (mode) {
+            GameMode.Droid -> -4f
+            GameMode.Standard -> -6.4f
+        }
 
         difficultyScale = when (mode) {
             GameMode.Droid -> {

--- a/src/com/rian/osu/beatmap/hitobject/HitObject.kt
+++ b/src/com/rian/osu/beatmap/hitobject/HitObject.kt
@@ -152,12 +152,14 @@ abstract class HitObject(
      */
     open var stackOffsetMultiplier = -6.4f
         set(value) {
-            field = value
+            if (field != value) {
+                field = value
 
-            difficultyStackOffsetCache.invalidate()
-            difficultyStackedPositionCache.invalidate()
-            gameplayStackOffsetCache.invalidate()
-            gameplayStackedPositionCache.invalidate()
+                difficultyStackOffsetCache.invalidate()
+                difficultyStackedPositionCache.invalidate()
+                gameplayStackOffsetCache.invalidate()
+                gameplayStackedPositionCache.invalidate()
+            }
         }
 
     // Difficulty calculation object positions
@@ -167,10 +169,12 @@ abstract class HitObject(
      */
     open var difficultyStackHeight = 0
         set(value) {
-            field = value
+            if (field != value) {
+                field = value
 
-            difficultyStackOffsetCache.invalidate()
-            difficultyStackedPositionCache.invalidate()
+                difficultyStackOffsetCache.invalidate()
+                difficultyStackedPositionCache.invalidate()
+            }
         }
 
     /**
@@ -232,10 +236,12 @@ abstract class HitObject(
      */
     open var gameplayStackHeight = 0
         set(value) {
-            field = value
+            if (field != value) {
+                field = value
 
-            gameplayStackOffsetCache.invalidate()
-            gameplayStackedPositionCache.invalidate()
+                gameplayStackOffsetCache.invalidate()
+                gameplayStackedPositionCache.invalidate()
+            }
         }
 
     /**

--- a/src/com/rian/osu/beatmap/hitobject/Slider.kt
+++ b/src/com/rian/osu/beatmap/hitobject/Slider.kt
@@ -197,11 +197,14 @@ class Slider(
     override var difficultyStackHeight
         get() = super.difficultyStackHeight
         set(value) {
+            val wasEqual = super.difficultyStackHeight == value
+
             super.difficultyStackHeight = value
 
-            difficultyStackedEndPositionCache.invalidate()
-
-            nestedHitObjects.forEach { it.difficultyStackHeight = value }
+            if (!wasEqual) {
+                difficultyStackedEndPositionCache.invalidate()
+                nestedHitObjects.forEach { it.difficultyStackHeight = value }
+            }
         }
 
     override var difficultyScale
@@ -241,11 +244,14 @@ class Slider(
     override var gameplayStackHeight
         get() = super.gameplayStackHeight
         set(value) {
+            val wasEqual = super.gameplayStackHeight == value
+
             super.gameplayStackHeight = value
 
-            gameplayStackedEndPositionCache.invalidate()
-
-            nestedHitObjects.forEach { it.gameplayStackHeight = value }
+            if (!wasEqual) {
+                gameplayStackedEndPositionCache.invalidate()
+                nestedHitObjects.forEach { it.gameplayStackHeight = value }
+            }
         }
 
     override var gameplayScale

--- a/src/com/rian/osu/difficulty/calculator/DroidDifficultyCalculator.kt
+++ b/src/com/rian/osu/difficulty/calculator/DroidDifficultyCalculator.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.ensureActive
 class DroidDifficultyCalculator : DifficultyCalculator<DroidPlayableBeatmap, DroidDifficultyHitObject, DroidDifficultyAttributes>() {
     override val difficultyMultiplier = 0.18
     override val difficultyAdjustmentMods = super.difficultyAdjustmentMods +
-        setOf(ModPrecise::class, ModScoreV2::class, ModTraceable::class)
+        setOf(ModPrecise::class, ModScoreV2::class, ModTraceable::class, ModReplayV6::class)
 
     private val maximumSectionDeltaTime = 2000
     private val minimumSectionObjectCount = 5

--- a/src/com/rian/osu/mods/IModApplicableToBeatmap.kt
+++ b/src/com/rian/osu/mods/IModApplicableToBeatmap.kt
@@ -1,6 +1,7 @@
 package com.rian.osu.mods
 
 import com.rian.osu.beatmap.Beatmap
+import kotlinx.coroutines.CoroutineScope
 
 /**
  * An interface for [Mod]s that applies changes to a [Beatmap] after conversion and post-processing has completed.
@@ -10,6 +11,7 @@ interface IModApplicableToBeatmap {
      * Applies this [IModApplicableToBeatmap] to a [Beatmap].
      *
      * @param beatmap The [Beatmap] to apply to.
+     * @param scope The [CoroutineScope] to use for the operation.
      */
-    fun applyToBeatmap(beatmap: Beatmap)
+    fun applyToBeatmap(beatmap: Beatmap, scope: CoroutineScope? = null)
 }

--- a/src/com/rian/osu/mods/Mod.kt
+++ b/src/com/rian/osu/mods/Mod.kt
@@ -53,6 +53,13 @@ sealed class Mod {
     open val isRelevant = true
 
     /**
+     * Whether this [Mod] is playable by a real human user.
+     *
+     * Should be `false` for cases where the user is not meant to apply the [Mod] by themselves.
+     */
+    open val isUserPlayable = true
+
+    /**
      * Whether this [Mod] is valid for multiplayer matches.
      *
      * Should be `false` for [Mod]s that make gameplay duration different across players.

--- a/src/com/rian/osu/mods/ModHidden.kt
+++ b/src/com/rian/osu/mods/ModHidden.kt
@@ -4,6 +4,7 @@ import com.rian.osu.beatmap.Beatmap
 import com.rian.osu.beatmap.hitobject.HitObject
 import com.rian.osu.beatmap.hitobject.Slider
 import com.rian.osu.beatmap.sections.BeatmapDifficulty
+import kotlinx.coroutines.CoroutineScope
 
 /**
  * Represents the Hidden mod.
@@ -18,7 +19,7 @@ class ModHidden : Mod(), IModApplicableToBeatmap {
 
     override fun calculateScoreMultiplier(difficulty: BeatmapDifficulty) = 1.06f
 
-    override fun applyToBeatmap(beatmap: Beatmap) {
+    override fun applyToBeatmap(beatmap: Beatmap, scope: CoroutineScope?) {
         fun applyFadeInAdjustment(hitObject: HitObject) {
             hitObject.timeFadeIn = hitObject.timePreempt * FADE_IN_DURATION_MULTIPLIER
 

--- a/src/com/rian/osu/mods/ModReplayV6.kt
+++ b/src/com/rian/osu/mods/ModReplayV6.kt
@@ -56,9 +56,6 @@ class ModReplayV6 : Mod(), IModApplicableToBeatmap {
             val current = objects[i]
             val next = objects[i + 1]
 
-            current.stackOffsetMultiplier = 4f
-            next.stackOffsetMultiplier = 4f
-
             if (current is HitCircle && next.startTime - current.startTime < maxDeltaTime) {
                 val distanceSquared = next.position.getDistance(current.position).pow(2)
 

--- a/src/com/rian/osu/mods/ModReplayV6.kt
+++ b/src/com/rian/osu/mods/ModReplayV6.kt
@@ -47,6 +47,7 @@ class ModReplayV6 : Mod(), IModApplicableToBeatmap {
             val current = objects[i]
             val next = objects[i + 1]
 
+            current.stackOffsetMultiplier = 4f
             next.stackOffsetMultiplier = 4f
 
             if (current is HitCircle && next.startTime - current.startTime < maxDeltaTime) {

--- a/src/com/rian/osu/mods/ModReplayV6.kt
+++ b/src/com/rian/osu/mods/ModReplayV6.kt
@@ -1,0 +1,60 @@
+package com.rian.osu.mods
+
+import com.rian.osu.beatmap.Beatmap
+import com.rian.osu.beatmap.hitobject.HitCircle
+import com.rian.osu.utils.CircleSizeCalculator
+import kotlin.math.pow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ensureActive
+
+/**
+ * Represents the Replay V6 mod.
+ *
+ * Some behavior of beatmap parsing was changed in replay version 7. More specifically, stacking behavior now matches
+ * osu!stable and osu!lazer.
+ *
+ * This mod is meant to reapply the stacking behavior prior to replay version 7 to a [Beatmap] that was played in
+ * replays recorded in version 6 and older for replayability and difficulty calculation.
+ */
+class ModReplayV6 : Mod(), IModApplicableToBeatmap {
+    override val name = "Replay V6"
+    override val acronym = "RV6"
+    override val description = "Applies the old behavior of stacking to a beatmap."
+    override val type = ModType.System
+
+    override val isUserPlayable = false
+
+    override fun applyToBeatmap(beatmap: Beatmap, scope: CoroutineScope?) {
+        val objects = beatmap.hitObjects.objects
+
+        if (objects.isEmpty()) {
+            return
+        }
+
+        val droidDifficultyScale =
+            CircleSizeCalculator.standardScaleToDroidDifficultyScale(objects[0].difficultyScale, true)
+
+        val maxDeltaTime = 2000 * beatmap.general.stackLeniency
+
+        for (i in 0 until objects.size - 1) {
+            scope?.ensureActive()
+
+            val current = objects[i]
+            val next = objects[i + 1]
+
+            if (current is HitCircle && next.startTime - current.startTime < maxDeltaTime) {
+                val distanceSquared = next.position.getDistance(current.position).pow(2)
+
+                next.difficultyStackHeight =
+                    if (distanceSquared < droidDifficultyScale) current.difficultyStackHeight + 1
+                    else 0
+
+                next.gameplayStackHeight =
+                    if (distanceSquared < current.gameplayScale) current.gameplayStackHeight + 1
+                    else 0
+            }
+        }
+    }
+
+    override fun deepCopy() = ModReplayV6()
+}

--- a/src/com/rian/osu/mods/ModReplayV6.kt
+++ b/src/com/rian/osu/mods/ModReplayV6.kt
@@ -11,8 +11,8 @@ import kotlinx.coroutines.ensureActive
 /**
  * Represents the Replay V6 mod.
  *
- * Some behavior of beatmap parsing was changed in replay version 7. More specifically, stacking behavior now matches
- * osu!stable and osu!lazer.
+ * Some behavior of beatmap parsing was changed in replay version 7. More specifically, object stacking behavior now
+ * matches osu!stable and osu!lazer.
  *
  * This [Mod] is meant to reapply the stacking behavior prior to replay version 7 to a [Beatmap] that was played in
  * replays recorded in version 6 and older for replayability and difficulty calculation.
@@ -20,7 +20,7 @@ import kotlinx.coroutines.ensureActive
 class ModReplayV6 : Mod(), IModApplicableToBeatmap {
     override val name = "Replay V6"
     override val acronym = "RV6"
-    override val description = "Applies the old behavior of stacking to a beatmap."
+    override val description = "Applies the old object stacking behavior to a beatmap."
     override val type = ModType.System
 
     override val isUserPlayable = false

--- a/src/com/rian/osu/mods/ModReplayV6.kt
+++ b/src/com/rian/osu/mods/ModReplayV6.kt
@@ -1,5 +1,6 @@
 package com.rian.osu.mods
 
+import com.rian.osu.GameMode
 import com.rian.osu.beatmap.Beatmap
 import com.rian.osu.beatmap.hitobject.HitCircle
 import com.rian.osu.utils.CircleSizeCalculator
@@ -25,6 +26,10 @@ class ModReplayV6 : Mod(), IModApplicableToBeatmap {
     override val isUserPlayable = false
 
     override fun applyToBeatmap(beatmap: Beatmap, scope: CoroutineScope?) {
+        if (beatmap.mode != GameMode.Droid) {
+            return
+        }
+
         val objects = beatmap.hitObjects.objects
 
         if (objects.isEmpty()) {

--- a/src/com/rian/osu/mods/ModReplayV6.kt
+++ b/src/com/rian/osu/mods/ModReplayV6.kt
@@ -4,6 +4,7 @@ import com.rian.osu.GameMode
 import com.rian.osu.beatmap.Beatmap
 import com.rian.osu.beatmap.hitobject.HitCircle
 import com.rian.osu.utils.CircleSizeCalculator
+import kotlin.collections.forEach
 import kotlin.math.pow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ensureActive
@@ -36,6 +37,14 @@ class ModReplayV6 : Mod(), IModApplicableToBeatmap {
             return
         }
 
+        // Reset stacking
+        objects.forEach {
+            scope?.ensureActive()
+
+            it.difficultyStackHeight = 0
+            it.gameplayStackHeight = 0
+        }
+
         val droidDifficultyScale =
             CircleSizeCalculator.standardScaleToDroidDifficultyScale(objects[0].difficultyScale, true)
 
@@ -53,13 +62,13 @@ class ModReplayV6 : Mod(), IModApplicableToBeatmap {
             if (current is HitCircle && next.startTime - current.startTime < maxDeltaTime) {
                 val distanceSquared = next.position.getDistance(current.position).pow(2)
 
-                next.difficultyStackHeight =
-                    if (distanceSquared < droidDifficultyScale) current.difficultyStackHeight + 1
-                    else 0
+                if (distanceSquared < droidDifficultyScale) {
+                    next.difficultyStackHeight = current.difficultyStackHeight + 1
+                }
 
-                next.gameplayStackHeight =
-                    if (distanceSquared < current.gameplayScale) current.gameplayStackHeight + 1
-                    else 0
+                if (distanceSquared < current.gameplayScale) {
+                    next.gameplayStackHeight = current.gameplayStackHeight + 1
+                }
             }
         }
     }

--- a/src/com/rian/osu/mods/ModReplayV6.kt
+++ b/src/com/rian/osu/mods/ModReplayV6.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.ensureActive
  * Some behavior of beatmap parsing was changed in replay version 7. More specifically, stacking behavior now matches
  * osu!stable and osu!lazer.
  *
- * This mod is meant to reapply the stacking behavior prior to replay version 7 to a [Beatmap] that was played in
+ * This [Mod] is meant to reapply the stacking behavior prior to replay version 7 to a [Beatmap] that was played in
  * replays recorded in version 6 and older for replayability and difficulty calculation.
  */
 class ModReplayV6 : Mod(), IModApplicableToBeatmap {
@@ -41,6 +41,8 @@ class ModReplayV6 : Mod(), IModApplicableToBeatmap {
 
             val current = objects[i]
             val next = objects[i + 1]
+
+            next.stackOffsetMultiplier = 4f
 
             if (current is HitCircle && next.startTime - current.startTime < maxDeltaTime) {
                 val distanceSquared = next.position.getDistance(current.position).pow(2)

--- a/src/com/rian/osu/mods/ModTimeRamp.kt
+++ b/src/com/rian/osu/mods/ModTimeRamp.kt
@@ -3,6 +3,7 @@ package com.rian.osu.mods
 import com.rian.osu.beatmap.Beatmap
 import com.rian.osu.math.Interpolation
 import kotlin.math.max
+import kotlinx.coroutines.CoroutineScope
 import org.json.JSONObject
 
 /**
@@ -37,7 +38,7 @@ abstract class ModTimeRamp : Mod(), IModApplicableToBeatmap, IModApplicableToTra
         put("finalRate", finalRate)
     }
 
-    override fun applyToBeatmap(beatmap: Beatmap) {
+    override fun applyToBeatmap(beatmap: Beatmap, scope: CoroutineScope?) {
         initialRateTime = beatmap.hitObjects.objects.firstOrNull()?.startTime ?: 0.0
 
         finalRateTime = Interpolation.linear(

--- a/src/com/rian/osu/mods/ModType.kt
+++ b/src/com/rian/osu/mods/ModType.kt
@@ -17,4 +17,5 @@ enum class ModType(
     Automation(R.string.mod_section_difficulty_automation),
     Conversion(R.string.mod_section_difficulty_conversion),
     Fun(R.string.mod_section_fun),
+    System(R.string.mod_section_system),
 }

--- a/src/com/rian/osu/utils/ModHashMap.kt
+++ b/src/com/rian/osu/utils/ModHashMap.kt
@@ -308,7 +308,8 @@ open class ModHashMap : HashMap<Class<out Mod>, Mod> {
             ModPerfect(),
             ModSuddenDeath(),
             ModSynesthesia(),
-            ModScoreV2()
+            ModScoreV2(),
+            ModReplayV6()
         )
     }
 }

--- a/src/com/rian/osu/utils/ModHashMap.kt
+++ b/src/com/rian/osu/utils/ModHashMap.kt
@@ -164,8 +164,12 @@ open class ModHashMap : HashMap<Class<out Mod>, Mod> {
 
     /**
      * Serializes the [Mod]s in this [ModHashMap] to a [JSONArray].
+     *
+     * @param includeNonUserPlayable Whether to include non-user-playable [Mod]s in the serialization.
+     * Defaults to `true`.
      */
-    fun serializeMods() = ModUtils.serializeMods(values)
+    @JvmOverloads
+    fun serializeMods(includeNonUserPlayable: Boolean = true) = ModUtils.serializeMods(values, includeNonUserPlayable)
 
     /**
      * Converts the container [Mod]s in this [ModHashMap] to their [String] representative.

--- a/src/com/rian/osu/utils/ModUtils.kt
+++ b/src/com/rian/osu/utils/ModUtils.kt
@@ -36,6 +36,7 @@ object ModUtils {
             ModPrecise(),
             ModReallyEasy(),
             ModRelax(),
+            ModReplayV6(),
             ModScoreV2(),
             ModSmallCircle(),
             ModSuddenDeath(),

--- a/src/com/rian/osu/utils/ModUtils.kt
+++ b/src/com/rian/osu/utils/ModUtils.kt
@@ -54,11 +54,17 @@ object ModUtils {
      * The serialized [Mod]s can be deserialized using [deserializeMods].
      *
      * @param mods The list of [Mod]s to serialize.
+     * @param includeNonUserPlayable Whether to serialize non-user-playable [Mod]s. Defaults to true.
      * @return The serialized [Mod]s in a [JSONArray].
      */
     @JvmStatic
-    fun serializeMods(mods: Iterable<Mod>) = JSONArray().also {
+    @JvmOverloads
+    fun serializeMods(mods: Iterable<Mod>, includeNonUserPlayable: Boolean = true) = JSONArray().also {
         for (mod in mods) {
+            if (!includeNonUserPlayable && !mod.isUserPlayable) {
+                continue
+            }
+
             it.put(mod.serialize())
         }
     }

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -920,6 +920,10 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
         float timeOffset = 0;
 
         for (var mod : lastMods.values()) {
+            if (!mod.isUserPlayable()) {
+                continue;
+            }
+
             var effect = GameObjectPool.getInstance().getEffect(mod.getTextureName());
 
             effect.init(fgScene, position, scale, Modifiers.sequence(

--- a/src/ru/nsu/ccfit/zuev/osu/scoring/Replay.java
+++ b/src/ru/nsu/ccfit/zuev/osu/scoring/Replay.java
@@ -328,7 +328,7 @@ public class Replay {
         Version 4: Adds ExtraModString's save and load in save()/load()/loadInfo()
         Version 5: Changes coordinates to use the float primitive type
         Version 6: Removed accuracy and perfect, slider ends no longer give combo when not hit
-        Version 7: Reworked mod storage to not serialize GameMod
+        Version 7: Reworked mod storage to not serialize GameMod, object stacking behavior overhaul
      */
     public static class ReplayVersion implements Serializable {
         private static final long serialVersionUID = 4643121693566795335L;

--- a/src/ru/nsu/ccfit/zuev/osu/scoring/Replay.java
+++ b/src/ru/nsu/ccfit/zuev/osu/scoring/Replay.java
@@ -6,6 +6,7 @@ import androidx.annotation.NonNull;
 
 import com.rian.osu.mods.LegacyModConverter;
 import com.rian.osu.mods.ModHardRock;
+import com.rian.osu.mods.ModReplayV6;
 import com.rian.osu.utils.ModHashMap;
 import com.rian.osu.utils.ModUtils;
 
@@ -250,6 +251,7 @@ public class Replay {
                         }
 
                         stat.setMod(LegacyModConverter.convert(mod, extraModString));
+                        stat.getMod().put(new ModReplayV6());
                     }
                 }
 

--- a/src/ru/nsu/ccfit/zuev/osu/scoring/ScoringScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/scoring/ScoringScene.java
@@ -323,6 +323,10 @@ public class ScoringScene {
         var modX = mark.getX() - 30;
         var modY = mark.getY() + mark.getHeight() * 2 / 3;
         for (var mod : mods.values()) {
+            if (!mod.isUserPlayable()) {
+                continue;
+            }
+
             var modSprite = new Sprite(modX, modY, ResourceManager.getInstance().getTexture(mod.getTextureName()));
             modX -= 30;
             scene.attachChild(modSprite);

--- a/src/ru/nsu/ccfit/zuev/osu/scoring/StatisticV2.java
+++ b/src/ru/nsu/ccfit/zuev/osu/scoring/StatisticV2.java
@@ -575,7 +575,7 @@ public class StatisticV2 implements Serializable {
             beatmapMD5,
             playerName,
             replayFilename,
-            mod.serializeMods().toString(),
+            mod.serializeMods(false).toString(),
             getTotalScoreWithMultiplier(),
             scoreMaxCombo,
             getMark(),

--- a/tests/test/kotlin/com/rian/osu/difficulty/calculator/DroidDifficultyCalculatorTest.kt
+++ b/tests/test/kotlin/com/rian/osu/difficulty/calculator/DroidDifficultyCalculatorTest.kt
@@ -36,12 +36,12 @@ class DroidDifficultyCalculatorTest {
 
         calculator.calculate(beatmap).apply {
             // These results are off by a margin from server-side results due to floating point differences.
-            Assert.assertEquals(aimDifficulty, 2.5694955103340424, 1e-5)
+            Assert.assertEquals(2.5686593810525644, aimDifficulty, 1e-5)
             Assert.assertEquals(tapDifficulty, 1.4928164438079188, 1e-5)
             Assert.assertEquals(rhythmDifficulty, 0.8031331688998974, 1e-5)
             Assert.assertEquals(flashlightDifficulty, 0.0, 1e-5)
             Assert.assertEquals(visualDifficulty, 0.7809831991279115, 1e-5)
-            Assert.assertEquals(starRating, 4.043497848534318, 1e-6)
+            Assert.assertEquals(4.042873079569523, starRating, 1e-6)
         }
     }
 }

--- a/tests/test/kotlin/com/rian/osu/difficulty/calculator/DroidDifficultyCalculatorTest.kt
+++ b/tests/test/kotlin/com/rian/osu/difficulty/calculator/DroidDifficultyCalculatorTest.kt
@@ -37,11 +37,11 @@ class DroidDifficultyCalculatorTest {
         calculator.calculate(beatmap).apply {
             // These results are off by a margin from server-side results due to floating point differences.
             Assert.assertEquals(2.5686593810525644, aimDifficulty, 1e-5)
-            Assert.assertEquals(tapDifficulty, 1.4928164438079188, 1e-5)
-            Assert.assertEquals(rhythmDifficulty, 0.8031331688998974, 1e-5)
-            Assert.assertEquals(flashlightDifficulty, 0.0, 1e-5)
-            Assert.assertEquals(visualDifficulty, 0.7809831991279115, 1e-5)
-            Assert.assertEquals(4.042873079569523, starRating, 1e-6)
+            Assert.assertEquals(1.4928164438079188, tapDifficulty, 1e-5)
+            Assert.assertEquals(0.8031331688998974, rhythmDifficulty, 1e-5)
+            Assert.assertEquals(0.0, flashlightDifficulty, 1e-5)
+            Assert.assertEquals(0.7809831991279115, visualDifficulty, 1e-5)
+            Assert.assertEquals(4.042875478100303, starRating, 1e-6)
         }
     }
 }

--- a/tests/test/kotlin/com/rian/osu/difficulty/calculator/StandardDifficultyCalculatorTest.kt
+++ b/tests/test/kotlin/com/rian/osu/difficulty/calculator/StandardDifficultyCalculatorTest.kt
@@ -32,14 +32,14 @@ class StandardDifficultyCalculatorTest {
                 TestResourceManager.getBeatmapFile(
                     "YOASOBI - Love Letter (ohm002) [Please accept my overflowing emotions.]"
                 )!!
-            ).parse(true, GameMode.Droid)!!
+            ).parse(true, GameMode.Standard)!!
 
         calculator.calculate(beatmap).apply {
             // These results are off by a margin from server-side results due to floating point differences.
-            Assert.assertEquals(aimDifficulty, 2.4086917511345836, 1e-5)
-            Assert.assertEquals(speedDifficulty, 1.8083767275879148, 1e-5)
-            Assert.assertEquals(flashlightDifficulty, 0.0, 1e-5)
-            Assert.assertEquals(starRating, 4.521063460612202, 1e-6)
+            Assert.assertEquals(2.413839842506594, aimDifficulty, 1e-5)
+            Assert.assertEquals(1.808471044396375, speedDifficulty, 1e-5)
+            Assert.assertEquals(0.0, flashlightDifficulty, 1e-5)
+            Assert.assertEquals(4.528123418924582, starRating, 1e-6)
         }
     }
 }

--- a/tests/test/kotlin/com/rian/osu/mods/ModReplayV6Test.kt
+++ b/tests/test/kotlin/com/rian/osu/mods/ModReplayV6Test.kt
@@ -18,11 +18,9 @@ class ModReplayV6Test {
         val playableBeatmap = beatmap.createDroidPlayableBeatmap(listOf(ModReplayV6()))
         val objects = playableBeatmap.hitObjects.objects
 
-        Assert.assertEquals(4f, objects[0].stackOffsetMultiplier, 1e-5f)
         Assert.assertEquals(0, objects[0].difficultyStackHeight)
         Assert.assertEquals(0, objects[0].gameplayStackHeight)
 
-        Assert.assertEquals(4f, objects[1].stackOffsetMultiplier, 1e-5f)
         Assert.assertEquals(1, objects[1].difficultyStackHeight)
         Assert.assertEquals(1, objects[1].gameplayStackHeight)
     }

--- a/tests/test/kotlin/com/rian/osu/mods/ModReplayV6Test.kt
+++ b/tests/test/kotlin/com/rian/osu/mods/ModReplayV6Test.kt
@@ -1,0 +1,29 @@
+package com.rian.osu.mods
+
+import com.rian.osu.GameMode
+import com.rian.osu.beatmap.Beatmap
+import com.rian.osu.beatmap.hitobject.HitCircle
+import com.rian.osu.math.Vector2
+import org.junit.Assert
+import org.junit.Test
+
+class ModReplayV6Test {
+    @Test
+    fun `Test old object stacking`() {
+        val beatmap = Beatmap(GameMode.Droid).apply {
+            hitObjects.add(HitCircle(0.0, Vector2(0), true, 0))
+            hitObjects.add(HitCircle(75.0, Vector2(0), true, 0))
+        }
+
+        val playableBeatmap = beatmap.createDroidPlayableBeatmap(listOf(ModReplayV6()))
+        val objects = playableBeatmap.hitObjects.objects
+
+        Assert.assertEquals(4f, objects[0].stackOffsetMultiplier, 1e-5f)
+        Assert.assertEquals(0, objects[0].difficultyStackHeight)
+        Assert.assertEquals(0, objects[0].gameplayStackHeight)
+
+        Assert.assertEquals(4f, objects[1].stackOffsetMultiplier, 1e-5f)
+        Assert.assertEquals(1, objects[1].difficultyStackHeight)
+        Assert.assertEquals(1, objects[1].gameplayStackHeight)
+    }
+}

--- a/tests/test/kotlin/com/rian/osu/utils/ModUtilsTest.kt
+++ b/tests/test/kotlin/com/rian/osu/utils/ModUtilsTest.kt
@@ -11,6 +11,7 @@ import com.rian.osu.mods.ModHidden
 import com.rian.osu.mods.ModNightCore
 import com.rian.osu.mods.ModOldNightCore
 import com.rian.osu.mods.ModPrecise
+import com.rian.osu.mods.ModReplayV6
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -19,26 +20,38 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class ModUtilsTest {
     @Test
-    fun `Test mod serialization`() {
-        val serializedMods = ModUtils.serializeMods(
-            listOf(
-                ModAutoplay(),
-                ModCustomSpeed(1.25f),
-                ModHidden()
+    fun `Test mod serialization with non-user playable mods`() {
+        ModUtils.serializeMods(listOf(ModAutoplay(), ModCustomSpeed(1.25f), ModHidden(), ModReplayV6())).apply {
+            Assert.assertEquals(length(), 4)
+            Assert.assertEquals(getJSONObject(0).getString("acronym"), "AT")
+            Assert.assertEquals(getJSONObject(1).getString("acronym"), "CS")
+
+            Assert.assertEquals(
+                getJSONObject(1).getJSONObject("settings").getDouble("rateMultiplier").toFloat(),
+                1.25f,
+                0.01f
             )
-        )
 
-        Assert.assertEquals(serializedMods.length(), 3)
-        Assert.assertEquals(serializedMods.getJSONObject(0).getString("acronym"), "AT")
-        Assert.assertEquals(serializedMods.getJSONObject(1).getString("acronym"), "CS")
+            Assert.assertEquals(getJSONObject(2).getString("acronym"), "HD")
+            Assert.assertEquals(getJSONObject(3).getString("acronym"), "RV6")
+        }
+    }
 
-        Assert.assertEquals(
-            serializedMods.getJSONObject(1).getJSONObject("settings").getDouble("rateMultiplier").toFloat(),
-            1.25f,
-            0.01f
-        )
+    @Test
+    fun `Test mod serialization without non-user playable mods`() {
+        ModUtils.serializeMods(listOf(ModAutoplay(), ModCustomSpeed(1.25f), ModHidden(), ModReplayV6()), false).apply {
+            Assert.assertEquals(length(), 3)
+            Assert.assertEquals(getJSONObject(0).getString("acronym"), "AT")
+            Assert.assertEquals(getJSONObject(1).getString("acronym"), "CS")
 
-        Assert.assertEquals(serializedMods.getJSONObject(2).getString("acronym"), "HD")
+            Assert.assertEquals(
+                getJSONObject(1).getJSONObject("settings").getDouble("rateMultiplier").toFloat(),
+                1.25f,
+                0.01f
+            )
+
+            Assert.assertEquals(getJSONObject(2).getString("acronym"), "HD")
+        }
     }
 
     @Test


### PR DESCRIPTION
This will be the first round of fixes for the current stacking behavior.

In short, the current stacking behavior is wrong for a multitude of reasons. Some of them are that:
- It does not stack sliders
- It is based on the delta time of two objects instead of approach rate, the factor that *actually* affects readability
- Stacking can still apply even when two objects are not in the same position

More importantly, or perhaps the primary driving factor of this change, is because stack offset calculation depends on the device's screen resolution under the following logic:

https://github.com/osudroid/osu-droid/blob/fdb145b5b198bd0c5060898b83800bd043c42391/src/ru/nsu/ccfit/zuev/osu/Config.java#L253-L269

Which is used when calculating `HitObject.gameplayScale`:

https://github.com/osudroid/osu-droid/blob/fdb145b5b198bd0c5060898b83800bd043c42391/src/com/rian/osu/beatmap/hitobject/HitObject.kt#L357-L358

https://github.com/osudroid/osu-droid/blob/fdb145b5b198bd0c5060898b83800bd043c42391/src/com/rian/osu/utils/CircleSizeCalculator.kt#L38-L45

Which affects `HitObject.gameplayStackHeight`:

https://github.com/osudroid/osu-droid/blob/fdb145b5b198bd0c5060898b83800bd043c42391/src/com/rian/osu/beatmap/BeatmapProcessor.kt#L99-L101

This proves that stack height depends on the device's screen resolution, which is so broken I don't know what to say. However, this problem will be fixed in another PR to manage complexity.

---

Because this change affects the resulting `PlayableBeatmap`, it also affects other crucial modules, such as replay playback, difficulty calculation, and replay analysis. To accommodate for that, a new `ModReplayV6` mod has been added to reapply the current stacking behavior. The name was chosen over the fact that replay version 7 will be used in the next release in conformity with #516. It is meant to only be used when replaying and nothing else.