### PR TITLE
Add support for text input based `ModSetting`

### DIFF
--- a/src/com/osudroid/ui/v2/modmenu/ModCustomizationMenu.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModCustomizationMenu.kt
@@ -186,9 +186,14 @@ private sealed class ModSettingTextInput<V : Number?>(val mod: Mod, override val
     Container(),
     IModSettingComponent<V> {
 
-    abstract val control: FormInput
+    val control = createControl().apply {
+        width = FillParent
+    }
 
-    init { +control }
+    init {
+        width = FillParent
+        +control
+    }
 
     final override fun update() {
         control.label = setting.name
@@ -207,11 +212,12 @@ private sealed class ModSettingTextInput<V : Number?>(val mod: Mod, override val
         }
     }
 
+    abstract fun createControl(): FormInput
     abstract fun convertValue(value: String): V?
 }
 
 private class IntegerModSettingTextInput(mod: Mod, setting: ModSetting<Int>) : ModSettingTextInput<Int>(mod, setting) {
-    override val control = IntegerFormInput(
+    override fun createControl() = IntegerFormInput(
         setting.initialValue,
         (setting as? RangeConstrainedModSetting<Int>)?.minValue,
         (setting as? RangeConstrainedModSetting<Int>)?.maxValue
@@ -221,7 +227,7 @@ private class IntegerModSettingTextInput(mod: Mod, setting: ModSetting<Int>) : M
 }
 
 private class FloatModSettingTextInput(mod: Mod, setting: ModSetting<Float>) : ModSettingTextInput<Float>(mod, setting) {
-    override val control = FloatFormInput(
+    override fun createControl() = FloatFormInput(
         setting.initialValue,
         (setting as? RangeConstrainedModSetting<Float>)?.minValue,
         (setting as? RangeConstrainedModSetting<Float>)?.maxValue
@@ -232,8 +238,7 @@ private class FloatModSettingTextInput(mod: Mod, setting: ModSetting<Float>) : M
 
 private class NullableFloatModSettingTextInput(mod: Mod, setting: ModSetting<Float?>) :
     ModSettingTextInput<Float?>(mod, setting) {
-
-    override val control = FloatFormInput(
+    override fun createControl() = FloatFormInput(
         setting.initialValue ?: 0f,
         (setting as? RangeConstrainedModSetting<Float?>)?.minValue,
         (setting as? RangeConstrainedModSetting<Float?>)?.maxValue

--- a/src/com/osudroid/ui/v2/modmenu/ModCustomizationMenu.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModCustomizationMenu.kt
@@ -77,6 +77,10 @@ class ModCustomizationMenu : Modal(
                 if (setting.useManualInput) NullableFloatModSettingTextInput(mod, setting)
                 else NullableFloatModSettingSlider(mod, setting)
 
+            is NullableIntegerModSetting ->
+                if (setting.useManualInput) NullableIntegerModSettingTextInput(mod, setting)
+                else NullableIntegerModSettingSlider(mod, setting)
+
             is BooleanModSetting -> ModSettingCheckbox(mod, setting)
         }
         modSettingComponents.add(component)
@@ -167,6 +171,15 @@ private class IntegerModSettingSlider(mod: Mod, setting: ModSetting<Int>) : ModS
     override fun convertValue(value: Float) = value.toInt()
 }
 
+private class NullableIntegerModSettingSlider(mod: Mod, setting: ModSetting<Int?>) :
+    ModSettingSlider<Int?>(mod, setting) {
+    override fun convertValue(value: Float): Int? {
+        val converted = value.toInt()
+
+        return if (converted == setting.defaultValue) null else converted
+    }
+}
+
 private class FloatModSettingSlider(mod: Mod, setting: ModSetting<Float>) : ModSettingSlider<Float>(mod, setting) {
     override fun convertValue(value: Float) = value
 }
@@ -233,6 +246,17 @@ private class IntegerModSettingTextInput(mod: Mod, setting: ModSetting<Int>) : M
         setting.initialValue,
         (setting as? RangeConstrainedModSetting<Int>)?.minValue,
         (setting as? RangeConstrainedModSetting<Int>)?.maxValue
+    )
+
+    override fun convertValue(value: String) = value.toIntOrNull()
+}
+
+private class NullableIntegerModSettingTextInput(mod: Mod, setting: ModSetting<Int?>) :
+    ModSettingTextInput<Int?>(mod, setting) {
+    override fun createControl() = IntegerFormInput(
+        setting.initialValue,
+        (setting as? RangeConstrainedModSetting<Int?>)?.minValue,
+        (setting as? RangeConstrainedModSetting<Int?>)?.maxValue
     )
 
     override fun convertValue(value: String) = value.toIntOrNull()

--- a/src/com/osudroid/ui/v2/modmenu/ModCustomizationMenu.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModCustomizationMenu.kt
@@ -62,12 +62,21 @@ class ModCustomizationMenu : Modal(
         modSettingComponents.fastForEach { it.update() }
     }
 
-    private fun ModSettingComponent(mod: Mod, setting: ModSetting<*>): FormControl<*, *> {
+    private fun ModSettingComponent(mod: Mod, setting: ModSetting<*>): Container {
 
         val component = when (setting) {
-            is FloatModSetting -> FloatModSettingSlider(mod, setting)
-            is IntegerModSetting -> IntegerModSettingSlider(mod, setting)
-            is NullableFloatModSetting -> NullableModSettingSlider(mod, setting)
+            is FloatModSetting ->
+                if (setting.useManualInput) FloatModSettingTextInput(mod, setting)
+                else FloatModSettingSlider(mod, setting)
+
+            is IntegerModSetting ->
+                if (setting.useManualInput) IntegerModSettingTextInput(mod, setting)
+                else IntegerModSettingSlider(mod, setting)
+
+            is NullableFloatModSetting ->
+                if (setting.useManualInput) NullableFloatModSettingTextInput(mod, setting)
+                else NullableFloatModSettingSlider(mod, setting)
+
             is BooleanModSetting -> ModSettingCheckbox(mod, setting)
         }
         modSettingComponents.add(component)
@@ -162,7 +171,10 @@ private class FloatModSettingSlider(mod: Mod, setting: ModSetting<Float>) : ModS
     override fun convertValue(value: Float) = value
 }
 
-private class NullableModSettingSlider(mod: Mod, setting: ModSetting<Float?>) : ModSettingSlider<Float?>(mod, setting) {
+private class NullableFloatModSettingSlider(
+    mod: Mod,
+    setting: ModSetting<Float?>
+) : ModSettingSlider<Float?>(mod, setting) {
     override fun convertValue(value: Float) = if (value == setting.defaultValue) null else value
 }
 

--- a/src/com/osudroid/ui/v2/modmenu/ModSettingCheckbox.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModSettingCheckbox.kt
@@ -1,0 +1,18 @@
+package com.osudroid.ui.v2.modmenu
+
+import com.reco1l.andengine.ui.Control
+import com.reco1l.andengine.ui.form.FormCheckbox
+import com.reco1l.andengine.ui.form.FormControl
+import com.rian.osu.mods.Mod
+import com.rian.osu.mods.ModSetting
+
+class ModSettingCheckbox(mod: Mod, setting: ModSetting<Boolean>) :
+    ModSettingComponent<Boolean, Boolean>(mod, setting),
+    IModSettingComponent<Boolean> {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun createControl() = FormCheckbox(setting.initialValue) as FormControl<Boolean, Control<Boolean>>
+
+    override fun convertSettingValue(value: Boolean) = value
+    override fun convertControlValue(value: Boolean) = value
+}

--- a/src/com/osudroid/ui/v2/modmenu/ModSettingComponent.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModSettingComponent.kt
@@ -41,7 +41,7 @@ sealed class ModSettingComponent<TSettingValue : Any?, TControlValue : Any>(
         }
     }
 
-    abstract fun createControl(): FormControl<TControlValue, Control<TControlValue>>
-    abstract fun convertSettingValue(value: TSettingValue): TControlValue
-    abstract fun convertControlValue(value: TControlValue): TSettingValue?
+    protected abstract fun createControl(): FormControl<TControlValue, Control<TControlValue>>
+    protected abstract fun convertSettingValue(value: TSettingValue): TControlValue
+    protected abstract fun convertControlValue(value: TControlValue): TSettingValue?
 }

--- a/src/com/osudroid/ui/v2/modmenu/ModSettingComponent.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModSettingComponent.kt
@@ -38,7 +38,7 @@ sealed class ModSettingComponent<TSettingValue : Any?, TControlValue : Any>(
         width = FillParent
 
         label = setting.name
-        valueFormatter = { setting.valueFormatter!!.invoke(convertControlValue(it)) }
+        valueFormatter = { setting.valueFormatter!!.invoke(setting, convertControlValue(it)) }
 
         onValueChanged = {
             setting.value = convertControlValue(it)

--- a/src/com/osudroid/ui/v2/modmenu/ModSettingComponent.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModSettingComponent.kt
@@ -1,0 +1,47 @@
+package com.osudroid.ui.v2.modmenu
+
+import com.reco1l.andengine.container.Container
+import com.reco1l.andengine.ui.Control
+import com.reco1l.andengine.ui.form.FormControl
+import com.rian.osu.mods.Mod
+import com.rian.osu.mods.ModSetting
+
+interface IModSettingComponent<V : Any?> {
+    val setting: ModSetting<V>
+    fun update()
+}
+
+sealed class ModSettingComponent<TSettingValue : Any?, TControlValue : Any>(
+    val mod: Mod,
+    override val setting: ModSetting<TSettingValue>
+) : Container(), IModSettingComponent<TSettingValue> {
+
+    val control = createControl().apply {
+        width = FillParent
+    }
+
+    init {
+        width = FillParent
+        +control
+    }
+
+    override fun update() {
+        control.apply {
+            label = setting.name
+            defaultValue = convertSettingValue(setting.defaultValue)
+            value = convertSettingValue(setting.value)
+            valueFormatter = {
+                setting.valueFormatter!!.invoke(convertControlValue(it) ?: setting.defaultValue)
+            }
+
+            onValueChanged = {
+                setting.value = convertControlValue(it) ?: setting.defaultValue
+                ModMenu.queueModChange(mod)
+            }
+        }
+    }
+
+    abstract fun createControl(): FormControl<TControlValue, Control<TControlValue>>
+    abstract fun convertSettingValue(value: TSettingValue): TControlValue
+    abstract fun convertControlValue(value: TControlValue): TSettingValue?
+}

--- a/src/com/osudroid/ui/v2/modmenu/ModSettingComponent.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModSettingComponent.kt
@@ -6,16 +6,34 @@ import com.reco1l.andengine.ui.form.FormControl
 import com.rian.osu.mods.Mod
 import com.rian.osu.mods.ModSetting
 
+/**
+ * Interface for a component that controls a [ModSetting].
+ */
 interface IModSettingComponent<V : Any?> {
+    /**
+     * The [ModSetting] that is controlled by this [IModSettingComponent].
+     */
     val setting: ModSetting<V>
+
+    /**
+     * Updates this [IModSettingComponent] to reflect the current state of the [ModSetting].
+     */
     fun update()
 }
 
+/**
+ * A component that controls a [ModSetting].
+ *
+ * @param TSettingValue The type of the value in the [ModSetting].
+ * @param TControlValue The type of the value in the [FormControl] that is used to display this [ModSettingComponent].
+ */
 sealed class ModSettingComponent<TSettingValue : Any?, TControlValue : Any>(
     val mod: Mod,
     override val setting: ModSetting<TSettingValue>
 ) : Container(), IModSettingComponent<TSettingValue> {
-
+    /**
+     * The [FormControl] that is used to display this [ModSettingComponent]
+     */
     protected val control = createControl().apply {
         width = FillParent
     }
@@ -41,7 +59,18 @@ sealed class ModSettingComponent<TSettingValue : Any?, TControlValue : Any>(
         }
     }
 
+    /**
+     * Creates the [FormControl] that is used to display this [ModSettingComponent].
+     */
     protected abstract fun createControl(): FormControl<TControlValue, Control<TControlValue>>
+
+    /**
+     * Converts a value from the [ModSetting] to a value that can be displayed in the [FormControl].
+     */
     protected abstract fun convertSettingValue(value: TSettingValue): TControlValue
+
+    /**
+     * Converts a value from the [FormControl] to a value that can be used in the [ModSetting].
+     */
     protected abstract fun convertControlValue(value: TControlValue): TSettingValue?
 }

--- a/src/com/osudroid/ui/v2/modmenu/ModSettingComponent.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModSettingComponent.kt
@@ -32,7 +32,7 @@ sealed class ModSettingComponent<TSettingValue : Any?, TControlValue : Any>(
     override val setting: ModSetting<TSettingValue>
 ) : Container(), IModSettingComponent<TSettingValue> {
     /**
-     * The [FormControl] that is used to display this [ModSettingComponent]
+     * The [FormControl] that is used to display this [ModSettingComponent].
      */
     protected val control = createControl().apply {
         width = FillParent
@@ -65,6 +65,9 @@ sealed class ModSettingComponent<TSettingValue : Any?, TControlValue : Any>(
 
     /**
      * Converts a value from the [ModSetting] to a value that can be displayed in the [FormControl].
+     *
+     * @param value The value from the [ModSetting].
+     * @return The value that can be displayed in the [FormControl].
      */
     protected abstract fun convertSettingValue(value: TSettingValue): TControlValue
 

--- a/src/com/osudroid/ui/v2/modmenu/ModSettingComponent.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModSettingComponent.kt
@@ -38,10 +38,10 @@ sealed class ModSettingComponent<TSettingValue : Any?, TControlValue : Any>(
         width = FillParent
 
         label = setting.name
-        valueFormatter = { setting.valueFormatter!!.invoke(convertControlValue(it) ?: setting.defaultValue) }
+        valueFormatter = { setting.valueFormatter!!.invoke(convertControlValue(it)) }
 
         onValueChanged = {
-            setting.value = convertControlValue(it) ?: setting.defaultValue
+            setting.value = convertControlValue(it)
             ModMenu.queueModChange(mod)
         }
     }
@@ -75,8 +75,7 @@ sealed class ModSettingComponent<TSettingValue : Any?, TControlValue : Any>(
      * Converts a value from the [FormControl] to a value that can be used in the [ModSetting].
      *
      * @param value The value from the [FormControl].
-     * @return The value that can be used in the [ModSetting]. If `null` is returned, the default value of the
-     * [ModSetting] will be used.
+     * @return The value that can be used in the [ModSetting].
      */
-    protected abstract fun convertControlValue(value: TControlValue): TSettingValue?
+    protected abstract fun convertControlValue(value: TControlValue): TSettingValue
 }

--- a/src/com/osudroid/ui/v2/modmenu/ModSettingComponent.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModSettingComponent.kt
@@ -38,7 +38,10 @@ sealed class ModSettingComponent<TSettingValue : Any?, TControlValue : Any>(
         width = FillParent
 
         label = setting.name
-        valueFormatter = { setting.valueFormatter!!.invoke(setting, convertControlValue(it)) }
+
+        valueFormatter = {
+            setting.valueFormatter?.invoke(setting, convertControlValue(it)) ?: it.toString()
+        }
 
         onValueChanged = {
             setting.value = convertControlValue(it)

--- a/src/com/osudroid/ui/v2/modmenu/ModSettingComponent.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModSettingComponent.kt
@@ -36,6 +36,14 @@ sealed class ModSettingComponent<TSettingValue : Any?, TControlValue : Any>(
      */
     protected val control = createControl().apply {
         width = FillParent
+
+        label = setting.name
+        valueFormatter = { setting.valueFormatter!!.invoke(convertControlValue(it) ?: setting.defaultValue) }
+
+        onValueChanged = {
+            setting.value = convertControlValue(it) ?: setting.defaultValue
+            ModMenu.queueModChange(mod)
+        }
     }
 
     init {
@@ -45,17 +53,8 @@ sealed class ModSettingComponent<TSettingValue : Any?, TControlValue : Any>(
 
     override fun update() {
         control.apply {
-            label = setting.name
             defaultValue = convertSettingValue(setting.defaultValue)
             value = convertSettingValue(setting.value)
-            valueFormatter = {
-                setting.valueFormatter!!.invoke(convertControlValue(it) ?: setting.defaultValue)
-            }
-
-            onValueChanged = {
-                setting.value = convertControlValue(it) ?: setting.defaultValue
-                ModMenu.queueModChange(mod)
-            }
         }
     }
 

--- a/src/com/osudroid/ui/v2/modmenu/ModSettingComponent.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModSettingComponent.kt
@@ -16,7 +16,7 @@ sealed class ModSettingComponent<TSettingValue : Any?, TControlValue : Any>(
     override val setting: ModSetting<TSettingValue>
 ) : Container(), IModSettingComponent<TSettingValue> {
 
-    val control = createControl().apply {
+    protected val control = createControl().apply {
         width = FillParent
     }
 

--- a/src/com/osudroid/ui/v2/modmenu/ModSettingComponent.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModSettingComponent.kt
@@ -70,6 +70,10 @@ sealed class ModSettingComponent<TSettingValue : Any?, TControlValue : Any>(
 
     /**
      * Converts a value from the [FormControl] to a value that can be used in the [ModSetting].
+     *
+     * @param value The value from the [FormControl].
+     * @return The value that can be used in the [ModSetting]. If `null` is returned, the default value of the
+     * [ModSetting] will be used.
      */
     protected abstract fun convertControlValue(value: TControlValue): TSettingValue?
 }

--- a/src/com/osudroid/ui/v2/modmenu/ModSettingSlider.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModSettingSlider.kt
@@ -36,7 +36,7 @@ class IntegerModSettingSlider(mod: Mod, setting: ModSetting<Int>) : ModSettingSl
 
 class NullableIntegerModSettingSlider(mod: Mod, setting: ModSetting<Int?>) :
     ModSettingSlider<Int?>(mod, setting) {
-    override fun convertSettingValue(value: Int?) = value?.toFloat() ?: control.defaultValue
+    override fun convertSettingValue(value: Int?) = value?.toFloat() ?: setting.initialValue?.toFloat() ?: 0f
 
     override fun convertControlValue(value: Float): Int? {
         val converted = value.toInt()
@@ -54,6 +54,6 @@ class NullableFloatModSettingSlider(
     mod: Mod,
     setting: ModSetting<Float?>
 ) : ModSettingSlider<Float?>(mod, setting) {
-    override fun convertSettingValue(value: Float?) = value ?: control.defaultValue
+    override fun convertSettingValue(value: Float?) = value ?: setting.initialValue ?: 0f
     override fun convertControlValue(value: Float) = if (value == setting.defaultValue) null else value
 }

--- a/src/com/osudroid/ui/v2/modmenu/ModSettingSlider.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModSettingSlider.kt
@@ -28,7 +28,7 @@ sealed class ModSettingSlider<V : Number?>(mod: Mod, setting: ModSetting<V>) :
     final override fun createControl() =
         FormSlider(convertSettingValue(setting.initialValue)) as FormControl<Float, Control<Float>>
 
-    final override fun convertSettingValue(value: V) = value?.toFloat() ?: setting.initialValue?.toFloat() ?: 0f
+    final override fun convertSettingValue(value: V) = value?.toFloat() ?: setting.defaultValue?.toFloat() ?: 0f
 }
 
 class IntegerModSettingSlider(mod: Mod, setting: ModSetting<Int>) : ModSettingSlider<Int>(mod, setting) {

--- a/src/com/osudroid/ui/v2/modmenu/ModSettingSlider.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModSettingSlider.kt
@@ -16,9 +16,18 @@ sealed class ModSettingSlider<V : Number?>(mod: Mod, setting: ModSetting<V>) :
         if (setting is RangeConstrainedModSetting<V>) {
             val setting = setting as RangeConstrainedModSetting<V>
 
+            // Assigning the min, max and step values to the slider may unexpectedly change the value of the setting
+            // due to their boundaries. We will reset the value to the current value after doing this. The same applies
+            // to the default value.
+            val currentValue = setting.value
+            val currentDefaultValue = setting.defaultValue
+
             slider.min = convertSettingValue(setting.minValue)
             slider.max = convertSettingValue(setting.maxValue)
             slider.step = convertSettingValue(setting.step)
+
+            control.defaultValue = convertSettingValue(currentDefaultValue)
+            control.value = convertSettingValue(currentValue)
         }
 
         super.update()

--- a/src/com/osudroid/ui/v2/modmenu/ModSettingSlider.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModSettingSlider.kt
@@ -27,17 +27,16 @@ sealed class ModSettingSlider<V : Number?>(mod: Mod, setting: ModSetting<V>) :
     @Suppress("UNCHECKED_CAST")
     final override fun createControl() =
         FormSlider(convertSettingValue(setting.initialValue)) as FormControl<Float, Control<Float>>
+
+    final override fun convertSettingValue(value: V) = value?.toFloat() ?: setting.initialValue?.toFloat() ?: 0f
 }
 
 class IntegerModSettingSlider(mod: Mod, setting: ModSetting<Int>) : ModSettingSlider<Int>(mod, setting) {
-    override fun convertSettingValue(value: Int) = value.toFloat()
     override fun convertControlValue(value: Float) = value.toInt()
 }
 
 class NullableIntegerModSettingSlider(mod: Mod, setting: ModSetting<Int?>) :
     ModSettingSlider<Int?>(mod, setting) {
-    override fun convertSettingValue(value: Int?) = value?.toFloat() ?: setting.initialValue?.toFloat() ?: 0f
-
     override fun convertControlValue(value: Float): Int? {
         val converted = value.toInt()
 
@@ -46,7 +45,6 @@ class NullableIntegerModSettingSlider(mod: Mod, setting: ModSetting<Int?>) :
 }
 
 class FloatModSettingSlider(mod: Mod, setting: ModSetting<Float>) : ModSettingSlider<Float>(mod, setting) {
-    override fun convertSettingValue(value: Float) = value
     override fun convertControlValue(value: Float) = value
 }
 
@@ -54,6 +52,5 @@ class NullableFloatModSettingSlider(
     mod: Mod,
     setting: ModSetting<Float?>
 ) : ModSettingSlider<Float?>(mod, setting) {
-    override fun convertSettingValue(value: Float?) = value ?: setting.initialValue ?: 0f
     override fun convertControlValue(value: Float) = if (value == setting.defaultValue) null else value
 }

--- a/src/com/osudroid/ui/v2/modmenu/ModSettingSlider.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModSettingSlider.kt
@@ -1,0 +1,59 @@
+package com.osudroid.ui.v2.modmenu
+
+import com.reco1l.andengine.ui.Control
+import com.reco1l.andengine.ui.form.FormControl
+import com.reco1l.andengine.ui.form.FormSlider
+import com.rian.osu.mods.Mod
+import com.rian.osu.mods.ModSetting
+import com.rian.osu.mods.RangeConstrainedModSetting
+
+sealed class ModSettingSlider<V : Number?>(mod: Mod, setting: ModSetting<V>) :
+    ModSettingComponent<V, Float>(mod, setting) {
+
+    final override fun update() {
+        val slider = (control as FormSlider).control
+
+        if (setting is RangeConstrainedModSetting<V>) {
+            val setting = setting as RangeConstrainedModSetting<V>
+
+            slider.min = convertSettingValue(setting.minValue)
+            slider.max = convertSettingValue(setting.maxValue)
+            slider.step = convertSettingValue(setting.step)
+        }
+
+        super.update()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    final override fun createControl() =
+        FormSlider(convertSettingValue(setting.initialValue)) as FormControl<Float, Control<Float>>
+}
+
+class IntegerModSettingSlider(mod: Mod, setting: ModSetting<Int>) : ModSettingSlider<Int>(mod, setting) {
+    override fun convertSettingValue(value: Int) = value.toFloat()
+    override fun convertControlValue(value: Float) = value.toInt()
+}
+
+class NullableIntegerModSettingSlider(mod: Mod, setting: ModSetting<Int?>) :
+    ModSettingSlider<Int?>(mod, setting) {
+    override fun convertSettingValue(value: Int?) = value?.toFloat() ?: control.defaultValue
+
+    override fun convertControlValue(value: Float): Int? {
+        val converted = value.toInt()
+
+        return if (converted == setting.defaultValue) null else converted
+    }
+}
+
+class FloatModSettingSlider(mod: Mod, setting: ModSetting<Float>) : ModSettingSlider<Float>(mod, setting) {
+    override fun convertSettingValue(value: Float) = value
+    override fun convertControlValue(value: Float) = value
+}
+
+class NullableFloatModSettingSlider(
+    mod: Mod,
+    setting: ModSetting<Float?>
+) : ModSettingSlider<Float?>(mod, setting) {
+    override fun convertSettingValue(value: Float?) = value ?: control.defaultValue
+    override fun convertControlValue(value: Float) = if (value == setting.defaultValue) null else value
+}

--- a/src/com/osudroid/ui/v2/modmenu/ModSettingSlider.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModSettingSlider.kt
@@ -17,17 +17,15 @@ sealed class ModSettingSlider<V : Number?>(mod: Mod, setting: ModSetting<V>) :
             val setting = setting as RangeConstrainedModSetting<V>
 
             // Assigning the min, max and step values to the slider may unexpectedly change the value of the setting
-            // due to their boundaries. We will reset the value to the current value after doing this. The same applies
-            // to the default value.
-            val currentValue = setting.value
-            val currentDefaultValue = setting.defaultValue
+            // due to their boundaries. As such, we do not want to trigger onValueChanged() here.
+            val valueChanged = control.onValueChanged
+            control.onValueChanged = null
 
             slider.min = convertSettingValue(setting.minValue)
             slider.max = convertSettingValue(setting.maxValue)
             slider.step = convertSettingValue(setting.step)
 
-            control.defaultValue = convertSettingValue(currentDefaultValue)
-            control.value = convertSettingValue(currentValue)
+            control.onValueChanged = valueChanged
         }
 
         super.update()

--- a/src/com/osudroid/ui/v2/modmenu/ModSettingTextInput.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModSettingTextInput.kt
@@ -23,7 +23,7 @@ class IntegerModSettingTextInput(mod: Mod, setting: ModSetting<Int>) : ModSettin
         (setting as? RangeConstrainedModSetting<Int>)?.maxValue
     ) as FormControl<String, Control<String>>
 
-    override fun convertControlValue(value: String) = value.toIntOrNull()
+    override fun convertControlValue(value: String) = value.toInt()
 }
 
 class NullableIntegerModSettingTextInput(mod: Mod, setting: ModSetting<Int?>) : ModSettingTextInput<Int?>(mod, setting) {
@@ -46,7 +46,7 @@ class FloatModSettingTextInput(mod: Mod, setting: ModSetting<Float>) : ModSettin
         (setting as? RangeConstrainedModSetting<Float>)?.maxValue
     ) as FormControl<String, Control<String>>
 
-    override fun convertControlValue(value: String) = value.toFloatOrNull()
+    override fun convertControlValue(value: String) = value.toFloat()
 }
 
 class NullableFloatModSettingTextInput(mod: Mod, setting: ModSetting<Float?>) : ModSettingTextInput<Float?>(mod, setting) {

--- a/src/com/osudroid/ui/v2/modmenu/ModSettingTextInput.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModSettingTextInput.kt
@@ -9,7 +9,10 @@ import com.rian.osu.mods.ModSetting
 import com.rian.osu.mods.RangeConstrainedModSetting
 
 sealed class ModSettingTextInput<V : Any?>(mod: Mod, setting: ModSetting<V>) :
-    ModSettingComponent<V, String>(mod, setting)
+    ModSettingComponent<V, String>(mod, setting) {
+
+    final override fun convertSettingValue(value: V) = value?.toString() ?: setting.initialValue?.toString() ?: ""
+}
 
 class IntegerModSettingTextInput(mod: Mod, setting: ModSetting<Int>) : ModSettingTextInput<Int>(mod, setting) {
 
@@ -20,7 +23,6 @@ class IntegerModSettingTextInput(mod: Mod, setting: ModSetting<Int>) : ModSettin
         (setting as? RangeConstrainedModSetting<Int>)?.maxValue
     ) as FormControl<String, Control<String>>
 
-    override fun convertSettingValue(value: Int) = value.toString()
     override fun convertControlValue(value: String) = value.toIntOrNull()
 }
 
@@ -33,7 +35,6 @@ class NullableIntegerModSettingTextInput(mod: Mod, setting: ModSetting<Int?>) : 
         (setting as? RangeConstrainedModSetting<Int?>)?.maxValue
     ) as FormControl<String, Control<String>>
 
-    override fun convertSettingValue(value: Int?) = value?.toString() ?: setting.initialValue?.toString() ?: ""
     override fun convertControlValue(value: String) = value.toIntOrNull()
 }
 
@@ -45,7 +46,6 @@ class FloatModSettingTextInput(mod: Mod, setting: ModSetting<Float>) : ModSettin
         (setting as? RangeConstrainedModSetting<Float>)?.maxValue
     ) as FormControl<String, Control<String>>
 
-    override fun convertSettingValue(value: Float) = value.toString()
     override fun convertControlValue(value: String) = value.toFloatOrNull()
 }
 
@@ -57,6 +57,5 @@ class NullableFloatModSettingTextInput(mod: Mod, setting: ModSetting<Float?>) : 
         (setting as? RangeConstrainedModSetting<Float?>)?.maxValue
     ) as FormControl<String, Control<String>>
 
-    override fun convertSettingValue(value: Float?) = value?.toString() ?: setting.initialValue?.toString() ?: ""
     override fun convertControlValue(value: String) = value.toFloatOrNull()
 }

--- a/src/com/osudroid/ui/v2/modmenu/ModSettingTextInput.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModSettingTextInput.kt
@@ -11,7 +11,7 @@ import com.rian.osu.mods.RangeConstrainedModSetting
 sealed class ModSettingTextInput<V : Any?>(mod: Mod, setting: ModSetting<V>) :
     ModSettingComponent<V, String>(mod, setting) {
 
-    final override fun convertSettingValue(value: V) = value?.toString() ?: setting.initialValue?.toString() ?: ""
+    final override fun convertSettingValue(value: V) = value?.toString() ?: setting.defaultValue?.toString() ?: ""
 }
 
 class IntegerModSettingTextInput(mod: Mod, setting: ModSetting<Int>) : ModSettingTextInput<Int>(mod, setting) {

--- a/src/com/osudroid/ui/v2/modmenu/ModSettingTextInput.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModSettingTextInput.kt
@@ -1,0 +1,62 @@
+package com.osudroid.ui.v2.modmenu
+
+import com.reco1l.andengine.ui.Control
+import com.reco1l.andengine.ui.form.FloatFormInput
+import com.reco1l.andengine.ui.form.FormControl
+import com.reco1l.andengine.ui.form.IntegerFormInput
+import com.rian.osu.mods.Mod
+import com.rian.osu.mods.ModSetting
+import com.rian.osu.mods.RangeConstrainedModSetting
+
+sealed class ModSettingTextInput<V : Any?>(mod: Mod, setting: ModSetting<V>) :
+    ModSettingComponent<V, String>(mod, setting)
+
+class IntegerModSettingTextInput(mod: Mod, setting: ModSetting<Int>) : ModSettingTextInput<Int>(mod, setting) {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun createControl() = IntegerFormInput(
+        setting.initialValue,
+        (setting as? RangeConstrainedModSetting<Int>)?.minValue,
+        (setting as? RangeConstrainedModSetting<Int>)?.maxValue
+    ) as FormControl<String, Control<String>>
+
+    override fun convertSettingValue(value: Int) = value.toString()
+    override fun convertControlValue(value: String) = value.toIntOrNull()
+}
+
+class NullableIntegerModSettingTextInput(mod: Mod, setting: ModSetting<Int?>) : ModSettingTextInput<Int?>(mod, setting) {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun createControl() = IntegerFormInput(
+        setting.initialValue,
+        (setting as? RangeConstrainedModSetting<Int?>)?.minValue,
+        (setting as? RangeConstrainedModSetting<Int?>)?.maxValue
+    ) as FormControl<String, Control<String>>
+
+    override fun convertSettingValue(value: Int?) = value?.toString() ?: control.defaultValue
+    override fun convertControlValue(value: String) = value.toIntOrNull()
+}
+
+class FloatModSettingTextInput(mod: Mod, setting: ModSetting<Float>) : ModSettingTextInput<Float>(mod, setting) {
+    @Suppress("UNCHECKED_CAST")
+    override fun createControl() = FloatFormInput(
+        setting.initialValue,
+        (setting as? RangeConstrainedModSetting<Float>)?.minValue,
+        (setting as? RangeConstrainedModSetting<Float>)?.maxValue
+    ) as FormControl<String, Control<String>>
+
+    override fun convertSettingValue(value: Float) = value.toString()
+    override fun convertControlValue(value: String) = value.toFloatOrNull()
+}
+
+class NullableFloatModSettingTextInput(mod: Mod, setting: ModSetting<Float?>) : ModSettingTextInput<Float?>(mod, setting) {
+    @Suppress("UNCHECKED_CAST")
+    override fun createControl() = FloatFormInput(
+        setting.initialValue,
+        (setting as? RangeConstrainedModSetting<Float?>)?.minValue,
+        (setting as? RangeConstrainedModSetting<Float?>)?.maxValue
+    ) as FormControl<String, Control<String>>
+
+    override fun convertSettingValue(value: Float?) = value?.toString() ?: control.defaultValue
+    override fun convertControlValue(value: String) = value.toFloatOrNull()
+}

--- a/src/com/osudroid/ui/v2/modmenu/ModSettingTextInput.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModSettingTextInput.kt
@@ -33,7 +33,7 @@ class NullableIntegerModSettingTextInput(mod: Mod, setting: ModSetting<Int?>) : 
         (setting as? RangeConstrainedModSetting<Int?>)?.maxValue
     ) as FormControl<String, Control<String>>
 
-    override fun convertSettingValue(value: Int?) = value?.toString() ?: control.defaultValue
+    override fun convertSettingValue(value: Int?) = value?.toString() ?: setting.initialValue?.toString() ?: ""
     override fun convertControlValue(value: String) = value.toIntOrNull()
 }
 
@@ -57,6 +57,6 @@ class NullableFloatModSettingTextInput(mod: Mod, setting: ModSetting<Float?>) : 
         (setting as? RangeConstrainedModSetting<Float?>)?.maxValue
     ) as FormControl<String, Control<String>>
 
-    override fun convertSettingValue(value: Float?) = value?.toString() ?: control.defaultValue
+    override fun convertSettingValue(value: Float?) = value?.toString() ?: setting.initialValue?.toString() ?: ""
     override fun convertControlValue(value: String) = value.toFloatOrNull()
 }

--- a/src/com/reco1l/andengine/ui/TextInput.kt
+++ b/src/com/reco1l/andengine/ui/TextInput.kt
@@ -306,3 +306,47 @@ open class TextInput(initialValue: String) : Control<String>(initialValue), IFoc
     }
 
 }
+
+/**
+ * A [TextInput] whose [value] is constrained to a range of values.
+ */
+sealed class RangeConstrainedTextInput<T : Comparable<T>>(
+    initialValue: T,
+
+    /**
+     * The minimum value that can be entered in this [RangeConstrainedTextInput].
+     *
+     * If set to `null`, there is no minimum value.
+     */
+    val minValue: T? = null,
+
+    /**
+     * The maximum value that can be entered in this [RangeConstrainedTextInput].
+     *
+     * If set to `null`, there is no maximum value.
+     */
+    val maxValue: T? = null
+) : TextInput(initialValue.toString()) {
+    override fun isTextValid(text: String): Boolean {
+        // Avoid calling convertValue whenever necessary, in case it is expensive
+        if (!super.isTextValid(text)) {
+            return false
+        }
+
+        if (minValue == null && maxValue == null) {
+            return true
+        }
+
+        val value = convertValue(text)
+
+        return (minValue == null || value >= minValue) && (maxValue == null || value <= maxValue)
+    }
+
+    /**
+     * Converts a value from a [String] to a [T].
+     *
+     * @param value The value to convert.
+     * @return The converted value.
+     */
+    protected abstract fun convertValue(value: String): T
+}

--- a/src/com/reco1l/andengine/ui/TextInput.kt
+++ b/src/com/reco1l/andengine/ui/TextInput.kt
@@ -310,8 +310,8 @@ open class TextInput(initialValue: String) : Control<String>(initialValue), IFoc
 /**
  * A [TextInput] whose [value] is constrained to a range of values.
  */
-sealed class RangeConstrainedTextInput<T : Comparable<T>>(
-    initialValue: T,
+sealed class RangeConstrainedTextInput<T : Comparable<T>?>(
+    initialValue: T?,
 
     /**
      * The minimum value that can be entered in this [RangeConstrainedTextInput].
@@ -326,12 +326,15 @@ sealed class RangeConstrainedTextInput<T : Comparable<T>>(
      * If set to `null`, there is no maximum value.
      */
     val maxValue: T? = null
-) : TextInput(initialValue.toString()) {
+) : TextInput(initialValue?.toString() ?: "") {
     override fun isTextValid(text: String): Boolean {
         // Avoid calling convertValue whenever necessary, in case it is expensive
         if (!super.isTextValid(text)) {
             return false
         }
+
+        val minValue = minValue
+        val maxValue = maxValue
 
         if (minValue == null && maxValue == null) {
             return true
@@ -339,16 +342,16 @@ sealed class RangeConstrainedTextInput<T : Comparable<T>>(
 
         val value = convertValue(text)
 
-        return (minValue == null || value >= minValue) && (maxValue == null || value <= maxValue)
+        return value == null || (value >= minValue!! && value <= maxValue!!)
     }
 
     /**
      * Converts a value from a [String] to a [T].
      *
      * @param value The value to convert.
-     * @return The converted value.
+     * @return The converted value. If `null`, [value] is always considered valid.
      */
-    protected abstract fun convertValue(value: String): T
+    protected abstract fun convertValue(value: String): T?
 }
 
 /**
@@ -361,7 +364,7 @@ class IntegerTextInput(
 ) : RangeConstrainedTextInput<Int>(initialValue, minValue, maxValue) {
     override fun isCharacterAllowed(char: Char) = super.isCharacterAllowed(char) && (char.isDigit() || char == '-')
 
-    override fun convertValue(value: String) = value.toInt()
+    override fun convertValue(value: String) = value.toIntOrNull()
 }
 
 /**
@@ -375,5 +378,5 @@ class FloatTextInput(
     override fun isCharacterAllowed(char: Char) =
         super.isCharacterAllowed(char) && (char.isDigit() || char == '.' || char == '-')
 
-    override fun convertValue(value: String) = value.toFloat()
+    override fun convertValue(value: String) = value.toFloatOrNull()
 }

--- a/src/com/reco1l/andengine/ui/TextInput.kt
+++ b/src/com/reco1l/andengine/ui/TextInput.kt
@@ -350,3 +350,30 @@ sealed class RangeConstrainedTextInput<T : Comparable<T>>(
      */
     protected abstract fun convertValue(value: String): T
 }
+
+/**
+ * A [TextInput] that only allows [Int]s to be entered.
+ */
+class IntegerTextInput(
+    initialValue: Int,
+    minValue: Int? = -Int.MAX_VALUE,
+    maxValue: Int? = Int.MAX_VALUE
+) : RangeConstrainedTextInput<Int>(initialValue, minValue, maxValue) {
+    override fun isCharacterAllowed(char: Char) = super.isCharacterAllowed(char) && (char.isDigit() || char == '-')
+
+    override fun convertValue(value: String) = value.toInt()
+}
+
+/**
+ * A [TextInput] that only allows [Float]s to be entered.
+ */
+class FloatTextInput(
+    initialValue: Float,
+    minValue: Float? = -Float.MAX_VALUE,
+    maxValue: Float? = Float.MAX_VALUE
+) : RangeConstrainedTextInput<Float>(initialValue, minValue, maxValue) {
+    override fun isCharacterAllowed(char: Char) =
+        super.isCharacterAllowed(char) && (char.isDigit() || char == '.' || char == '-')
+
+    override fun convertValue(value: String) = value.toFloat()
+}

--- a/src/com/reco1l/andengine/ui/TextInput.kt
+++ b/src/com/reco1l/andengine/ui/TextInput.kt
@@ -258,7 +258,7 @@ open class TextInput(initialValue: String) : Control<String>(initialValue), IFoc
         value = newText
 
         // Move the caret to the left if it's located after the deleted character
-        if (position > currentCaretPosition) {
+        if (position < currentCaretPosition) {
             caretPosition = max(0, currentCaretPosition - 1)
         }
     }

--- a/src/com/reco1l/andengine/ui/TextInput.kt
+++ b/src/com/reco1l/andengine/ui/TextInput.kt
@@ -358,7 +358,7 @@ sealed class RangeConstrainedTextInput<T : Comparable<T>?>(
  * A [TextInput] that only allows [Int]s to be entered.
  */
 class IntegerTextInput(
-    initialValue: Int,
+    initialValue: Int?,
     minValue: Int? = -Int.MAX_VALUE,
     maxValue: Int? = Int.MAX_VALUE
 ) : RangeConstrainedTextInput<Int>(initialValue, minValue, maxValue) {
@@ -371,7 +371,7 @@ class IntegerTextInput(
  * A [TextInput] that only allows [Float]s to be entered.
  */
 class FloatTextInput(
-    initialValue: Float,
+    initialValue: Float?,
     minValue: Float? = -Float.MAX_VALUE,
     maxValue: Float? = Float.MAX_VALUE
 ) : RangeConstrainedTextInput<Float>(initialValue, minValue, maxValue) {

--- a/src/com/reco1l/andengine/ui/TextInput.kt
+++ b/src/com/reco1l/andengine/ui/TextInput.kt
@@ -244,6 +244,7 @@ open class TextInput(initialValue: String) : Control<String>(initialValue), IFoc
         }
 
         val currentText = value
+        val currentCaretPosition = caretPosition
 
         val newText =
             if (position > 0) currentText.substring(0, position - 1) + currentText.substring(position)
@@ -255,7 +256,11 @@ open class TextInput(initialValue: String) : Control<String>(initialValue), IFoc
         }
 
         value = newText
-        caretPosition = max(0, caretPosition - 1)
+
+        // Move the caret to the left if it's located after the deleted character
+        if (position > currentCaretPosition) {
+            caretPosition = max(0, currentCaretPosition - 1)
+        }
     }
 
     private fun notifyInputError() {

--- a/src/com/reco1l/andengine/ui/TextInput.kt
+++ b/src/com/reco1l/andengine/ui/TextInput.kt
@@ -370,6 +370,10 @@ class IntegerTextInput(
 ) : RangeConstrainedTextInput<Int>(initialValue, minValue, maxValue) {
     override fun isCharacterAllowed(char: Char) = super.isCharacterAllowed(char) && (char.isDigit() || char == '-')
 
+    override fun isTextValid(text: String) =
+        // Check for underflow/overflow
+        super.isTextValid(text) && text.toIntOrNull() != null
+
     override fun convertValue(value: String) = value.toIntOrNull()
 }
 
@@ -383,6 +387,10 @@ class FloatTextInput(
 ) : RangeConstrainedTextInput<Float>(initialValue, minValue, maxValue) {
     override fun isCharacterAllowed(char: Char) =
         super.isCharacterAllowed(char) && (char.isDigit() || char == '.' || char == '-')
+
+    override fun isTextValid(text: String) =
+        // Check for underflow/overflow
+        super.isTextValid(text) && text.toFloatOrNull() != null
 
     override fun convertValue(value: String) = value.toFloatOrNull()
 }

--- a/src/com/reco1l/andengine/ui/TextInput.kt
+++ b/src/com/reco1l/andengine/ui/TextInput.kt
@@ -275,6 +275,7 @@ open class TextInput(initialValue: String) : Control<String>(initialValue), IFoc
     override fun onValueChanged() {
         super.onValueChanged()
         textEntity.text = value
+        caretPosition = min(caretPosition, value.length)
     }
 
     override fun onKeyPress(keyCode: Int, event: KeyEvent): Boolean = synchronized(value) {

--- a/src/com/reco1l/andengine/ui/form/FormInput.kt
+++ b/src/com/reco1l/andengine/ui/form/FormInput.kt
@@ -33,17 +33,17 @@ open class FormInput(initialValue: String = "") : FormControl<String, TextInput>
 }
 
 open class IntegerFormInput(
-    initialValue: Int,
+    initialValue: Int?,
     val minValue: Int? = -Int.MAX_VALUE,
     val maxValue: Int? = Int.MAX_VALUE
-) : FormInput(initialValue.toString()) {
-    override fun createControl() = IntegerTextInput(defaultValue.toInt(), minValue, maxValue)
+) : FormInput(initialValue?.toString() ?: "") {
+    override fun createControl() = IntegerTextInput(defaultValue.toIntOrNull(), minValue, maxValue)
 }
 
 open class FloatFormInput(
-    initialValue: Float,
+    initialValue: Float?,
     val minValue: Float? = -Float.MAX_VALUE,
     val maxValue: Float? = Float.MAX_VALUE
-) : FormInput(initialValue.toString()) {
-    override fun createControl() = FloatTextInput(defaultValue.toFloat(), minValue, maxValue)
+) : FormInput(initialValue?.toString() ?: "") {
+    override fun createControl() = FloatTextInput(defaultValue.toFloatOrNull(), minValue, maxValue)
 }

--- a/src/com/reco1l/andengine/ui/form/FormInput.kt
+++ b/src/com/reco1l/andengine/ui/form/FormInput.kt
@@ -8,14 +8,13 @@ import com.reco1l.framework.math.*
 @Suppress("LeakingThis")
 open class FormInput(initialValue: String = "") : FormControl<String, TextInput>(initialValue) {
 
-    override val control = TextInput(initialValue).apply {
-        width = FillParent
-    }
-
+    override val control = TextInput(initialValue)
     override val valueText = null
 
 
     init {
+        control.width = FillParent
+
         orientation = Orientation.Vertical
         spacing = 12f
 
@@ -28,4 +27,20 @@ open class FormInput(initialValue: String = "") : FormControl<String, TextInput>
         }
         +control
     }
+}
+
+open class IntegerFormInput(
+    initialValue: Int,
+    minValue: Int? = -Int.MAX_VALUE,
+    maxValue: Int? = Int.MAX_VALUE
+) : FormInput(initialValue.toString()) {
+    override val control = IntegerTextInput(initialValue, minValue, maxValue)
+}
+
+open class FloatFormInput(
+    initialValue: Float,
+    minValue: Float? = -Float.MAX_VALUE,
+    maxValue: Float? = Float.MAX_VALUE
+) : FormInput(initialValue.toString()) {
+    override val control = FloatTextInput(initialValue, minValue, maxValue)
 }

--- a/src/com/reco1l/andengine/ui/form/FormInput.kt
+++ b/src/com/reco1l/andengine/ui/form/FormInput.kt
@@ -8,13 +8,14 @@ import com.reco1l.framework.math.*
 @Suppress("LeakingThis")
 open class FormInput(initialValue: String = "") : FormControl<String, TextInput>(initialValue) {
 
-    override val control = TextInput(initialValue)
+    final override val control = createControl().apply {
+        width = FillParent
+    }
+
     override val valueText = null
 
 
     init {
-        control.width = FillParent
-
         orientation = Orientation.Vertical
         spacing = 12f
 
@@ -27,20 +28,22 @@ open class FormInput(initialValue: String = "") : FormControl<String, TextInput>
         }
         +control
     }
+
+    open fun createControl() = TextInput(defaultValue)
 }
 
 open class IntegerFormInput(
     initialValue: Int,
-    minValue: Int? = -Int.MAX_VALUE,
-    maxValue: Int? = Int.MAX_VALUE
+    val minValue: Int? = -Int.MAX_VALUE,
+    val maxValue: Int? = Int.MAX_VALUE
 ) : FormInput(initialValue.toString()) {
-    override val control = IntegerTextInput(initialValue, minValue, maxValue)
+    override fun createControl() = IntegerTextInput(defaultValue.toInt(), minValue, maxValue)
 }
 
 open class FloatFormInput(
     initialValue: Float,
-    minValue: Float? = -Float.MAX_VALUE,
-    maxValue: Float? = Float.MAX_VALUE
+    val minValue: Float? = -Float.MAX_VALUE,
+    val maxValue: Float? = Float.MAX_VALUE
 ) : FormInput(initialValue.toString()) {
-    override val control = FloatTextInput(initialValue, minValue, maxValue)
+    override fun createControl() = FloatTextInput(defaultValue.toFloat(), minValue, maxValue)
 }

--- a/src/com/rian/osu/mods/ModDifficultyAdjust.kt
+++ b/src/com/rian/osu/mods/ModDifficultyAdjust.kt
@@ -28,7 +28,7 @@ class ModDifficultyAdjust @JvmOverloads constructor(
      */
     var cs by NullableFloatModSetting(
         name = "Circle size",
-        valueFormatter = { it!!.roundBy(1).toString() },
+        valueFormatter = { (it ?: defaultValue)?.roundBy(1)?.toString() ?: "None" },
         defaultValue = cs,
         minValue = 0f,
         maxValue = 15f,
@@ -42,7 +42,7 @@ class ModDifficultyAdjust @JvmOverloads constructor(
      */
     var ar by NullableFloatModSetting(
         name = "Approach rate",
-        valueFormatter = { it!!.roundBy(1).toString() },
+        valueFormatter = { (it ?: defaultValue)?.roundBy(1)?.toString() ?: "None" },
         defaultValue = ar,
         minValue = 0f,
         maxValue = 12.5f,
@@ -56,7 +56,7 @@ class ModDifficultyAdjust @JvmOverloads constructor(
      */
     var od by NullableFloatModSetting(
         name = "Overall difficulty",
-        valueFormatter = { it!!.roundBy(1).toString() },
+        valueFormatter = { (it ?: defaultValue)?.roundBy(1)?.toString() ?: "None" },
         defaultValue = od,
         minValue = 0f,
         maxValue = 11f,
@@ -70,7 +70,7 @@ class ModDifficultyAdjust @JvmOverloads constructor(
      */
     var hp by NullableFloatModSetting(
         name = "Health drain",
-        valueFormatter = { it!!.roundBy(1).toString() },
+        valueFormatter = { (it ?: defaultValue)?.roundBy(1)?.toString() ?: "None" },
         defaultValue = hp,
         minValue = 0f,
         maxValue = 11f,

--- a/src/com/rian/osu/mods/ModRandom.kt
+++ b/src/com/rian/osu/mods/ModRandom.kt
@@ -22,6 +22,11 @@ class ModRandom : Mod(), IModApplicableToBeatmap {
     override val description = "It never gets boring!"
     override val type = ModType.Conversion
 
+    /**
+     * The seed that is used to generate the random numbers.
+     *
+     * If `null`, a random seed will be generated.
+     */
     var seed by NullableIntegerModSetting(
         name = "Seed",
         valueFormatter = { it.toString() },

--- a/src/com/rian/osu/mods/ModRandom.kt
+++ b/src/com/rian/osu/mods/ModRandom.kt
@@ -29,7 +29,7 @@ class ModRandom : Mod(), IModApplicableToBeatmap {
      */
     var seed by NullableIntegerModSetting(
         name = "Seed",
-        valueFormatter = { it.toString() },
+        valueFormatter = { it?.toString() ?: "" },
         defaultValue = null,
         minValue = 0,
         orderPosition = 0,

--- a/src/com/rian/osu/mods/ModRandom.kt
+++ b/src/com/rian/osu/mods/ModRandom.kt
@@ -22,8 +22,14 @@ class ModRandom : Mod(), IModApplicableToBeatmap {
     override val description = "It never gets boring!"
     override val type = ModType.Conversion
 
-    // TODO: Make this a mod setting once user input is possible
-    var seed: Int? = null
+    var seed by NullableIntegerModSetting(
+        name = "Seed",
+        valueFormatter = { it.toString() },
+        defaultValue = null,
+        minValue = 0,
+        orderPosition = 0,
+        useManualInput = true
+    )
 
     /**
      * Defines how sharp the angles of [HitObject]s should be.

--- a/src/com/rian/osu/mods/ModSetting.kt
+++ b/src/com/rian/osu/mods/ModSetting.kt
@@ -24,7 +24,7 @@ sealed class ModSetting<V>(
      *
      * This is used to format the value of this [ModSetting] when displaying it.
      */
-    val valueFormatter: ((V) -> String)?,
+    val valueFormatter: (ModSetting<V>.(V) -> String)?,
 
     /**
      * The default value of this [ModSetting], which is also the initial value of this [ModSetting].
@@ -77,7 +77,7 @@ sealed class ModSetting<V>(
  */
 sealed class RangeConstrainedModSetting<V>(
     name: String,
-    valueFormatter: (V) -> String = { it.toString() },
+    valueFormatter: ModSetting<V>.(V) -> String = { it.toString() },
     defaultValue: V,
 
     /**
@@ -158,7 +158,7 @@ sealed class RangeConstrainedModSetting<V>(
 
 open class IntegerModSetting(
     name: String,
-    valueFormatter: (Int) -> String = { it.toString() },
+    valueFormatter: ModSetting<Int>.(Int) -> String = { it.toString() },
     defaultValue: Int,
     minValue: Int = Int.MIN_VALUE,
     maxValue: Int = Int.MAX_VALUE,
@@ -227,7 +227,7 @@ open class IntegerModSetting(
 
 open class NullableIntegerModSetting(
     name: String,
-    valueFormatter: (Int?) -> String = { it.toString() },
+    valueFormatter: ModSetting<Int?>.(Int?) -> String = { it.toString() },
     defaultValue: Int?,
     minValue: Int = Int.MIN_VALUE,
     maxValue: Int = Int.MAX_VALUE,
@@ -290,7 +290,7 @@ open class NullableIntegerModSetting(
 
 open class FloatModSetting(
     name: String,
-    valueFormatter: (Float) -> String = { it.toString() },
+    valueFormatter: ModSetting<Float>.(Float) -> String = { it.toString() },
     defaultValue: Float,
     minValue: Float = Float.MIN_VALUE,
     maxValue: Float = Float.MAX_VALUE,
@@ -393,7 +393,7 @@ open class FloatModSetting(
 
 open class NullableFloatModSetting(
     name: String,
-    valueFormatter: (Float?) -> String = { it.toString() },
+    valueFormatter: ModSetting<Float?>.(Float?) -> String = { it.toString() },
     defaultValue: Float?,
     minValue: Float = Float.MIN_VALUE,
     maxValue: Float = Float.MAX_VALUE,

--- a/src/com/rian/osu/mods/ModSetting.kt
+++ b/src/com/rian/osu/mods/ModSetting.kt
@@ -225,6 +225,89 @@ open class IntegerModSetting(
     }
 }
 
+open class NullableIntegerModSetting(
+    name: String,
+    valueFormatter: (Int?) -> String = { it.toString() },
+    defaultValue: Int?,
+    minValue: Int = Int.MIN_VALUE,
+    maxValue: Int = Int.MAX_VALUE,
+    step: Int = 1,
+    orderPosition: Int? = null,
+
+    /**
+     * Whether to allow the user to input the value of this [NullableIntegerModSetting] manually.
+     */
+    val useManualInput: Boolean = false
+
+) : RangeConstrainedModSetting<Int?>(name, valueFormatter, defaultValue, minValue, maxValue, step, orderPosition) {
+    override var defaultValue
+        get() = super.defaultValue
+        set(value) {
+            if (value != null && value !in minValue!!..maxValue!!) {
+                throw IllegalArgumentException("defaultValue must be between minValue and maxValue.")
+            }
+
+            super.defaultValue = value
+        }
+
+    override var minValue
+        get() = super.minValue
+        set(value) {
+            if (value == null) {
+                throw IllegalArgumentException("minValue cannot be null.")
+            }
+
+            if (value > maxValue!!) {
+                throw IllegalArgumentException("minValue cannot be greater than maxValue.")
+            }
+
+            super.minValue = value
+        }
+
+    override var maxValue
+        get() = super.maxValue
+        set(value) {
+            if (value == null) {
+                throw IllegalArgumentException("maxValue cannot be null.")
+            }
+
+            if (value < minValue!!) {
+                throw IllegalArgumentException("maxValue cannot be less than minValue.")
+            }
+
+            super.maxValue = value
+        }
+
+    override var step
+        get() = super.step
+        set(value) {
+            if (value == null) {
+                throw IllegalArgumentException("step cannot be null.")
+            }
+
+            if (value < 0) {
+                throw IllegalArgumentException("step cannot be less than 0.")
+            }
+
+            super.step = value
+        }
+
+    init {
+        require(minValue <= maxValue) { "minValue must be less than or equal to maxValue." }
+        require(step >= 0f) { "step must be greater than or equal to 0." }
+        require(defaultValue == null || defaultValue in minValue..maxValue) { "defaultValue must be between minValue and maxValue." }
+    }
+
+    override fun processValue(value: Int?) = when {
+        value == null -> null
+        value < minValue!! -> minValue
+        value > maxValue!! -> maxValue
+        step == 0 -> value
+
+        else -> (round((value - minValue!!) / step!!.toFloat()) * step!! + minValue!!).roundToInt()
+    }
+}
+
 open class FloatModSetting(
     name: String,
     valueFormatter: (Float) -> String = { it.toString() },

--- a/src/com/rian/osu/mods/ModSetting.kt
+++ b/src/com/rian/osu/mods/ModSetting.kt
@@ -83,17 +83,17 @@ sealed class RangeConstrainedModSetting<V>(
     /**
      * The minimum value of this [RangeConstrainedModSetting].
      */
-    minValue: V,
+    minValue: V & Any,
 
     /**
      * The maximum value of this [RangeConstrainedModSetting].
      */
-    maxValue: V,
+    maxValue: V & Any,
 
     /**
      * The step size for the value of this [RangeConstrainedModSetting].
      */
-    step: V,
+    step: V & Any,
 
     /**
      * The position of this [RangeConstrainedModSetting] in the mod customization menu.
@@ -243,7 +243,7 @@ open class NullableIntegerModSetting(
     override var defaultValue
         get() = super.defaultValue
         set(value) {
-            if (value != null && value !in minValue!!..maxValue!!) {
+            if (value != null && value !in minValue..maxValue) {
                 throw IllegalArgumentException("defaultValue must be between minValue and maxValue.")
             }
 
@@ -253,11 +253,7 @@ open class NullableIntegerModSetting(
     override var minValue
         get() = super.minValue
         set(value) {
-            if (value == null) {
-                throw IllegalArgumentException("minValue cannot be null.")
-            }
-
-            if (value > maxValue!!) {
+            if (value > maxValue) {
                 throw IllegalArgumentException("minValue cannot be greater than maxValue.")
             }
 
@@ -267,11 +263,7 @@ open class NullableIntegerModSetting(
     override var maxValue
         get() = super.maxValue
         set(value) {
-            if (value == null) {
-                throw IllegalArgumentException("maxValue cannot be null.")
-            }
-
-            if (value < minValue!!) {
+            if (value < minValue) {
                 throw IllegalArgumentException("maxValue cannot be less than minValue.")
             }
 
@@ -281,10 +273,6 @@ open class NullableIntegerModSetting(
     override var step
         get() = super.step
         set(value) {
-            if (value == null) {
-                throw IllegalArgumentException("step cannot be null.")
-            }
-
             if (value < 0) {
                 throw IllegalArgumentException("step cannot be less than 0.")
             }
@@ -300,11 +288,11 @@ open class NullableIntegerModSetting(
 
     override fun processValue(value: Int?) = when {
         value == null -> null
-        value < minValue!! -> minValue
-        value > maxValue!! -> maxValue
+        value < minValue -> minValue
+        value > maxValue -> maxValue
         step == 0 -> value
 
-        else -> (round((value - minValue!!) / step!!.toFloat()) * step!! + minValue!!).roundToInt()
+        else -> (round((value - minValue) / step.toFloat()) * step + minValue).roundToInt()
     }
 }
 
@@ -453,7 +441,7 @@ open class NullableFloatModSetting(
     override var defaultValue
         get() = super.defaultValue
         set(value) {
-            if (value != null && value !in minValue!!..maxValue!!) {
+            if (value != null && value !in minValue..maxValue) {
                 throw IllegalArgumentException("defaultValue must be between minValue and maxValue.")
             }
 
@@ -463,11 +451,7 @@ open class NullableFloatModSetting(
     override var minValue
         get() = super.minValue
         set(value) {
-            if (value == null) {
-                throw IllegalArgumentException("minValue cannot be null.")
-            }
-
-            if (value > maxValue!!) {
+            if (value > maxValue) {
                 throw IllegalArgumentException("minValue cannot be greater than maxValue.")
             }
 
@@ -477,11 +461,7 @@ open class NullableFloatModSetting(
     override var maxValue
         get() = super.maxValue
         set(value) {
-            if (value == null) {
-                throw IllegalArgumentException("maxValue cannot be null.")
-            }
-
-            if (value < minValue!!) {
+            if (value < minValue) {
                 throw IllegalArgumentException("maxValue cannot be less than minValue.")
             }
 
@@ -491,10 +471,6 @@ open class NullableFloatModSetting(
     override var step
         get() = super.step
         set(value) {
-            if (value == null) {
-                throw IllegalArgumentException("step cannot be null.")
-            }
-
             if (value < 0) {
                 throw IllegalArgumentException("step cannot be less than 0.")
             }
@@ -533,13 +509,13 @@ open class NullableFloatModSetting(
 
     override fun processValue(value: Float?) = when {
         value == null -> null
-        value < minValue!! -> minValue
-        value > maxValue!! -> maxValue
+        value < minValue -> minValue
+        value > maxValue -> maxValue
         step == 0f -> value
 
         else -> {
-            val minValue = minValue!!
-            val step = step!!
+            val minValue = minValue
+            val step = step
             val precision = precision
 
             val value = round((value - minValue) / step) * step + minValue

--- a/src/com/rian/osu/mods/ModSetting.kt
+++ b/src/com/rian/osu/mods/ModSetting.kt
@@ -163,7 +163,13 @@ open class IntegerModSetting(
     minValue: Int = Int.MIN_VALUE,
     maxValue: Int = Int.MAX_VALUE,
     step: Int = 1,
-    orderPosition: Int? = null
+    orderPosition: Int? = null,
+
+    /**
+     * Whether to allow the user to input the value of this [IntegerModSetting] manually.
+     */
+    val useManualInput: Boolean = false
+
 ) : RangeConstrainedModSetting<Int>(name, valueFormatter, defaultValue, minValue, maxValue, step, orderPosition) {
     override var defaultValue
         get() = super.defaultValue
@@ -234,7 +240,12 @@ open class FloatModSetting(
      */
     precision: Int? = null,
 
-    orderPosition: Int? = null
+    orderPosition: Int? = null,
+
+    /**
+     * Whether to allow the user to input the value of this [FloatModSetting] manually.
+     */
+    val useManualInput: Boolean = false
 
 ) : RangeConstrainedModSetting<Float>(
     name,
@@ -340,7 +351,12 @@ open class NullableFloatModSetting(
      */
     precision: Int? = null,
 
-    orderPosition: Int? = null
+    orderPosition: Int? = null,
+
+    /**
+     * Whether to allow the user to input the value of this [NullableFloatModSetting] manually.
+     */
+    val useManualInput: Boolean = false
 
 ) : RangeConstrainedModSetting<Float?>(
     name,

--- a/src/com/rian/osu/mods/ModSetting.kt
+++ b/src/com/rian/osu/mods/ModSetting.kt
@@ -253,21 +253,13 @@ open class NullableIntegerModSetting(
     override var minValue
         get() = super.minValue
         set(value) {
-            if (value > maxValue) {
-                throw IllegalArgumentException("minValue cannot be greater than maxValue.")
-            }
-
-            super.minValue = value
+            super.minValue = min(value, maxValue)
         }
 
     override var maxValue
         get() = super.maxValue
         set(value) {
-            if (value < minValue) {
-                throw IllegalArgumentException("maxValue cannot be less than minValue.")
-            }
-
-            super.maxValue = value
+            super.maxValue = max(value, minValue)
         }
 
     override var step
@@ -340,21 +332,13 @@ open class FloatModSetting(
     override var minValue
         get() = super.minValue
         set(value) {
-            if (value > maxValue) {
-                throw IllegalArgumentException("minValue cannot be greater than maxValue.")
-            }
-
-            super.minValue = value
+            super.minValue = min(value, maxValue)
         }
 
     override var maxValue
         get() = super.maxValue
         set(value) {
-            if (value < minValue) {
-                throw IllegalArgumentException("maxValue cannot be less than minValue.")
-            }
-
-            super.maxValue = value
+            super.maxValue = max(value, minValue)
         }
 
     override var step
@@ -451,21 +435,13 @@ open class NullableFloatModSetting(
     override var minValue
         get() = super.minValue
         set(value) {
-            if (value > maxValue) {
-                throw IllegalArgumentException("minValue cannot be greater than maxValue.")
-            }
-
-            super.minValue = value
+            super.minValue = min(value, maxValue)
         }
 
     override var maxValue
         get() = super.maxValue
         set(value) {
-            if (value < minValue) {
-                throw IllegalArgumentException("maxValue cannot be less than minValue.")
-            }
-
-            super.maxValue = value
+            super.maxValue = max(value, minValue)
         }
 
     override var step


### PR DESCRIPTION
This PR adds support for `ModSetting`s that rely on manual user input, such as `ModRandom.seed`.

Of note, this also fixes the following problems with the current `TextInput` implementation (oversights on my review):
- The caret's position is not updated when the value of a `TextInput` is changed via external means (i.e., a `FormControl`'s reset button). This causes an IOOBE when the user attempts to write again.
- When deleting a character, the caret now only moves if its position is after the deleted character. This behavior is in line with many text inputs.

I've also changed the behavior of `minValue` and `maxValue` in `ModSetting` to cap the value instead of throwing.