### PR TITLE
Add `GameObject` lifetime tracking

### DIFF
--- a/src/ru/nsu/ccfit/zuev/osu/game/GameObject.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameObject.java
@@ -226,7 +226,7 @@ public abstract class GameObject {
     }
 
     /**
-     * Called when the lifetime of this {@link GameObject}'s lifetime expires and is about to be considered inactive.
+     * Called when this {@link GameObject}'s lifetime expires.
      */
     public void onExpire() {}
 

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameObject.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameObject.java
@@ -218,6 +218,14 @@ public abstract class GameObject {
     //region Lifetime management
 
     /**
+     * Whether the underlying {@link HitObject} of this {@link GameObject} has been judged in its entirety, including
+     * nested {@link HitObject}s.
+     */
+    public boolean isJudged() {
+        return false;
+    }
+
+    /**
      * Called when the lifetime of this {@link GameObject}'s lifetime expires and is about to be considered inactive.
      */
     public void onExpire() {}

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameObject.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameObject.java
@@ -9,6 +9,8 @@ import com.osudroid.game.CursorEvent;
 import com.rian.osu.beatmap.HitWindow;
 import com.rian.osu.beatmap.hitobject.HitObject;
 
+import org.anddev.andengine.util.modifier.IModifier;
+
 import ru.nsu.ccfit.zuev.osu.Utils;
 import ru.nsu.ccfit.zuev.osu.scoring.Replay;
 
@@ -20,6 +22,7 @@ public abstract class GameObject {
     protected Replay.ReplayObjectData replayObjectData = null;
     protected boolean startHit = false;
     protected PointF position = new PointF();
+    private float lifetimeEnd;
 
     public Replay.ReplayObjectData getReplayData() {
         return replayObjectData;
@@ -211,4 +214,34 @@ public abstract class GameObject {
 
         return Utils.squaredDistance(position, cursorEvent.position) <= Utils.sqr((float) hitObject.getScreenSpaceGameplayRadius());
     }
+
+    //region Lifetime management
+
+    /**
+     * Called when the lifetime of this {@link GameObject}'s lifetime expires and is about to be considered inactive.
+     */
+    public void onExpire() {}
+
+    /**
+     * Obtains the time in seconds since the beatmap started at which this {@link GameObject}'s lifetime ends.
+     */
+    public float getLifetimeEnd() {
+        return lifetimeEnd;
+    }
+
+    protected void setLifetimeEnd(float lifetimeEnd) {
+        this.lifetimeEnd = lifetimeEnd;
+    }
+
+    /**
+     * Extends the lifetime of this {@link GameObject} to allow an {@link IModifier} to finish.
+     *
+     * @param elapsedTime Elapsed time since the start of the beatmap, in seconds.
+     * @param modifier The {@link IModifier} to extend this {@link GameObject}'s lifetime with.
+     */
+    protected void extendLifetime(float elapsedTime, IModifier<?> modifier) {
+        lifetimeEnd = Math.max(lifetimeEnd, elapsedTime + modifier.getDuration());
+    }
+
+    //endregion
 }

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameObjectListener.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameObjectListener.java
@@ -26,8 +26,6 @@ public interface GameObjectListener {
 
     void addObject(GameObject object);
 
-    void removeObject(GameObject object);
-
     boolean isObjectHittable(GameObject object);
 
     Cursor getCursor(int index);

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -2508,10 +2508,6 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
         activeObjects.add(object);
     }
 
-    public void removeObject(final GameObject object) {
-        expiredObjects.add(object);
-    }
-
     @Override
     public boolean isObjectHittable(GameObject object) {
         return object == judgeableObject;

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -1682,6 +1682,10 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
 
         // Clearing expired objects.
         if (!expiredObjects.isEmpty()) {
+            for (int i = 0, size = expiredObjects.size(); i < size; i++) {
+                expiredObjects.get(i).onExpire();
+            }
+
             activeObjects.removeAll(expiredObjects);
             expiredObjects.clear();
         }
@@ -1984,6 +1988,10 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
                 // is hit.
                 judgeableObject = searchJudgeableObject(i + 1);
             }
+
+            if (elapsedTime >= obj.getLifetimeEnd()) {
+                expiredObjects.add(obj);
+            }
         }
     }
 
