### PR TITLE
More corrections and improvements to the framework

### DIFF
--- a/src/com/osudroid/ui/v2/modmenu/ModMenuPresetsSection.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModMenuPresetsSection.kt
@@ -30,7 +30,7 @@ class ModMenuPresetsSection : ModMenuSection("Presets") {
             text = "Add preset"
             leadingIcon = UISprite(ResourceManager.getInstance().getTexture("plus"))
             onActionUp = {
-                ModMenu.attachChild(ModPresetsForm(this@ModMenuPresetsSection))
+                ModPresetsForm(this@ModMenuPresetsSection).show()
             }
         }
         toggleContainer += addButton
@@ -100,7 +100,7 @@ class ModMenuPresetsSection : ModMenuSection("Presets") {
                 }
             }
             onActionLongPress = {
-                ModMenu.attachChild(UIMessageDialog().apply {
+                UIMessageDialog().apply {
                     title = "Delete preset"
                     text = "Delete preset \"${preset.name}\"?"
 
@@ -121,7 +121,7 @@ class ModMenuPresetsSection : ModMenuSection("Presets") {
                         }
                     })
                     show()
-                })
+                }
             }
 
             text {

--- a/src/com/osudroid/ui/v2/modmenu/ModPresetsForm.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModPresetsForm.kt
@@ -45,7 +45,5 @@ class ModPresetsForm(section: ModMenuPresetsSection) : UIDialog<UILinearContaine
                 hide()
             }
         })
-
-        show()
     }
 }

--- a/src/com/reco1l/andengine/ExtendedEngine.kt
+++ b/src/com/reco1l/andengine/ExtendedEngine.kt
@@ -170,6 +170,13 @@ class ExtendedEngine(val context: Activity, options: EngineOptions) : Engine(opt
     }
 
 
