### PR TITLE
Use Config.SENSITIVE_KEYS constant for ConfigBackup

### DIFF
--- a/src/ru/nsu/ccfit/zuev/osu/Config.java
+++ b/src/ru/nsu/ccfit/zuev/osu/Config.java
@@ -17,6 +17,7 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import com.osudroid.multiplayer.Multiplayer;
@@ -99,6 +100,13 @@ public class Config {
     private static Color4[] comboColors;
     private static Context context;
 
+    public static final Set<String> SENSITIVE_KEYS = Set.of(
+        "installID",
+        "onlineUsername",
+        "onlinePassword",
+        "starRatingVersion",
+        "version"
+    );
 
     /**
      * The shared preferences of the application.

--- a/src/ru/nsu/ccfit/zuev/osu/ConfigBackup.java
+++ b/src/ru/nsu/ccfit/zuev/osu/ConfigBackup.java
@@ -13,13 +13,10 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Set;
 
 import org.anddev.andengine.util.Debug;
 
 public class ConfigBackup {
-
-    private static final Set<String> EXCLUDE_KEYS = Set.of("installID", "onlineUsername", "onlinePassword");
 
     public static boolean exportPreferences() {
         try {
@@ -31,7 +28,7 @@ public class ConfigBackup {
             
             allPrefs.entrySet()
                 .stream()
-                .filter(entry -> !EXCLUDE_KEYS.contains(entry.getKey()))
+                .filter(entry -> !Config.SENSITIVE_KEYS.contains(entry.getKey()))
                 .forEach(entry -> {
                     try{
                         json.put(entry.getKey(), entry.getValue());
@@ -76,7 +73,7 @@ public class ConfigBackup {
             Iterator<String> keys = json.keys();
             while(keys.hasNext()) {
                 String key = keys.next();
-                if(EXCLUDE_KEYS.contains(key)) continue;
+                if(Config.SENSITIVE_KEYS.contains(key)) continue;
                 Object value = json.get(key);
             
                 switch(value.getClass().getSimpleName()) {


### PR DESCRIPTION
Continuation of #553

Use a centralized SENSITIVE_KEYS constant from the Config class instead of being a one-use variable inside of the ConfigBackup class.

This also adds `version` and `starRatingVersion` to the exclusion.