@@ -2000,14 +2008,10 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
 
     @Nullable
     private GameObject searchJudgeableObject(int startIndex) {
-        if (!Config.isRemoveSliderLock()) {
-            return activeObjects.isEmpty() ? null : activeObjects.get(0);
-        }
-
         for (int i = startIndex, size = activeObjects.size(); i < size; i++) {
             var obj = activeObjects.get(i);
 
-            if (!obj.isStartHit()) {
+            if (!obj.isJudged()) {
                 return obj;
             }
         }

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -165,6 +165,7 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
     private boolean comboWas100 = false;
     private ArrayList<GameObject> activeObjects;
     private ArrayList<GameObject> expiredObjects;
+    private final Set<GameObject> processedExpiredObjects = Collections.newSetFromMap(new IdentityHashMap<>());
     private GameObject judgeableObject;
     private BreakPeriod[] breakPeriods;
     private int breakPeriodIndex;
@@ -1681,9 +1682,15 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
         }
 
         // Clearing expired objects.
+        processedExpiredObjects.clear();
+
         if (!expiredObjects.isEmpty()) {
             for (int i = 0, size = expiredObjects.size(); i < size; i++) {
-                expiredObjects.get(i).onExpire();
+                var obj = expiredObjects.get(i);
+
+                if (processedExpiredObjects.add(obj)) {
+                    obj.onExpire();
+                }
             }
 
             activeObjects.removeAll(expiredObjects);

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -1693,8 +1693,8 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
         updatePassiveObjects(dt);
         updateActiveObjects(dt);
 
-        if (GameHelper.isAutoplay() || GameHelper.isAutopilot()) {
-            autoCursor.moveToObject(activeObjects.isEmpty() ? null : activeObjects.get(0), elapsedTime, this);
+        if (judgeableObject != null && (GameHelper.isAutoplay() || GameHelper.isAutopilot())) {
+            autoCursor.moveToObject(judgeableObject, elapsedTime, this);
         }
 
         if (videoEnabled && video != null && elapsedTime >= videoOffset)

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameplayHitCircle.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameplayHitCircle.java
@@ -166,6 +166,8 @@ public class GameplayHitCircle extends GameObject {
 
         scene.attachChild(circlePiece, 0);
         scene.attachChild(approachCircle);
+
+        setLifetimeEnd(hitTime + (float) beatmapCircle.hitWindow.getMehWindow() / 1000);
     }
 
     private void removeFromScene() {
@@ -188,16 +190,13 @@ public class GameplayHitCircle extends GameObject {
 
         if (successfulHit || !circlePiece.isVisible() || circlePiece.getAlpha() == 0) {
             circlePiece.detachSelf();
-
-            Execution.updateThread(() -> GameObjectPool.getInstance().putCircle(this));
         } else {
-            circlePiece.registerEntityModifier(Modifiers.alpha(0.1f, circlePiece.getAlpha(), 0, e -> Execution.updateThread(() -> {
-                circlePiece.detachSelf();
-                GameObjectPool.getInstance().putCircle(this);
-            })));
+            var fadeOutModifier = Modifiers.alpha(0.1f, circlePiece.getAlpha(), 0, e -> Execution.updateThread(e::detachSelf));
+
+            circlePiece.registerEntityModifier(fadeOutModifier);
+            extendLifetime(hitTime + passedTime - timePreempt, fadeOutModifier);
         }
 
-        listener.removeObject(this);
         scene = null;
     }
 
@@ -212,9 +211,7 @@ public class GameplayHitCircle extends GameObject {
             return;
         }
 
-        // PassedTime < 0 means circle logic is over
-        if (passedTime < 0) {
-            removeFromScene();
+        if (isJudged()) {
             return;
         }
 
@@ -226,7 +223,6 @@ public class GameplayHitCircle extends GameObject {
                 listener.registerAccuracy(replayObjectData.accuracy / 1000f);
                 startHit = true;
                 successfulHit = Math.abs(replayObjectData.accuracy / 1000f) <= mehWindow;
-                passedTime = -1;
                 // Remove circle and register hit in update thread
                 listener.onCircleHit(id, replayObjectData.accuracy / 1000f, position,endsCombo, replayObjectData.result, comboColor);
                 if (successfulHit) {
@@ -243,7 +239,6 @@ public class GameplayHitCircle extends GameObject {
                 listener.registerAccuracy(hitOffset);
                 startHit = true;
                 successfulHit = Math.abs(hitOffset) <= mehWindow;
-                passedTime = -1;
                 // Remove circle and register hit in update thread
                 listener.onCircleHit(id, (float) hitOffset, position, endsCombo, (byte) 0, comboColor);
                 if (successfulHit) {
@@ -276,7 +271,6 @@ public class GameplayHitCircle extends GameObject {
         }
 
         if (autoPlay) {
-            passedTime = -1;
             // Remove circle and register hit in update thread
             listener.onCircleHit(id, 0, position, endsCombo, ResultType.HIT300.getId(), comboColor);
             startHit = true;
@@ -289,12 +283,24 @@ public class GameplayHitCircle extends GameObject {
 
             // If passed too much time, counting it as miss
             if (passedTime > timePreempt + mehWindow) {
-                passedTime = -1;
+                startHit = true;
                 final byte forcedScore = (replayObjectData == null) ? 0 : replayObjectData.result;
 
                 removeFromScene();
                 listener.onCircleHit(id, 10, position, false, forcedScore, comboColor);
             }
         }
+    }
+
+    @Override
+    public void onExpire() {
+        super.onExpire();
+
+        GameObjectPool.getInstance().putCircle(this);
+    }
+
+    @Override
+    public boolean isJudged() {
+        return startHit;
     }
 }

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameplayModernSpinner.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameplayModernSpinner.java
@@ -2,7 +2,6 @@ package ru.nsu.ccfit.zuev.osu.game;
 
 import android.graphics.PointF;
 
-import com.osudroid.utils.Execution;
 import com.reco1l.andengine.sprite.UISprite;
 import com.reco1l.andengine.modifier.Modifiers;
 import com.reco1l.andengine.Anchor;
@@ -84,7 +83,6 @@ public class GameplayModernSpinner extends GameplaySpinner {
         fullRotations = 0;
         rotations = 0;
         bonusScoreCounter = 1;
-        spinnable = false;
 
         reloadHitSounds();
 
@@ -120,25 +118,28 @@ public class GameplayModernSpinner extends GameplaySpinner {
         scene.attachChild(middle2);
 
         float timePreempt = (float) beatmapSpinner.timePreempt / 1000f;
+        passedTime = -timePreempt;
 
-        top.registerEntityModifier(Modifiers.sequence(e -> Execution.updateThread(this::removeFromScene),
-            Modifiers.fadeIn(timePreempt, e -> {
-                    spinnable = true;
-                    listener.onSpinnerStart(id);
-            }),
-            Modifiers.delay(duration)
-        ));
-
+        top.registerEntityModifier(Modifiers.fadeIn(timePreempt));
         bottom.registerEntityModifier(Modifiers.fadeIn(timePreempt));
         middle.registerEntityModifier(Modifiers.fadeIn(timePreempt));
         middle2.registerEntityModifier(Modifiers.fadeIn(timePreempt));
+
+        setLifetimeEnd((float) beatmapSpinner.getEndTime() / 1000);
     }
 
     @Override
     public void update(float dt) {
+        passedTime += dt;
+
         // Allow the spinner to fully fade in first before receiving spins.
-        if (!spinnable) {
+        if (passedTime < 0) {
             return;
+        }
+
+        if (!startHit) {
+            listener.onSpinnerStart(id);
+            startHit = true;
         }
 
         updateSamples(dt);
@@ -262,6 +263,10 @@ public class GameplayModernSpinner extends GameplaySpinner {
         }
 
         oldMouse.set(currMouse);
+
+        if (passedTime >= duration) {
+            removeFromScene();
+        }
     }
 
     public void removeFromScene() {
@@ -281,10 +286,6 @@ public class GameplayModernSpinner extends GameplaySpinner {
         scene.detachChild(glow);
 
         scene.detachChild(bonusScore);
-
-        listener.removeObject(GameplayModernSpinner.this);
-
-        Execution.updateThread(() -> GameObjectPool.getInstance().putSpinner(this));
 
         int score = 0;
         if (replayObjectData != null) {

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameplayModernSpinner.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameplayModernSpinner.java
@@ -83,6 +83,7 @@ public class GameplayModernSpinner extends GameplaySpinner {
         fullRotations = 0;
         rotations = 0;
         bonusScoreCounter = 1;
+        startHit = false;
 
         reloadHitSounds();
 

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameplaySlider.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameplaySlider.java
@@ -458,6 +458,7 @@ public class GameplaySlider extends GameObject {
         }
 
         applyBodyFadeAdjustments(fadeInDuration);
+        setLifetimeEnd(hitTime + (float) Math.max(duration, hitWindow.getMehWindow() / 1000));
     }
 
     private PointF getPositionAt(final float percentage, final boolean updateBallAngle, final boolean updateEndArrowRotation) {
@@ -565,33 +566,36 @@ public class GameplaySlider extends GameObject {
             return;
         }
 
+        float elapsedTime = (float) getGameplayPassedTimeMilliseconds() / 1000;
+
+        if (Config.isAnimateFollowCircle() && isInRadius) {
+            isFollowCircleAnimating = true;
+
+            followCircle.clearEntityModifiers();
+            followCircle.registerEntityModifier(Modifiers.scale(0.2f, followCircle.getScaleX(), followCircle.getScaleX() * 0.8f, null, Easing.OutQuad));
+
+            var modifier = Modifiers.alpha(0.2f, followCircle.getAlpha(), 0f, e -> {
+                Execution.updateThread(e::detachSelf);
+                isFollowCircleAnimating = false;
+            });
+
+            followCircle.registerEntityModifier(modifier);
+            extendLifetime(elapsedTime, modifier);
+        }
+
         if (GameHelper.getHidden() != null && !GameHelper.getHidden().isOnlyFadeApproachCircles()) {
             sliderBody.detachSelf();
-
-            // If the animation is enabled, at this point it will be still animating.
-            if (!Config.isAnimateFollowCircle() || !isFollowCircleAnimating) {
-                poolObject();
-            }
         } else {
-            sliderBody.registerEntityModifier(Modifiers.fadeOut(0.24f, e -> {
-                Execution.updateThread(() -> {
-                    sliderBody.detachSelf();
+            var modifier = Modifiers.fadeOut(0.24f, e -> Execution.updateThread(e::detachSelf));
 
-                    // We can pool the hit object once all animations are finished.
-                    // The slider body is the last object to finish animating.
-                    poolObject();
-                });
-            }));
+            sliderBody.registerEntityModifier(modifier);
+            extendLifetime(elapsedTime, modifier);
         }
 
-        ball.registerEntityModifier(Modifiers.fadeOut(0.1f, e -> {
-            Execution.updateThread(ball::detachSelf);
-        }));
+        var ballModifier = Modifiers.fadeOut(0.1f, e -> Execution.updateThread(e::detachSelf));
 
-        // Follow circle might still be animating when the slider is removed from the scene.
-        if (!Config.isAnimateFollowCircle() || !isFollowCircleAnimating) {
-            followCircle.detachSelf();
-        }
+        ball.registerEntityModifier(ballModifier);
+        extendLifetime(elapsedTime, ballModifier);
 
         if (!isHeadCircleAnimating) {
             // When animating, the head circle will detach after the animation ends.
@@ -604,7 +608,6 @@ public class GameplaySlider extends GameObject {
         endArrow.detachSelf();
         tickContainer.detachSelf();
 
-        listener.removeObject(this);
         stopSlidingSamples();
 
         for (int i = 0, iSize = nestedHitSamples.size(); i < iSize; ++i) {
@@ -624,8 +627,8 @@ public class GameplaySlider extends GameObject {
         scene = null;
     }
 
-    public void poolObject() {
-
+    @Override
+    public void onExpire() {
         headCirclePiece.clearEntityModifiers();
         tailCirclePiece.clearEntityModifiers();
         sliderHeadLateMissFadeModifier = null;
@@ -778,25 +781,6 @@ public class GameplaySlider extends GameObject {
 
         listener.onSliderEnd(id, firstHitAccuracy, tickSet);
 
-        // Remove slider from scene
-        if (Config.isAnimateFollowCircle() && isInRadius) {
-            isFollowCircleAnimating = true;
-
-            followCircle.clearEntityModifiers();
-            followCircle.registerEntityModifier(Modifiers.scale(0.2f, followCircle.getScaleX(), followCircle.getScaleX() * 0.8f, null, Easing.OutQuad));
-            followCircle.registerEntityModifier(Modifiers.alpha(0.2f, followCircle.getAlpha(), 0f, e -> {
-                Execution.updateThread(() -> {
-                    followCircle.detachSelf();
-
-                    // When hidden mod is enabled, the follow circle is the last object to finish animating.
-                    if (GameHelper.getHidden() != null && !GameHelper.getHidden().isOnlyFadeApproachCircles()) {
-                        poolObject();
-                    }
-                });
-                isFollowCircleAnimating = false;
-            }));
-        }
-
         removeFromScene();
     }
 
@@ -862,6 +846,7 @@ public class GameplaySlider extends GameObject {
     }
 
     private void updateFollowCircleTrackingState() {
+        float elapsedTime = (float) getGameplayPassedTimeMilliseconds() / 1000;
         float scale = beatmapSlider.getScreenSpaceGameplayScale();
         boolean isTracking = isTracking();
 
@@ -878,9 +863,11 @@ public class GameplaySlider extends GameObject {
 
                 followCircle.clearEntityModifiers();
                 followCircle.registerEntityModifier(Modifiers.alpha(Math.min(remainTime, 0.06f), followCircle.getAlpha(), 1f));
-                followCircle.registerEntityModifier(Modifiers.scale(Math.min(remainTime, 0.18f), initialScale, scale, e -> {
-                    isFollowCircleAnimating = false;
-                }, Easing.OutQuad));
+
+                var scaleModifier = Modifiers.scale(Math.min(remainTime, 0.18f), initialScale, scale, e -> isFollowCircleAnimating = false, Easing.OutQuad);
+
+                followCircle.registerEntityModifier(scaleModifier);
+                extendLifetime(elapsedTime, scaleModifier);
             } else if (!isTracking && isInRadius) {
                 isInRadius = false;
                 isFollowCircleAnimating = true;
@@ -888,12 +875,16 @@ public class GameplaySlider extends GameObject {
 
                 followCircle.clearEntityModifiers();
                 followCircle.registerEntityModifier(Modifiers.scale(0.1f, followCircle.getScaleX(), scale * 2f));
-                followCircle.registerEntityModifier(Modifiers.alpha(0.1f, followCircle.getAlpha(), 0f, e -> {
+
+                var alphaModifier = Modifiers.alpha(0.1f, followCircle.getAlpha(), 0f, e -> {
                     if (isOver) {
                         Execution.updateThread(e::detachSelf);
                     }
                     isFollowCircleAnimating = false;
-                }));
+                });
+
+                followCircle.registerEntityModifier(alphaModifier);
+                extendLifetime(elapsedTime, alphaModifier);
             }
         } else {
             if (isTracking && !isInRadius) {
@@ -1065,6 +1056,11 @@ public class GameplaySlider extends GameObject {
         }
     }
 
+    @Override
+    public boolean isJudged() {
+        return Config.isRemoveSliderLock() ? startHit : isOver;
+    }
+
     private float getTrackingDistanceThresholdSquared(boolean isTracking) {
         float radius = (float) beatmapSlider.getScreenSpaceGameplayRadius();
         float distanceThresholdSquared = radius * radius;
@@ -1218,10 +1214,13 @@ public class GameplaySlider extends GameObject {
                 // Slider head is hit too early - slowly fade it.
                 isHeadCircleAnimating = true;
 
-                headCirclePiece.registerEntityModifier(Modifiers.alpha(0.1f, headCirclePiece.getAlpha(), 0, e -> {
+                var modifier = Modifiers.alpha(0.1f, headCirclePiece.getAlpha(), 0, e -> {
                     isHeadCircleAnimating = false;
-                    Execution.updateThread(headCirclePiece::detachSelf);
-                }));
+                    Execution.updateThread(e::detachSelf);
+                });
+
+                headCirclePiece.registerEntityModifier(modifier);
+                extendLifetime((float) getGameplayPassedTimeMilliseconds() / 1000, modifier);
             }
         }
     }

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameplaySlider.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameplaySlider.java
@@ -602,6 +602,11 @@ public class GameplaySlider extends GameObject {
             headCirclePiece.detachSelf();
         }
 
+        // Follow circle might still be animating when the slider is removed from the scene.
+        if (!Config.isAnimateFollowCircle() || !isFollowCircleAnimating) {
+            followCircle.detachSelf();
+        }
+
         tailCirclePiece.detachSelf();
         approachCircle.detachSelf();
         startArrow.detachSelf();

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameplaySpinner.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameplaySpinner.java
@@ -2,7 +2,6 @@ package ru.nsu.ccfit.zuev.osu.game;
 
 import android.graphics.PointF;
 
-import com.osudroid.utils.Execution;
 import com.reco1l.andengine.sprite.UISprite;
 import com.reco1l.andengine.modifier.Modifiers;
 import com.reco1l.andengine.Anchor;
@@ -48,8 +47,8 @@ public class GameplaySpinner extends GameObject {
     protected boolean clear = false;
     protected int bonusScoreCounter = 1;
     protected StatisticV2 stat;
+    protected float passedTime;
     protected float duration;
-    protected boolean spinnable;
 
     protected final boolean isSpinnerFrequencyModulate;
     protected final ArrayList<GameplayHitSampleInfo> hitSamples = new ArrayList<>(5);
@@ -120,15 +119,14 @@ public class GameplaySpinner extends GameObject {
 
         this.listener = listener;
         this.stat = stat;
-        startHit = true;
         clear = duration <= 0f;
         bonusScoreCounter = 1;
-        spinnable = false;
 
         reloadHitSounds();
         ResourceManager.getInstance().checkSpinnerTextures();
 
         float timePreempt = (float) beatmapSpinner.timePreempt / 1000f;
+        passedTime = -timePreempt;
 
         background.setVisible(!GameHelper.isTraceable() ||
                 (Config.isShowFirstApproachCircle() && GameHelper.getTraceable().getFirstObject() == beatmapSpinner));
@@ -142,7 +140,7 @@ public class GameplaySpinner extends GameObject {
         }
 
         circle.setAlpha(0);
-        circle.registerEntityModifier(Modifiers.sequence(e -> listener.onSpinnerStart(id),
+        circle.registerEntityModifier(Modifiers.sequence(
             Modifiers.delay(timePreempt * 0.75f),
             Modifiers.fadeIn(timePreempt * 0.25f)
         ));
@@ -159,8 +157,9 @@ public class GameplaySpinner extends GameObject {
         if (GameHelper.isHidden()) {
             approachCircle.setVisible(false);
         }
-        approachCircle.registerEntityModifier(Modifiers.sequence(e -> Execution.updateThread(this::removeFromScene),
-            Modifiers.delay(timePreempt, e -> spinnable = true),
+
+        approachCircle.registerEntityModifier(Modifiers.sequence(
+            Modifiers.delay(timePreempt),
             Modifiers.parallel(
                 Modifiers.alpha(duration, 0.75f, 1),
                 Modifiers.scale(duration, 2.0f, 0)
@@ -183,6 +182,7 @@ public class GameplaySpinner extends GameObject {
 
         oldMouse = null;
 
+        setLifetimeEnd((float) beatmapSpinner.getEndTime() / 1000);
     }
 
     void removeFromScene() {
@@ -205,10 +205,6 @@ public class GameplaySpinner extends GameObject {
         scene.detachChild(metre);
 
         scene.detachChild(bonusScore);
-
-        listener.removeObject(GameplaySpinner.this);
-
-        Execution.updateThread(() -> GameObjectPool.getInstance().putSpinner(this));
 
         int score = 0;
         if (replayObjectData != null) {
@@ -257,9 +253,16 @@ public class GameplaySpinner extends GameObject {
 
     @Override
     public void update(final float dt) {
+        passedTime += dt;
+
         // Allow the spinner to fully fade in first before receiving spins.
-        if (!spinnable) {
+        if (passedTime < 0) {
             return;
+        }
+
+        if (!startHit) {
+            listener.onSpinnerStart(id);
+            startHit = true;
         }
 
         updateSamples(dt);
@@ -365,6 +368,24 @@ public class GameplaySpinner extends GameObject {
                 (int) (metre.getBaseHeight() * (1 - Math.abs(percentfill))));
 
         oldMouse.set(currMouse);
+
+        if (passedTime >= duration) {
+            removeFromScene();
+        }
+    }
+
+    @Override
+    public void onExpire() {
+        super.onExpire();
+
+        GameObjectPool.getInstance().putSpinner(this);
+    }
+
+    @Override
+    public boolean isJudged() {
+        // In remove spinner lock mode, the spinner is assumed to be judged to allow other objects to be judged while
+        // the spinner is still active.
+        return Config.isRemoveSliderLock() || passedTime >= duration;
     }
 
     protected void reloadHitSounds() {

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameplaySpinner.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameplaySpinner.java
@@ -121,6 +121,7 @@ public class GameplaySpinner extends GameObject {
         this.stat = stat;
         clear = duration <= 0f;
         bonusScoreCounter = 1;
+        startHit = false;
 
         reloadHitSounds();
         ResourceManager.getInstance().checkSpinnerTextures();

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameplaySpinner.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameplaySpinner.java
@@ -158,14 +158,6 @@ public class GameplaySpinner extends GameObject {
             approachCircle.setVisible(false);
         }
 
-        approachCircle.registerEntityModifier(Modifiers.sequence(
-            Modifiers.delay(timePreempt),
-            Modifiers.parallel(
-                Modifiers.alpha(duration, 0.75f, 1),
-                Modifiers.scale(duration, 2.0f, 0)
-            )
-        ));
-
         spinText.setAlpha(0);
         spinText.registerEntityModifier(Modifiers.sequence(
             Modifiers.delay(timePreempt * 0.75f),
@@ -175,7 +167,19 @@ public class GameplaySpinner extends GameObject {
         ));
 
         scene.attachChild(spinText, 0);
-        scene.attachChild(approachCircle, 0);
+
+        if (approachCircle.isVisible()) {
+            approachCircle.registerEntityModifier(Modifiers.sequence(
+                Modifiers.delay(timePreempt),
+                Modifiers.parallel(
+                    Modifiers.alpha(duration, 0.75f, 1),
+                    Modifiers.scale(duration, 2.0f, 0)
+                )
+            ));
+
+            scene.attachChild(approachCircle, 0);
+        }
+
         scene.attachChild(circle, 0);
         scene.attachChild(metre, 0);
         scene.attachChild(background, 0);


### PR DESCRIPTION
In version 2026.328.0, there was an issue where active `GameObject`s would permanently persist until the end of gameplay. This was fixed in https://github.com/osudroid/osu-droid/commit/a84b2efcc6f49a0be09a5250a03074e41431be95, but is still considered incomplete for what it's worth, possibly due to the change that removes *all* expired `GameObject`s from `activeObjects` instead of just the first occurrence (see the linked commit's note for more details). To users, they would get a `Replay file corrupted` toast message if this issue occurred at least once throughout gameplay, because the bugged `GameObject` may potentially never be judged, resulting in an inequal judged object count with respect to the beatmap's object count.

In order to understand the magnitude of this problem, we need to look at a bigger picture. `GameObject` pooling must also consider running modifiers. As long as a modifier is running, the object must be considered active. This is called the lifetime of the `GameObject`.

However, `Scene`s (or `Entity`s in general) do not have an absolute time reference, which is why modifiers rely on relative time instead. Coupled with the fact that modifiers may be freely removed or added from `Entity`s, this is exactly why lifetime management is painful. The proper fix to this is to make `GameObject` itself an `Entity` and track its lifetime by checking whether any modifier in itself (or its children) is still active, but this requires a huge refactor that I cannot afford at the present time.

This PR takes a simpler approach by introducing a self-managed lifetime in `GameObject` that its underlying implementations can directly alter. The lifetime is queried by `GameScene` to know whether the `GameObject` can be marked as expired in the current frame and pooled in the next frame. This removes the need for `GameObject` to juggle around the possible modifiers that would finish last to let `GameScene` know that it can be pooled, and ultimately, solve the issue mentioned at the beginning. Do note that this may cause `GameObject`s to be pooled late, but not to the point where it will never be pooled unlike before.

Because `activeObjects` now contain objects that are already judged, `GameObject.isJudged` was added to allow `searchJudgeableObject` to properly check if a `GameObject` has been judged. Consequently, the Auto cursor now moves to `judgeableObject` rather than the first `GameObject` in `activeObjects`. This changes the way that it behaves when `Config.isRemoveSliderLock` is enabled, because now it moves towards the next object rather than staying on the first object after the first object is hit.