+    override fun setScene(scene: Scene?) {
+        mScene?.onDetached()
+        super.setScene(scene)
+        scene?.onAttached()
+    }
+
+
     companion object {
 
         @JvmStatic

--- a/src/com/reco1l/andengine/ExtendedEngine.kt
+++ b/src/com/reco1l/andengine/ExtendedEngine.kt
@@ -90,10 +90,12 @@ class ExtendedEngine(val context: Activity, options: EngineOptions) : Engine(opt
         val scene = scene ?: return
 
         fun IEntity.propagateSkinChange() {
-            callOnChildren { it.propagateSkinChange() }
+
             if (this is ISkinnable) {
                 onSkinChanged()
             }
+
+            forEach { it.propagateSkinChange() }
         }
 
         scene.propagateSkinChange()
@@ -106,10 +108,16 @@ class ExtendedEngine(val context: Activity, options: EngineOptions) : Engine(opt
         val scene = scene ?: return
 
         fun IEntity.propagateThemeChange() {
-            callOnChildren { it.propagateThemeChange() }
+
             if (this is UIComponent) {
                 onThemeChanged(theme)
             }
+
+            if (this is Scene) {
+                childScene?.propagateThemeChange()
+            }
+
+            forEach { it.propagateThemeChange() }
         }
 
         scene.propagateThemeChange()
@@ -131,6 +139,7 @@ class ExtendedEngine(val context: Activity, options: EngineOptions) : Engine(opt
                     return true
                 }
             }
+
             return false
         }
 
@@ -154,6 +163,7 @@ class ExtendedEngine(val context: Activity, options: EngineOptions) : Engine(opt
             if (event.x < left || event.x > right || event.y < top || event.y > bottom) {
                 (focusedEntity as IFocusable).blur()
             }
+            return true
         }
 
         return super.onTouchScene(scene, event)

--- a/src/com/reco1l/andengine/Initializers.kt
+++ b/src/com/reco1l/andengine/Initializers.kt
@@ -24,6 +24,10 @@ inline fun IEntity.constraintContainer(builder: UIConstraintContainer.() -> Unit
     return UIConstraintContainer().apply(builder).also(::attachChild)
 }
 
+inline fun IEntity.flexContainer(builder: UIFlexContainer.() -> Unit): UIFlexContainer {
+    return UIFlexContainer().apply(builder).also(::attachChild)
+}
+
 inline fun IEntity.scrollableContainer(builder: UIScrollableContainer.() -> Unit): UIScrollableContainer {
     return UIScrollableContainer().apply(builder).also(::attachChild)
 }

--- a/src/com/reco1l/andengine/UIScene.kt
+++ b/src/com/reco1l/andengine/UIScene.kt
@@ -1,8 +1,11 @@
 package com.reco1l.andengine
 
 import android.util.Log
+import com.reco1l.andengine.component.*
+import com.reco1l.andengine.ui.*
 import javax.microedition.khronos.opengles.GL10
 import org.anddev.andengine.engine.camera.Camera
+import org.anddev.andengine.entity.IEntity
 import org.anddev.andengine.entity.scene.Scene
 import org.anddev.andengine.entity.shape.IShape
 import org.anddev.andengine.input.touch.TouchEvent
@@ -44,6 +47,26 @@ open class UIScene : Scene(), IShape {
 
     override fun onManagedUpdate(deltaTimeSec: Float) {
         super.onManagedUpdate(deltaTimeSec * timeMultiplier)
+    }
+
+    override fun setChildScene(childScene: Scene?, modalDraw: Boolean, modalUpdate: Boolean, modalTouch: Boolean) {
+        childScene?.onDetached()
+        super.setChildScene(childScene, modalDraw, modalUpdate, modalTouch)
+        childScene?.onAttached()
+    }
+
+    override fun onAttached() {
+
+        fun IEntity.propagateThemeChange() {
+
+            if (this is UIComponent) {
+                onThemeChanged(Theme.current)
+            }
+
+            forEach { it.propagateThemeChange() }
+        }
+
+        propagateThemeChange()
     }
 
     //endregion

--- a/src/com/reco1l/andengine/buffered/BufferSharingMode.kt
+++ b/src/com/reco1l/andengine/buffered/BufferSharingMode.kt
@@ -1,0 +1,32 @@
+package com.reco1l.andengine.buffered
+
+/**
+ * Defines how a buffer is shared between multiple entities.
+ */
+enum class BufferSharingMode {
+    /**
+     * The buffer is not shared and is only used by a single entity.
+     */
+    Off,
+
+    /**
+     * The buffer is shared between multiple entities and is updated
+     * dynamically each frame according to the entity's data.
+     *
+     * This mode might be CPU intensive depending on the number of
+     * entities and how they update their data, but consumes less
+     * memory.
+     */
+    Dynamic,
+
+    /**
+     * The buffer is shared between multiple entities and is updated
+     * only once, when the entity is created or when its needed.
+     *
+     * This mode is the most memory and CPU efficient, but its not as
+     * flexible as the dynamic mode, since the data is not updated
+     * every frame. This is only recommended for entities where its
+     * data does not change.
+     */
+    Static,
+}

--- a/src/com/reco1l/andengine/buffered/CompoundBuffer.kt
+++ b/src/com/reco1l/andengine/buffered/CompoundBuffer.kt
@@ -8,18 +8,13 @@ import javax.microedition.khronos.opengles.GL10
  */
 class CompoundBuffer(vararg val buffers: Buffer) : IBuffer {
 
+    override var sharingMode = BufferSharingMode.Off
+
 
     inline fun <reified T : Buffer> getFirstOf(): T {
         return buffers.first { it is T } as T
     }
 
-
-    override fun update(gl: GL10, entity: UIBufferedComponent<*>, vararg data: Any) {
-        buffers.fastForEach { buffer ->
-            buffer.update(gl, entity, *data)
-            buffer.setHardwareBufferNeedsUpdate()
-        }
-    }
 
     //region Draw pipeline
 
@@ -33,6 +28,10 @@ class CompoundBuffer(vararg val buffers: Buffer) : IBuffer {
 
     override fun draw(gl: GL10, entity: UIBufferedComponent<*>) {
         buffers.fastForEach { it.draw(gl, entity) }
+    }
+
+    override fun invalidateOnHardware() {
+        buffers.fastForEach { it.invalidateOnHardware() }
     }
 
     //endregion

--- a/src/com/reco1l/andengine/buffered/IBuffer.kt
+++ b/src/com/reco1l/andengine/buffered/IBuffer.kt
@@ -5,6 +5,13 @@ import javax.microedition.khronos.opengles.GL10
 
 interface IBuffer {
 
+
+    /**
+     * Determines whether the buffer is shared between multiple entities and how it should be handled.
+     */
+    var sharingMode: BufferSharingMode
+
+
     /**
      * Called before drawing the buffer.
      */
@@ -16,11 +23,6 @@ interface IBuffer {
     fun declarePointers(gl: GL10, entity: UIBufferedComponent<*>)
 
     /**
-     * Called when the buffer should update its data.
-     */
-    fun update(gl: GL10, entity: UIBufferedComponent<*>, vararg data: Any)
-
-    /**
      * Called when the buffer should draw itself.
      */
     fun draw(gl: GL10, entity: UIBufferedComponent<*>)
@@ -30,6 +32,15 @@ interface IBuffer {
      */
     fun finalize() = Unit
 
+    /**
+     * Marks the buffer as needing an update in hardware buffers.
+     */
+    fun invalidateOnHardware() {
+        if (this is Buffer) {
+            setHardwareBufferNeedsUpdate()
+        }
+    }
+
 }
 
 abstract class Buffer(
@@ -38,6 +49,7 @@ abstract class Buffer(
     isManaged: Boolean = true
 ) : BufferObject(capacity, bufferUsage, isManaged), IBuffer {
 
+    override var sharingMode = BufferSharingMode.Off
 
     override fun finalize() {
         if (isManaged) {
@@ -45,4 +57,15 @@ abstract class Buffer(
         }
     }
 
+}
+
+
+fun <T : IBuffer> T.asSharedStatically(): T {
+    sharingMode = BufferSharingMode.Static
+    return this
+}
+
+fun <T : IBuffer> T.asSharedDynamically(): T {
+    sharingMode = BufferSharingMode.Dynamic
+    return this
 }

--- a/src/com/reco1l/andengine/buffered/UIBufferedComponent.kt
+++ b/src/com/reco1l/andengine/buffered/UIBufferedComponent.kt
@@ -39,7 +39,6 @@ abstract class UIBufferedComponent<T: IBuffer> : UIComponent() {
      */
     open var clearInfo = ClearInfo.None
 
-
     /**
      * Flags that determine when the buffer should be invalidated.
      */
@@ -64,47 +63,48 @@ abstract class UIBufferedComponent<T: IBuffer> : UIComponent() {
     /**
      * Called when the buffer needs to be built.
      */
-    protected abstract fun onCreateBuffer(gl: GL10): T?
+    protected abstract fun onCreateBuffer(): T?
 
     /**
      * Called when the buffer needs to be updated.
      */
-    protected open fun onUpdateBuffer(gl: GL10, vararg data: Any) {
-        val buffer = buffer
-
-        if (buffer != null) {
-            buffer.update(gl, this, *data)
-
-            if (buffer is Buffer) {
-                buffer.setHardwareBufferNeedsUpdate()
-            }
-        }
-    }
+    abstract fun onUpdateBuffer()
 
     //endregion
 
     //region Draw pipeline
 
-    override fun onManagedDraw(gl: GL10, camera: Camera) {
+    override fun onHandleInvalidations(restoreFlags: Boolean) {
 
         val invalidationFlags = bufferInvalidationFlags
 
         if (invalidationFlags != 0) {
-
             if (invalidationFlags and BufferInvalidationFlag.Instance != 0) {
-                buffer = onCreateBuffer(gl)
+                buffer = onCreateBuffer()
             }
+        }
 
+        super.onHandleInvalidations(restoreFlags)
+
+        // Buffer update is done after invalidations are handled so we can
+        // refer the buffer in those invalidations.
+        if (invalidationFlags != 0) {
+
+            // If the buffer is shared and its sharing mode is dynamic, we
+            // need to update it before drawing every frame, this might be
+            // CPU intensive, but the memory consumption is lower.
             if (invalidationFlags and BufferInvalidationFlag.Instance != 0 || invalidationFlags and BufferInvalidationFlag.Data != 0) {
-                onUpdateBuffer(gl)
+                val buffer = buffer
+
+                if (buffer != null && buffer.sharingMode != BufferSharingMode.Dynamic) {
+                    updateBuffer()
+                }
             }
 
             if (invalidationFlags == bufferInvalidationFlags) {
                 bufferInvalidationFlags = 0
             }
         }
-
-        super.onManagedDraw(gl, camera)
     }
 
     override fun doDraw(gl: GL10, camera: Camera) {
@@ -156,7 +156,17 @@ abstract class UIBufferedComponent<T: IBuffer> : UIComponent() {
         GLHelper.enableBlend(gl)
         GLHelper.blendFunction(gl, sourceFactor, destinationFactor)
 
+        // If it's a shared buffer, we might need to update it before drawing.
+        if (buffer?.sharingMode == BufferSharingMode.Dynamic) {
+            updateBuffer()
+        }
+
         buffer?.beginDraw(gl)
+    }
+
+    private fun updateBuffer() {
+        onUpdateBuffer()
+        buffer?.invalidateOnHardware()
     }
 
     protected open fun onDeclarePointers(gl: GL10) {

--- a/src/com/reco1l/andengine/component/Components.kt
+++ b/src/com/reco1l/andengine/component/Components.kt
@@ -13,7 +13,7 @@ import ru.nsu.ccfit.zuev.osu.Config
 
 fun IEntity?.getWidth() = when (this) {
     is UIComponent -> width
-    is CameraScene -> camera.widthRaw
+    is CameraScene -> camera?.widthRaw ?: 0f
     is IShape -> width
     is Scene -> Config.getRES_WIDTH().toFloat()
     else -> 0f
@@ -21,7 +21,7 @@ fun IEntity?.getWidth() = when (this) {
 
 fun IEntity?.getHeight() = when (this) {
     is UIComponent -> height
-    is CameraScene -> camera.heightRaw
+    is CameraScene -> camera?.heightRaw ?: 0f
     is IShape -> height
     is Scene -> Config.getRES_HEIGHT().toFloat()
     else -> 0f

--- a/src/com/reco1l/andengine/component/UIComponent.kt
+++ b/src/com/reco1l/andengine/component/UIComponent.kt
@@ -686,7 +686,7 @@ abstract class UIComponent : Entity(0f, 0f), ITouchArea, IModifierChain, IThemea
         }
     }
 
-    private fun onHandleInvalidations() {
+    fun onHandleInvalidations() {
 
         val flags = invalidationFlags
 

--- a/src/com/reco1l/andengine/component/UIComponent.kt
+++ b/src/com/reco1l/andengine/component/UIComponent.kt
@@ -429,14 +429,14 @@ abstract class UIComponent : Entity(0f, 0f), ITouchArea, IModifierChain, IThemea
      * Called when a child is attached to this entity.
      */
     open fun onChildAttached(child: IEntity) {
-        onContentChanged()
+        invalidate(InvalidationFlag.Content)
     }
 
     /**
      * Called when a child is detached from this entity.
      */
     open fun onChildDetached(child: IEntity) {
-        onContentChanged()
+        invalidate(InvalidationFlag.Content)
     }
 
     override fun setVisible(value: Boolean) {
@@ -448,6 +448,7 @@ abstract class UIComponent : Entity(0f, 0f), ITouchArea, IModifierChain, IThemea
 
     override fun onAttached() {
         onThemeChanged(Theme.current)
+        onHandleInvalidations(false)
     }
 
     //endregion
@@ -458,7 +459,7 @@ abstract class UIComponent : Entity(0f, 0f), ITouchArea, IModifierChain, IThemea
      * Called when the size of a child entity changes.
      */
     open fun onChildSizeChanged(child: IEntity) {
-        onContentChanged()
+        invalidate(InvalidationFlag.Content)
     }
 
     /**
@@ -527,7 +528,7 @@ abstract class UIComponent : Entity(0f, 0f), ITouchArea, IModifierChain, IThemea
      * Called when the position of a child entity changes.
      */
     open fun onChildPositionChanged(child: IEntity) {
-        onContentChanged()
+        invalidate(InvalidationFlag.Content)
     }
 
     /**
@@ -675,7 +676,7 @@ abstract class UIComponent : Entity(0f, 0f), ITouchArea, IModifierChain, IThemea
         }
     }
 
-    fun onHandleInvalidations() {
+    open fun onHandleInvalidations(restoreFlags: Boolean = true) {
 
         val flags = invalidationFlags
 
@@ -708,9 +709,12 @@ abstract class UIComponent : Entity(0f, 0f), ITouchArea, IModifierChain, IThemea
         }
 
         // During the invalidation process the flags could be changed.
-        if (this.invalidationFlags == flags) {
+        if (this.invalidationFlags == flags && restoreFlags) {
             this.invalidationFlags = 0
         }
+
+        background?.onHandleInvalidations()
+        foreground?.onHandleInvalidations()
     }
 
     override fun onManagedDraw(gl: GL10, camera: Camera) {

--- a/src/com/reco1l/andengine/component/UIComponent.kt
+++ b/src/com/reco1l/andengine/component/UIComponent.kt
@@ -62,26 +62,15 @@ abstract class UIComponent : Entity(0f, 0f), ITouchArea, IModifierChain, IThemea
 
     //region Size related properties
 
-    private fun isReservedSizeValue(value: Float): Boolean {
-        return value == MatchContent
-            || value == FillParent
-            || value == FitParent
-    }
+    @Suppress("NOTHING_TO_INLINE")
+    private inline fun computeSizeValue(value: Float, padding: Float, position: Float, isRelative: Boolean, contentSize: Float, containerSize: Float): Float {
+        return when (value) {
+            MatchContent -> contentSize + padding
+            FillParent -> containerSize - position
+            FitParent -> min(contentSize + padding, containerSize - position)
 
-    private fun computeSizeValue(value: Float, padding: Float, position: Float, isRelative: Boolean, contentSize: Float, containerSize: Float): Float {
-
-        if (isReservedSizeValue(value)) {
-            return when (value) {
-                MatchContent -> contentSize + padding
-                FillParent -> containerSize - position
-                FitParent -> min(contentSize + padding, containerSize - position)
-
-                // This is unreachable, if it happens means the function `isReservedSizeValue` is not working properly.
-                else -> throw IllegalArgumentException("Invalid reserved size value: $value")
-            }
+            else -> if (isRelative) value * containerSize else value
         }
-
-        return if (isRelative) value * containerSize else value + padding
     }
 
     /**

--- a/src/com/reco1l/andengine/container/UIFlexContainer.kt
+++ b/src/com/reco1l/andengine/container/UIFlexContainer.kt
@@ -1,0 +1,176 @@
+@file:Suppress("MemberVisibilityCanBePrivate")
+
+package com.reco1l.andengine.container
+
+import com.reco1l.andengine.component.*
+
+class UIFlexContainer : UIContainer() {
+
+    /**
+     * The gap between the children of the container.
+     *
+     * This will only take effect if justify content is set to [Start][JustifyContent.Start],
+     * [End][JustifyContent.End] or [Center][JustifyContent.Center].
+     */
+    var gap = 0f
+        set(value) {
+            field = value
+            invalidate(InvalidationFlag.Content)
+        }
+
+    /**
+     * The direction of the flex container.
+     */
+    var direction = FlexDirection.Row
+        set(value) {
+            field = value
+            invalidate(InvalidationFlag.Content)
+        }
+
+    /**
+     * The justification of the content inside the flex container.
+     *
+     * This will affect how the children are positioned and sized inside the container.
+     */
+    var justifyContent = JustifyContent.Start
+        set(value) {
+            field = value
+            invalidate(InvalidationFlag.Content)
+        }
+
+
+    private var rules = mutableMapOf<UIComponent, FlexRules>()
+
+
+    //region Utilities
+
+    private var UIComponent.directionSize
+        get() = if (direction == FlexDirection.Row) width else height
+        set(value) = if (direction == FlexDirection.Row) {
+            minWidth = value
+            maxWidth = value
+        } else {
+            minHeight = value
+            maxHeight = value
+        }
+
+    private val UIComponent.directionBaseSize
+        get() = if (direction == FlexDirection.Row) contentWidth + padding.horizontal else contentHeight + padding.vertical
+
+    private val UIComponent.directionInnerSize
+        get() = if (direction == FlexDirection.Row) innerWidth else innerHeight
+
+    private var UIComponent.directionPosition
+        get() = if (direction == FlexDirection.Row) x else y
+        set(value) = (if (direction == FlexDirection.Row) x = value else y = value)
+
+    //endregion
+
+    override fun onContentChanged() {
+
+        var spaceSum = 0f
+        var growSum = 0f
+
+        forEach { child -> child as UIComponent
+            val rules = rules[child]
+
+            spaceSum += rules?.basis ?: child.directionBaseSize
+            growSum += rules?.grow ?: 0f
+        }
+
+        val totalGapSpace = gap * (childCount - 1)
+        val freeSpace = directionInnerSize - spaceSum - totalGapSpace
+        val freeSpaceToJustify = if (growSum > 0f) 0f else freeSpace
+
+        var currentPosition = when (justifyContent) {
+            JustifyContent.End -> freeSpaceToJustify
+            JustifyContent.Center -> freeSpaceToJustify / 2f
+            else -> 0f
+        }
+
+        forEachIndexed { _, child -> child as UIComponent
+
+            val rules = rules[child]
+            val assignedSpace = if (growSum > 0f) ((rules?.grow ?: 0f) / growSum) * freeSpace else 0f
+
+            child.directionSize = (rules?.basis ?: child.directionBaseSize) + assignedSpace
+
+            when (justifyContent) {
+
+                JustifyContent.Start, JustifyContent.End, JustifyContent.Center -> {
+                    child.directionPosition = currentPosition
+                    currentPosition += child.directionSize + gap
+                }
+
+                JustifyContent.SpaceBetween, JustifyContent.SpaceAround -> {
+
+                    val space = when (justifyContent) {
+                        JustifyContent.SpaceBetween -> if (childCount == 1) 0f else freeSpaceToJustify / (childCount - 1)
+                        JustifyContent.SpaceAround -> freeSpaceToJustify / (childCount + 1)
+
+                        else -> 0f // Unreachable
+                    }
+
+                    if (justifyContent == JustifyContent.SpaceAround) {
+                        currentPosition += space / 2f
+                    }
+
+                    child.directionPosition = currentPosition
+                    currentPosition += child.directionSize + space
+                }
+            }
+        }
+
+        super.onContentChanged()
+    }
+
+
+    /**
+     * Sets the flex rules for the given [UIComponent].
+     */
+    fun UIComponent.flexRules(block: FlexRules.() -> Unit) {
+        rules.getOrPut(this) { FlexRules() }.block()
+        invalidate(InvalidationFlag.Content)
+    }
+
+}
+
+/**
+ * The flex rules for a [UIComponent] inside a [UIFlexContainer].
+ */
+data class FlexRules(
+    /**
+     * The grow factor of the component.
+     *
+     * This will determine how much space the component will take relative to other components
+     * with a grow factor.
+     */
+    var grow: Float = 0f,
+
+    /**
+     * The basis size of the component.
+     *
+     * This will be the initial size of the component before any grow factor is applied.
+     */
+    var basis: Float? = null
+)
+
+
+/**
+ * The direction of the flex container.
+ */
+enum class FlexDirection {
+    Row,
+    Column
+}
+
+/**
+ * The justification of the content inside a [UIFlexContainer].
+ */
+enum class JustifyContent {
+    Start,
+    End,
+    Center,
+    SpaceBetween,
+    SpaceAround
+}

--- a/src/com/reco1l/andengine/container/UILinearContainer.kt
+++ b/src/com/reco1l/andengine/container/UILinearContainer.kt
@@ -44,7 +44,7 @@ open class UILinearContainer : UIContainer() {
                     right += child.getWidth()
                     bottom = max(bottom, child.getHeight())
 
-                    if (i < childCount - 1) {
+                    if (childCount > 1 && i < childCount - 1) {
                         right += spacing
                     }
                 }
@@ -55,7 +55,7 @@ open class UILinearContainer : UIContainer() {
                     right = max(right, child.getWidth())
                     bottom += child.getHeight()
 
-                    if (i < childCount - 1) {
+                    if (childCount > 1 && i < childCount - 1) {
                         bottom += spacing
                     }
                 }

--- a/src/com/reco1l/andengine/container/UIScrollableContainer.kt
+++ b/src/com/reco1l/andengine/container/UIScrollableContainer.kt
@@ -370,14 +370,14 @@ open class UIScrollableContainer : UIContainer() {
         val length = hypot(deltaX, deltaY)
 
         fun decreaseInBoundary(current: Float, delta: Float, max: Float): Float {
-            if (current - delta < 0f || current - delta > max) {
+            if (current - delta > 0f && current - delta < max) {
                 return delta
             }
             return delta * if (length > 0) length.pow(0.7f) / length else 0f
         }
 
         if (scrollAxes.isHorizontal && !Precision.almostEquals(deltaX, 0f)) {
-            velocityX = abs(deltaX) / dragTimeSeconds * sign(deltaX)
+            velocityX = if (dragTimeSeconds > 0.3f) 0f else deltaX / dragTimeSeconds
             scrollX -= decreaseInBoundary(scrollX, deltaX, maxScrollX)
 
             if (!overflowAxes.isHorizontal) {
@@ -386,7 +386,7 @@ open class UIScrollableContainer : UIContainer() {
         }
 
         if (scrollAxes.isVertical && !Precision.almostEquals(deltaY, 0f)) {
-            velocityY = abs(deltaY) / dragTimeSeconds * sign(deltaY)
+            velocityY = if (dragTimeSeconds > 0.3f) 0f else deltaY / dragTimeSeconds
             scrollY -= decreaseInBoundary(scrollY, deltaY, maxScrollY)
 
             if (!overflowAxes.isVertical) {

--- a/src/com/reco1l/andengine/container/UIScrollableContainer.kt
+++ b/src/com/reco1l/andengine/container/UIScrollableContainer.kt
@@ -222,6 +222,15 @@ open class UIScrollableContainer : UIContainer() {
     private var dragStartTimeMillis = 0L
 
 
+    /**
+     * Stops the scrolling of the container by setting the velocity to 0.
+     */
+    fun stopScroll() {
+        velocityX = 0f
+        velocityY = 0f
+    }
+
+
     //region Callbacks
 
     @CallSuper

--- a/src/com/reco1l/andengine/shape/UIBox.kt
+++ b/src/com/reco1l/andengine/shape/UIBox.kt
@@ -51,7 +51,7 @@ open class UIBox : UIBufferedComponent<BoxVBO>() {
         invalidateBuffer(BufferInvalidationFlag.Instance)
     }
 
-    override fun onCreateBuffer(gl: GL10): BoxVBO {
+    override fun onCreateBuffer(): BoxVBO {
 
         val radius = cornerRadius.coerceAtMost(min(width, height) / 2f).coerceAtLeast(0f)
         val segments = if (radius > 0f) UICircle.approximateSegments(radius, radius, 90f) else 0
@@ -62,6 +62,10 @@ open class UIBox : UIBufferedComponent<BoxVBO>() {
         }
 
         return BoxVBO(radius, segments, paintStyle)
+    }
+
+    override fun onUpdateBuffer() {
+        buffer?.update(this)
     }
 
     override fun beginDraw(gl: GL10) {
@@ -89,7 +93,7 @@ open class UIBox : UIBufferedComponent<BoxVBO>() {
             Outline -> GL_LINE_STRIP
         }
     ) {
-        override fun update(gl: GL10, entity: UIBufferedComponent<*>, vararg data: Any) {
+        fun update(entity: UIBox) {
 
             val width = entity.width
             val height = entity.height

--- a/src/com/reco1l/andengine/shape/UICircle.kt
+++ b/src/com/reco1l/andengine/shape/UICircle.kt
@@ -77,12 +77,24 @@ open class UICircle : UIBufferedComponent<CircleVertexBuffer>() {
         invalidateBuffer(BufferInvalidationFlag.Instance)
     }
 
-    override fun onCreateBuffer(gl: GL10): CircleVertexBuffer {
-        return CircleVertexBuffer(approximateSegments(width, height))
+    override fun onCreateBuffer(): CircleVertexBuffer {
+
+        val buffer = buffer
+        val segments = approximateSegments(width, height)
+
+        if (buffer?.segments == segments && buffer.paintStyle == paintStyle) {
+            return buffer
+        }
+
+        return CircleVertexBuffer(segments, paintStyle)
+    }
+
+    override fun onUpdateBuffer() {
+        buffer?.update(this)
     }
 
 
-    inner class CircleVertexBuffer(private val segments: Int) : VertexBuffer(
+    class CircleVertexBuffer(val segments: Int, val paintStyle: PaintStyle) : VertexBuffer(
 
         // Segments + Center point
         vertexCount = segments + if (paintStyle == PaintStyle.Fill) 1 else 0,
@@ -92,7 +104,7 @@ open class UICircle : UIBufferedComponent<CircleVertexBuffer>() {
         drawTopology = if (paintStyle == PaintStyle.Fill) GL_TRIANGLE_FAN else GL_LINE_STRIP
     ) {
 
-        override fun update(gl: GL10, entity: UIBufferedComponent<*>, vararg data: Any) {
+        fun update(entity: UICircle) {
 
             val halfWidth = entity.width / 2f
             val halfHeight = entity.height / 2f
@@ -103,7 +115,7 @@ open class UICircle : UIBufferedComponent<CircleVertexBuffer>() {
                 putVertex(position++, halfWidth, halfHeight)
             }
 
-            addArc(position, halfWidth, halfHeight, startAngle, endAngle, halfWidth, halfHeight, segments)
+            addArc(position, halfWidth, halfHeight, entity.startAngle, entity.endAngle, halfWidth, halfHeight, segments)
         }
     }
 

--- a/src/com/reco1l/andengine/shape/UILine.kt
+++ b/src/com/reco1l/andengine/shape/UILine.kt
@@ -41,8 +41,12 @@ class UILine : UIBufferedComponent<LineVertexBuffer>() {
         }
 
 
-    override fun onCreateBuffer(gl: GL10): LineVertexBuffer {
+    override fun onCreateBuffer(): LineVertexBuffer {
         return LineVertexBuffer()
+    }
+
+    override fun onUpdateBuffer() {
+        buffer?.update(this)
     }
 
     override fun beginDraw(gl: GL10) {
@@ -51,15 +55,15 @@ class UILine : UIBufferedComponent<LineVertexBuffer>() {
     }
 
 
-    inner class LineVertexBuffer : VertexBuffer(
+    class LineVertexBuffer : VertexBuffer(
         drawTopology = GL_LINES,
         vertexCount = 2,
         vertexSize = VERTEX_2D,
         bufferUsage = GL_STATIC_DRAW
     ) {
-        override fun update(gl: GL10, entity: UIBufferedComponent<*>, vararg data: Any) {
-            putVertex(0, fromPoint.x, fromPoint.y)
-            putVertex(1, toPoint.x, toPoint.y)
+        fun update(entity: UILine) {
+            putVertex(0, entity.fromPoint.x, entity.fromPoint.y)
+            putVertex(1, entity.toPoint.x, entity.toPoint.y)
         }
     }
 

--- a/src/com/reco1l/andengine/shape/UITriangle.kt
+++ b/src/com/reco1l/andengine/shape/UITriangle.kt
@@ -28,8 +28,12 @@ open class UITriangle : UIBufferedComponent<TriangleVBO>() {
         invalidateBuffer(BufferInvalidationFlag.Data)
     }
 
-    override fun onCreateBuffer(gl: GL10): TriangleVBO {
+    override fun onCreateBuffer(): TriangleVBO {
         return TriangleVBO()
+    }
+
+    override fun onUpdateBuffer() {
+        buffer?.update(this)
     }
 
     override fun beginDraw(gl: GL10) {
@@ -38,9 +42,9 @@ open class UITriangle : UIBufferedComponent<TriangleVBO>() {
     }
 
 
-    inner class TriangleVBO : VertexBuffer(GL_TRIANGLES, 3, VERTEX_2D, GL_STATIC_DRAW) {
+    class TriangleVBO : VertexBuffer(GL_TRIANGLES, 3, VERTEX_2D, GL_STATIC_DRAW) {
 
-        override fun update(gl: GL10, entity: UIBufferedComponent<*>, vararg data: Any) {
+        fun update(entity: UITriangle) {
             addTriangle(
                 index = 0,
                 centerX = entity.width / 2f,
@@ -51,7 +55,8 @@ open class UITriangle : UIBufferedComponent<TriangleVBO>() {
         }
 
         override fun draw(gl: GL10, entity: UIBufferedComponent<*>) {
-            gl.glDrawArrays(if (paintStyle == PaintStyle.Fill) GL_TRIANGLES else GL_LINE_LOOP, 0, vertexCount)
+            entity as UITriangle
+            gl.glDrawArrays(if (entity.paintStyle == PaintStyle.Fill) GL_TRIANGLES else GL_LINE_LOOP, 0, vertexCount)
         }
 
     }

--- a/src/com/reco1l/andengine/sprite/UISprite.kt
+++ b/src/com/reco1l/andengine/sprite/UISprite.kt
@@ -124,9 +124,20 @@ open class UISprite(textureRegion: TextureRegion? = null) : UIBufferedComponent<
     }
 
 
-    override fun onCreateBuffer(gl: GL10): SpriteVBO {
-        return SpriteVBO()
+    override fun onSizeChanged() {
+        super.onSizeChanged()
+        invalidateBuffer(BufferInvalidationFlag.Data)
     }
+
+
+    override fun onCreateBuffer(): SpriteVBO {
+        return buffer ?: SpriteVBO()
+    }
+
+    override fun onUpdateBuffer() {
+        buffer?.update(this)
+    }
+
 
     override fun beginDraw(gl: GL10) {
         super.beginDraw(gl)
@@ -140,30 +151,29 @@ open class UISprite(textureRegion: TextureRegion? = null) : UIBufferedComponent<
     }
 
 
-    inner class SpriteVBO : VertexBuffer(
+    class SpriteVBO : VertexBuffer(
         drawTopology = GL_TRIANGLE_STRIP,
         vertexCount = 4,
         vertexSize = VERTEX_2D,
         bufferUsage = GL_STATIC_DRAW
     ) {
-        override fun update(gl: GL10, entity: UIBufferedComponent<*>, vararg data: Any) {
-
-            val textureWidth = contentWidth
-            val textureHeight = contentHeight
+        fun update(entity: UISprite) {
+            val textureWidth = entity.contentWidth
+            val textureHeight = entity.contentHeight
 
             var quadWidth = textureWidth
             var quadHeight = textureHeight
 
-            when (scaleType) {
+            when (entity.scaleType) {
 
                 Crop -> {
-                    val scale = max(width / textureWidth, height / textureHeight)
+                    val scale = max(entity.width / textureWidth, entity.height / textureHeight)
                     quadWidth = textureWidth * scale
                     quadHeight = textureHeight * scale
                 }
 
                 Fit -> {
-                    val scale = min(width / textureWidth, height / textureHeight)
+                    val scale = min(entity.width / textureWidth, entity.height / textureHeight)
                     quadWidth = textureWidth * scale
                     quadHeight = textureHeight * scale
                 }
@@ -171,8 +181,8 @@ open class UISprite(textureRegion: TextureRegion? = null) : UIBufferedComponent<
                 Stretch -> Unit
             }
 
-            val x = (width - quadWidth) * gravity.x
-            val y = (height - quadHeight) * gravity.y
+            val x = (entity.width - quadWidth) * entity.gravity.x
+            val y = (entity.height - quadHeight) * entity.gravity.y
 
             addQuad(0, x, y, x + quadWidth, y + quadHeight)
         }

--- a/src/com/reco1l/andengine/text/UITextureText.kt
+++ b/src/com/reco1l/andengine/text/UITextureText.kt
@@ -119,7 +119,7 @@ open class UITextureText(val characters: MutableMap<Char, TextureRegion>) : UIBu
             gl.glPushMatrix()
             gl.glTranslatef(offsetX, 0f, 0f)
 
-            onUpdateBuffer(gl, textureWidth, textureHeight)
+            buffer?.update(textureWidth, textureHeight)
             texture.onApply(gl)
 
             onDeclarePointers(gl)
@@ -131,18 +131,13 @@ open class UITextureText(val characters: MutableMap<Char, TextureRegion>) : UIBu
         }
     }
 
-    override fun onCreateBuffer(gl: GL10): TextureTextVertexBuffer {
+    override fun onCreateBuffer(): TextureTextVertexBuffer {
         return TextureTextVertexBuffer()
     }
 
-    override fun onUpdateBuffer(gl: GL10, vararg data: Any) {
-        if (data.isEmpty()) {
-            super.onUpdateBuffer(gl, 0f, 0f)
-        } else {
-            super.onUpdateBuffer(gl, *data)
-        }
+    override fun onUpdateBuffer() {
+        // Nothing to do here, buffer is updated in `doDraw`.
     }
-
 
     inner class TextureTextVertexBuffer : VertexBuffer(
         drawTopology = GL_TRIANGLE_STRIP,
@@ -150,8 +145,8 @@ open class UITextureText(val characters: MutableMap<Char, TextureRegion>) : UIBu
         vertexSize = VERTEX_2D,
         bufferUsage = GL_STATIC_DRAW
     ) {
-        override fun update(gl: GL10, entity: UIBufferedComponent<*>, vararg data: Any) {
-            addQuad(0, 0f, 0f, data[0] as Float, data[1] as Float)
+        fun update(textureWidth: Float, textureHeight: Float) {
+            addQuad(0, 0f, 0f, textureWidth, textureHeight)
         }
     }
 }

--- a/src/com/reco1l/andengine/ui/UIButton.kt
+++ b/src/com/reco1l/andengine/ui/UIButton.kt
@@ -16,6 +16,7 @@ open class UIButton : UILinearContainer() {
     override var applyTheme: UIComponent.(Theme) -> Unit = { theme ->
         background?.color = if (isSelected) theme.accentColor else theme.accentColor * 0.175f
         color = if (isSelected) theme.accentColor * 0.1f else theme.accentColor
+        alpha = if (isEnabled) 1f else 0.5f
     }
 
 

--- a/src/ru/nsu/ccfit/zuev/audio/serviceAudio/BassAudioFunc.java
+++ b/src/ru/nsu/ccfit/zuev/audio/serviceAudio/BassAudioFunc.java
@@ -27,8 +27,6 @@ public class BassAudioFunc {
     private ByteBuffer buffer = null;
     private int playFlag = BASS.BASS_STREAM_PRESCAN;
     private boolean isGaming = false;
-    private BroadcastReceiver receiver;
-    private LocalBroadcastManager broadcastManager;
 
     /**
      * The channel's frequency, in Hz.
@@ -257,27 +255,13 @@ public class BassAudioFunc {
         this.isGaming = isGaming;
     }
 
-    public void setReciverStuff(BroadcastReceiver receiver, IntentFilter filter, Context context) {
-        this.receiver = receiver;
-        if (broadcastManager == null) {
-            broadcastManager = LocalBroadcastManager.getInstance(context);
-            broadcastManager.registerReceiver(receiver, filter);
-        }
-    }
-
-    public void unregisterReceiverBM() {
-        if (broadcastManager != null) broadcastManager.unregisterReceiver(receiver);
-    }
-
     public void freeALL() {
         BASS.BASS_Free();
     }
 
     private void setEndSync() {
         BASS.BASS_ChannelSetSync(channel, BASS.BASS_SYNC_END, 0, (handle, channel, data, user) -> {
-            if (!isGaming) {
-                broadcastManager.sendBroadcast(new Intent("Notify_next"));
-            } else {
+            if (isGaming) {
                 stop();
             }
         }, 0);

--- a/src/ru/nsu/ccfit/zuev/audio/serviceAudio/SongService.java
+++ b/src/ru/nsu/ccfit/zuev/audio/serviceAudio/SongService.java
@@ -107,7 +107,6 @@ public class SongService extends Service {
         Log.w("SongService", "Hei Service is on EXIT()");
         if (audioFunc == null) return false;
         audioFunc.stop();
-        audioFunc.unregisterReceiverBM();
         audioFunc.freeALL();
         stopSelf();
         return true;

--- a/src/ru/nsu/ccfit/zuev/osu/MainScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/MainScene.java
@@ -16,6 +16,9 @@ import com.osudroid.data.BeatmapInfo;
 import com.osudroid.ui.MainMenu;
 
 import com.osudroid.beatmaplisting.BeatmapListing;
+import com.reco1l.andengine.ui.UIConfirmDialog;
+import com.reco1l.andengine.ui.UIMessageDialog;
+import com.reco1l.andengine.ui.UITextButton;
 import com.reco1l.framework.Color4;
 import com.reco1l.osu.ui.MessageDialog;
 import com.rian.osu.beatmap.parser.BeatmapParser;
@@ -123,6 +126,7 @@ public class MainScene implements IUpdateHandler {
         Debug.i("Load: mainMenuLoaded()");
         VibratorManager.INSTANCE.init(context);
         scene = new Scene();
+        scene.setOnAreaTouchTraversalFrontToBack();
 
         final TextureRegion tex = ResourceManager.getInstance().getTexture("menu-background");
 
@@ -907,20 +911,14 @@ public class MainScene implements IUpdateHandler {
     }
 
     public void showExitDialog() {
-
-        new MessageDialog()
-            .setTitle("Exit")
-            .setMessage(context.getString(com.osudroid.resources.R.string.dialog_exit_message))
-            .addButton("Yes", dialog -> {
-                dialog.dismiss();
-                exit();
-                return null;
-            })
-            .addButton("No", dialog -> {
-                dialog.dismiss();
-                return null;
-            })
-            .show();
+        UIConfirmDialog dialog = new UIConfirmDialog();
+        dialog.setTitle("Exit");
+        dialog.setText(context.getString(com.osudroid.resources.R.string.dialog_exit_message));
+        dialog.setOnConfirm(() -> {
+            exit();
+            return null;
+        });
+        dialog.show();
     }
 
     public void exit() {

--- a/tests/test/kotlin/com/reco1l/andengine/UIComponentTest.kt
+++ b/tests/test/kotlin/com/reco1l/andengine/UIComponentTest.kt
@@ -1,0 +1,159 @@
+package com.reco1l.andengine
+
+import com.reco1l.andengine.container.*
+import com.reco1l.framework.math.*
+import junit.framework.TestCase.*
+import org.junit.Test
+import org.junit.runner.*
+import org.robolectric.*
+
+@RunWith(RobolectricTestRunner::class)
+class UIComponentTest {
+
+    @Test
+    fun `Test container auto-size`() {
+
+        val container = UIContainer().apply {
+            +UIDummyComponent().apply {
+                width = 100f
+                height = 100f
+            }
+
+            onHandleInvalidations()
+        }
+
+        assertEquals(100f, container.width)
+        assertEquals(100f, container.height)
+    }
+
+    @Test
+    fun `Test container auto-size with padding`() {
+
+        val container = UIContainer().apply {
+            padding = Vec4(20f)
+
+            +UIDummyComponent().apply {
+                width = 100f
+                height = 100f
+            }
+
+            onHandleInvalidations()
+        }
+
+        assertEquals(100f + 20f * 2, container.width)
+        assertEquals(100f + 20f * 2, container.height)
+    }
+
+    @Test
+    fun `Test linear container auto-size`() {
+
+        val container = UILinearContainer().apply {
+            spacing = 10f
+
+            +UIDummyComponent().apply {
+                width = 100f
+                height = 100f
+            }
+
+            +UIDummyComponent().apply {
+                width = 100f
+                height = 100f
+            }
+
+            onHandleInvalidations()
+        }
+
+        assertEquals(100f * 2, container.width)
+        assertEquals(100f, container.height)
+    }
+
+    @Test
+    fun `Test linear container auto-size with padding`() {
+
+        val container = UILinearContainer().apply {
+            padding = Vec4(20f)
+
+            +UIDummyComponent().apply {
+                width = 100f
+                height = 100f
+            }
+
+            +UIDummyComponent().apply {
+                width = 100f
+                height = 100f
+            }
+
+            onHandleInvalidations()
+        }
+
+        assertEquals(100f * 2 + 20f * 2, container.width)
+        assertEquals(100f + 20f * 2, container.height)
+    }
+
+    @Test
+    fun `Test linear container spacing`() {
+
+        val container = UILinearContainer().apply {
+            spacing = 10f
+
+            +UIDummyComponent().apply {
+                width = 100f
+                height = 100f
+            }
+
+            +UIDummyComponent().apply {
+                width = 100f
+                height = 100f
+            }
+
+            onHandleInvalidations()
+        }
+
+        assertEquals(100f * 2 + 10f, container.width)
+        assertEquals(100f, container.height)
+    }
+
+    @Test
+    fun `Test linear container spacing with padding`() {
+
+        val container = UILinearContainer().apply {
+            padding = Vec4(20f)
+            spacing = 10f
+
+            +UIDummyComponent().apply {
+                width = 100f
+                height = 100f
+            }
+
+            +UIDummyComponent().apply {
+                width = 100f
+                height = 100f
+            }
+
+            onHandleInvalidations()
+        }
+
+        assertEquals(100f * 2 + 10f + 20f * 2, container.width)
+        assertEquals(100f + 20f * 2, container.height)
+    }
+
+
+    @Test
+    fun `Test child's relative size axes`() {
+
+        val component = UIDummyComponent().apply {
+            relativeSizeAxes = Axes.X
+            width = 0.5f
+            height = 100f
+        }
+
+        UIContainer().apply {
+            width = 200f
+            height = 200f
+            +component
+            onHandleInvalidations()
+        }
+
+        assertEquals(component.width, 100f)
+    }
+}

--- a/tests/test/kotlin/com/reco1l/andengine/UIDummyComponent.kt
+++ b/tests/test/kotlin/com/reco1l/andengine/UIDummyComponent.kt
@@ -1,0 +1,9 @@
+package com.reco1l.andengine
+
+import com.reco1l.andengine.component.*
+
+
+/**
+ * A dummy component used for testing purposes.
+ */
+class UIDummyComponent : UIComponent()

--- a/tests/test/kotlin/com/reco1l/andengine/UIFlexContainerTest.kt
+++ b/tests/test/kotlin/com/reco1l/andengine/UIFlexContainerTest.kt
@@ -1,0 +1,45 @@
+package com.reco1l.andengine
+
+import com.reco1l.andengine.container.*
+import junit.framework.TestCase.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class UIFlexContainerTest {
+
+    @Test
+    fun `Test flex container flex-grow`() {
+
+        val component1: UIDummyComponent
+        val component2: UIDummyComponent
+
+        UIFlexContainer().apply {
+            width = 100f
+
+            +UIDummyComponent().apply {
+                height = 100f
+                flexRules {
+                    grow = 2f
+                }
+                component1 = this
+            }
+
+            +UIDummyComponent().apply {
+                width = 100f
+
+                flexRules {
+                    grow = 1f
+                }
+                component2 = this
+            }
+
+            onHandleInvalidations()
+        }
+
+        assertEquals(component1.width, 100f * (2f / 3f))
+        assertEquals(component2.width, 100f * (1f / 3f))
+    }
+
+}


### PR DESCRIPTION
## Summary
* Introduced `UIFlexContainer`, works similarly as a flex-box from CSS (lacks features but for what we have now it's enough).
* `UIText` now measures its content size when the flag `Content` is set, it also preserves lines and line widths to reutilize on each invalidation.
* `UIBufferedComponent` no longer uses varargs when updating the buffer data.
* Introduced a way to determine when a buffer is shared and how should it be handled.
* Fixed a bug where the scrolling on a `UIScrollableContainer` was reduced in velocity incorrectly.
* Fixed content size measurement being wrong when a container has only one child in some layouts.
* Fixed potential NPE when trying to compute component size with Scene's `Camera` being `null`.
* Fixed theme not being propagated properly along entities.
* Fixed `onAttached()` and `onDetached()` not being called on scenes and child scenes.