### PR TITLE
Add color hit error meter

### DIFF
--- a/src/com/osudroid/ui/v2/hud/GameplayHUD.kt
+++ b/src/com/osudroid/ui/v2/hud/GameplayHUD.kt
@@ -11,6 +11,7 @@ import com.osudroid.utils.updateThread
 import com.reco1l.andengine.UIEngine
 import com.reco1l.andengine.component.*
 import com.reco1l.toolkt.kotlin.*
+import com.rian.osu.beatmap.constants.HitObjectType
 import com.rian.osu.beatmap.hitobject.HitObject
 import org.anddev.andengine.entity.IEntity
 import org.anddev.andengine.input.touch.TouchEvent
@@ -297,9 +298,9 @@ class GameplayHUD : UIContainer(), IGameplayEvents {
         elementSelector?.onBreakStateChange(isBreak)
     }
 
-    override fun onAccuracyRegister(accuracy: Float) {
-        forEachElement { it.onAccuracyRegister(accuracy) }
-        elementSelector?.onAccuracyRegister(accuracy)
+    override fun onAccuracyRegister(type: HitObjectType, accuracy: Float) {
+        forEachElement { it.onAccuracyRegister(type, accuracy) }
+        elementSelector?.onAccuracyRegister(type, accuracy)
     }
 
     //endregion

--- a/src/com/osudroid/ui/v2/hud/HUDElement.kt
+++ b/src/com/osudroid/ui/v2/hud/HUDElement.kt
@@ -7,8 +7,6 @@ import com.reco1l.andengine.shape.*
 import com.reco1l.framework.Color4
 import com.reco1l.framework.math.Vec2
 import com.osudroid.ui.v2.hud.editor.HUDElementOverlay
-import com.osudroid.ui.v2.hud.elements.HUDBarHitErrorMeter
-import com.osudroid.ui.v2.hud.elements.HUDLeaderboard
 import com.reco1l.andengine.component.*
 import com.reco1l.toolkt.kotlin.capitalize
 import com.rian.osu.beatmap.constants.HitObjectType

--- a/src/com/osudroid/ui/v2/hud/HUDElement.kt
+++ b/src/com/osudroid/ui/v2/hud/HUDElement.kt
@@ -35,6 +35,7 @@ enum class HUDElements(val type: KClass<out HUDElement>) {
     ur_counter(HUDUnstableRateCounter::class),
     avg_offset_counter(HUDAverageOffsetCounter::class),
     hit_error_meter(HUDBarHitErrorMeter::class),
+    color_hit_error_meter(HUDColorHitErrorMeter::class),
     linear_song_progress(HUDLinearSongProgress::class),
     great_counter(HUDGreatCounter::class),
     ok_counter(HUDOkCounter::class),

--- a/src/com/osudroid/ui/v2/hud/HUDElement.kt
+++ b/src/com/osudroid/ui/v2/hud/HUDElement.kt
@@ -1,29 +1,13 @@
 package com.osudroid.ui.v2.hud
 
-import com.osudroid.ui.v2.hud.elements.HUDAccuracyCounter
-import com.osudroid.ui.v2.hud.elements.HUDAverageOffsetCounter
-import com.osudroid.ui.v2.hud.elements.HUDBPMCounter
-import com.osudroid.ui.v2.hud.elements.HUDBackButton
-import com.osudroid.ui.v2.hud.elements.HUDComboCounter
-import com.osudroid.ui.v2.hud.elements.HUDGreatCounter
-import com.osudroid.ui.v2.hud.elements.HUDHealthBar
-import com.osudroid.ui.v2.hud.elements.HUDHitErrorMeter
-import com.osudroid.ui.v2.hud.elements.HUDLinearSongProgress
-import com.osudroid.ui.v2.hud.elements.HUDMehCounter
-import com.osudroid.ui.v2.hud.elements.HUDMissCounter
-import com.osudroid.ui.v2.hud.elements.HUDNotesPerSecondCounter
-import com.osudroid.ui.v2.hud.elements.HUDOkCounter
-import com.osudroid.ui.v2.hud.elements.HUDPPCounter
-import com.osudroid.ui.v2.hud.elements.HUDPieSongProgress
-import com.osudroid.ui.v2.hud.elements.HUDScoreCounter
-import com.osudroid.ui.v2.hud.elements.HUDTapsPerSecondCounter
-import com.osudroid.ui.v2.hud.elements.HUDUnstableRateCounter
+import com.osudroid.ui.v2.hud.elements.*
 import com.reco1l.andengine.*
 import com.reco1l.andengine.container.UIContainer
 import com.reco1l.andengine.shape.*
 import com.reco1l.framework.Color4
 import com.reco1l.framework.math.Vec2
 import com.osudroid.ui.v2.hud.editor.HUDElementOverlay
+import com.osudroid.ui.v2.hud.elements.HUDBarHitErrorMeter
 import com.osudroid.ui.v2.hud.elements.HUDLeaderboard
 import com.reco1l.andengine.component.*
 import com.reco1l.toolkt.kotlin.capitalize
@@ -50,7 +34,7 @@ enum class HUDElements(val type: KClass<out HUDElement>) {
     score_counter(HUDScoreCounter::class),
     ur_counter(HUDUnstableRateCounter::class),
     avg_offset_counter(HUDAverageOffsetCounter::class),
-    hit_error_meter(HUDHitErrorMeter::class),
+    hit_error_meter(HUDBarHitErrorMeter::class),
     linear_song_progress(HUDLinearSongProgress::class),
     great_counter(HUDGreatCounter::class),
     ok_counter(HUDOkCounter::class),

--- a/src/com/osudroid/ui/v2/hud/HUDElement.kt
+++ b/src/com/osudroid/ui/v2/hud/HUDElement.kt
@@ -11,6 +11,7 @@ import com.osudroid.ui.v2.hud.elements.HUDBarHitErrorMeter
 import com.osudroid.ui.v2.hud.elements.HUDLeaderboard
 import com.reco1l.andengine.component.*
 import com.reco1l.toolkt.kotlin.capitalize
+import com.rian.osu.beatmap.constants.HitObjectType
 import com.rian.osu.beatmap.hitobject.HitObject
 import org.anddev.andengine.input.touch.TouchEvent
 import kotlin.math.abs
@@ -194,7 +195,7 @@ abstract class HUDElement : UIContainer(), IGameplayEvents {
 
     override fun onBreakStateChange(isBreak: Boolean) {}
 
-    override fun onAccuracyRegister(accuracy: Float) {}
+    override fun onAccuracyRegister(type: HitObjectType, accuracy: Float) {}
 
     //endregion
 

--- a/src/com/osudroid/ui/v2/hud/HUDSkinData.kt
+++ b/src/com/osudroid/ui/v2/hud/HUDSkinData.kt
@@ -3,9 +3,9 @@ package com.osudroid.ui.v2.hud
 import com.osudroid.ui.v2.hud.elements.HUDAccuracyCounter
 import com.osudroid.ui.v2.hud.elements.HUDAverageOffsetCounter
 import com.osudroid.ui.v2.hud.elements.HUDBackButton
+import com.osudroid.ui.v2.hud.elements.HUDBarHitErrorMeter
 import com.osudroid.ui.v2.hud.elements.HUDComboCounter
 import com.osudroid.ui.v2.hud.elements.HUDHealthBar
-import com.osudroid.ui.v2.hud.elements.HUDHitErrorMeter
 import com.osudroid.ui.v2.hud.elements.HUDPieSongProgress
 import com.osudroid.ui.v2.hud.elements.HUDScoreCounter
 import com.osudroid.ui.v2.hud.elements.HUDUnstableRateCounter
@@ -88,7 +88,7 @@ data class HUDSkinData(val elements: List<HUDElementSkinData>) {
                     position = Vec2(-10f, -59f)
                 ),
                 HUDElementSkinData(
-                    type = HUDHitErrorMeter::class,
+                    type = HUDBarHitErrorMeter::class,
                     anchor = Anchor.BottomCenter,
                     origin = Anchor.BottomCenter
                 )

--- a/src/com/osudroid/ui/v2/hud/IGameplayEvents.kt
+++ b/src/com/osudroid/ui/v2/hud/IGameplayEvents.kt
@@ -1,6 +1,7 @@
 package com.osudroid.ui.v2.hud
 
 import android.view.MotionEvent
+import com.rian.osu.beatmap.constants.HitObjectType
 import com.rian.osu.beatmap.hitobject.HitObject
 import ru.nsu.ccfit.zuev.osu.game.GameScene
 import ru.nsu.ccfit.zuev.osu.scoring.StatisticV2
@@ -22,6 +23,6 @@ interface IGameplayEvents {
 
     fun onBreakStateChange(isBreak: Boolean)
 
-    fun onAccuracyRegister(accuracy: Float)
+    fun onAccuracyRegister(type: HitObjectType, accuracy: Float)
 
 }

--- a/src/com/osudroid/ui/v2/hud/editor/HUDElementSelector.kt
+++ b/src/com/osudroid/ui/v2/hud/editor/HUDElementSelector.kt
@@ -13,6 +13,7 @@ import com.osudroid.ui.v2.hud.GameplayHUD
 import com.osudroid.ui.v2.hud.HUDElements
 import com.osudroid.ui.v2.hud.IGameplayEvents
 import com.reco1l.toolkt.kotlin.fastForEach
+import com.rian.osu.beatmap.constants.HitObjectType
 import com.rian.osu.beatmap.hitobject.HitObject
 import org.anddev.andengine.input.touch.TouchEvent
 import ru.nsu.ccfit.zuev.osu.ResourceManager
@@ -153,8 +154,8 @@ class HUDElementSelector(private val hud: GameplayHUD) : UIContainer(), IGamepla
         elements.fastForEach { it.onHitObjectLifetimeStart(obj) }
     }
 
-    override fun onAccuracyRegister(accuracy: Float) {
-        elements.fastForEach { it.onAccuracyRegister(accuracy) }
+    override fun onAccuracyRegister(type: HitObjectType, accuracy: Float) {
+        elements.fastForEach { it.onAccuracyRegister(type, accuracy) }
     }
 
     //endregion

--- a/src/com/osudroid/ui/v2/hud/elements/HUDBarHitErrorMeter.kt
+++ b/src/com/osudroid/ui/v2/hud/elements/HUDBarHitErrorMeter.kt
@@ -6,6 +6,7 @@ import com.reco1l.framework.Color4
 import com.osudroid.utils.*
 import com.reco1l.andengine.component.*
 import com.reco1l.toolkt.kotlin.*
+import com.rian.osu.beatmap.constants.HitObjectType
 import org.anddev.andengine.engine.camera.*
 import javax.microedition.khronos.opengles.*
 import kotlin.math.abs
@@ -74,7 +75,11 @@ class HUDBarHitErrorMeter : HUDHitErrorMeter() {
         greatWindow.alpha = 0.6f
     }
 
-    override fun addResult(accuracy: Float, color: Color4) {
+    override fun addResult(type: HitObjectType, accuracy: Float, color: Color4) {
+        if (type == HitObjectType.Spinner) {
+            return
+        }
+
         val accuracyMs = accuracy * 1000
 
         if (abs(accuracyMs) > hitWindow.mehWindow) {

--- a/src/com/osudroid/ui/v2/hud/elements/HUDBarHitErrorMeter.kt
+++ b/src/com/osudroid/ui/v2/hud/elements/HUDBarHitErrorMeter.kt
@@ -8,6 +8,7 @@ import com.reco1l.andengine.component.*
 import com.reco1l.toolkt.kotlin.*
 import org.anddev.andengine.engine.camera.*
 import javax.microedition.khronos.opengles.*
+import kotlin.math.abs
 
 class HUDBarHitErrorMeter : HUDHitErrorMeter() {
 
@@ -74,9 +75,15 @@ class HUDBarHitErrorMeter : HUDHitErrorMeter() {
     }
 
     override fun addResult(accuracy: Float, color: Color4) {
+        val accuracyMs = accuracy * 1000
+
+        if (abs(accuracyMs) > hitWindow.mehWindow) {
+            return
+        }
+
         val indicator = expiredIndicators.acquire() ?: Indicator(0f, 0f, Color4.White)
 
-        indicator.x = (WIDTH / 2f) * (accuracy * 1000 / hitWindow.mehWindow.toFloat())
+        indicator.x = (WIDTH / 2f) * (accuracyMs / hitWindow.mehWindow.toFloat())
         indicator.alpha = 1f
         indicator.color = color
 

--- a/src/com/osudroid/ui/v2/hud/elements/HUDBarHitErrorMeter.kt
+++ b/src/com/osudroid/ui/v2/hud/elements/HUDBarHitErrorMeter.kt
@@ -1,0 +1,133 @@
+package com.osudroid.ui.v2.hud.elements
+
+import com.reco1l.andengine.*
+import com.reco1l.andengine.shape.UIBox
+import com.reco1l.framework.Color4
+import com.osudroid.utils.*
+import com.reco1l.andengine.component.*
+import com.reco1l.toolkt.kotlin.*
+import org.anddev.andengine.engine.camera.*
+import javax.microedition.khronos.opengles.*
+
+class HUDBarHitErrorMeter : HUDHitErrorMeter() {
+
+    private val expiredIndicators = SynchronizedPool<Indicator>(20)
+    private val activeIndicators = mutableListOf<Indicator>()
+
+    // Using a shared box for drawing indicators to reduce memory usage.
+    private val indicatorBox = UIBox().apply {
+        anchor = Anchor.Center
+        origin = Anchor.Center
+        setSize(INDICATOR_WIDTH, INDICATOR_HEIGHT - 2f)
+
+        // Used to get anchor working properly.
+        parent = this@HUDBarHitErrorMeter
+    }
+
+
+    init {
+        setSize(WIDTH, INDICATOR_HEIGHT)
+
+        val mehWindow = UIBox().apply {
+            anchor = Anchor.Center
+            origin = Anchor.Center
+            color = mehColor
+            cornerRadius = BAR_HEIGHT / 2
+            setSize(WIDTH, BAR_HEIGHT)
+
+            depthInfo = DepthInfo.Default
+        }
+
+        val okWindow = UIBox().apply {
+            anchor = Anchor.Center
+            origin = Anchor.Center
+            color = okColor
+            setSize(WIDTH * (hitWindow.okWindow / hitWindow.mehWindow).toFloat(), BAR_HEIGHT)
+
+            depthInfo = DepthInfo.Default
+        }
+
+        val greatWindow = UIBox().apply {
+            anchor = Anchor.Center
+            origin = Anchor.Center
+            setSize(WIDTH * (hitWindow.greatWindow / hitWindow.mehWindow).toFloat(), BAR_HEIGHT)
+            color = greatColor
+
+            clearInfo = ClearInfo.ClearDepthBuffer
+            depthInfo = DepthInfo.Less
+        }
+
+        attachChild(mehWindow)
+        attachChild(okWindow, 0)
+        attachChild(greatWindow, 0)
+
+        // Indicator
+        attachChild(UIBox().apply {
+            anchor = Anchor.Center
+            origin = Anchor.Center
+            setSize(INDICATOR_WIDTH / 2, INDICATOR_HEIGHT)
+        })
+
+        mehWindow.alpha = 0.6f
+        okWindow.alpha = 0.6f
+        greatWindow.alpha = 0.6f
+    }
+
+    override fun addResult(accuracy: Float, color: Color4) {
+        val indicator = expiredIndicators.acquire() ?: Indicator(0f, 0f, Color4.White)
+
+        indicator.x = (WIDTH / 2f) * (accuracy * 1000 / hitWindow.mehWindow.toFloat())
+        indicator.alpha = 1f
+        indicator.color = color
+
+        activeIndicators.add(indicator)
+    }
+
+    //region Indicator update & draw
+
+    override fun onDrawChildren(gl: GL10, camera: Camera) {
+        super.onDrawChildren(gl, camera)
+        activeIndicators.fastForEach {
+            indicatorBox.x = it.x
+            indicatorBox.color = it.color
+            indicatorBox.alpha = it.alpha
+            indicatorBox.onDraw(gl, camera)
+        }
+    }
+
+    override fun onManagedUpdate(deltaTimeSec: Float) {
+        activeIndicators.fastForEach(Indicator::update)
+        super.onManagedUpdate(deltaTimeSec)
+    }
+
+    //endregion
+
+
+    private inner class Indicator(var x: Float, var alpha: Float, var color: Color4) : IPoolable {
+        override var isRecycled = false
+
+        fun update() {
+            if (alpha > 0f) {
+                alpha -= 0.005f
+            }
+
+            if (alpha <= 0f) {
+                alpha = 0f
+                expiredIndicators.release(this)
+                updateThread {
+                    activeIndicators.remove(this)
+                }
+            }
+        }
+    }
+
+
+    companion object {
+
+        private const val WIDTH = 400f
+        private const val BAR_HEIGHT = 10f
+        private const val INDICATOR_HEIGHT = BAR_HEIGHT + 14f
+        private const val INDICATOR_WIDTH = 4f
+
+    }
+}

--- a/src/com/osudroid/ui/v2/hud/elements/HUDColorHitErrorMeter.kt
+++ b/src/com/osudroid/ui/v2/hud/elements/HUDColorHitErrorMeter.kt
@@ -1,0 +1,67 @@
+package com.osudroid.ui.v2.hud.elements
+
+import com.reco1l.andengine.Anchor
+import com.reco1l.andengine.shape.UIBox
+import com.reco1l.framework.Color4
+import com.reco1l.toolkt.kotlin.fastForEach
+import com.rian.osu.beatmap.constants.HitObjectType
+import javax.microedition.khronos.opengles.GL10
+import org.anddev.andengine.engine.camera.Camera
+
+class HUDColorHitErrorMeter : HUDHitErrorMeter() {
+    private val indicators = MutableList(20) { Indicator(it, 0f, Color4.Black) }
+    private var currentIndicatorIndex = 0
+
+    private val indicatorBox = UIBox().apply {
+        anchor = Anchor.CenterLeft
+        origin = Anchor.CenterLeft
+        setSize(INDICATOR_SIZE, INDICATOR_SIZE)
+
+        // Used to get anchor working properly.
+        parent = this@HUDColorHitErrorMeter
+    }
+
+    init {
+        // Extra 2 to indicator spacing for left and right padding.
+        val width = INDICATOR_SIZE * indicators.size + INDICATOR_SPACING * (indicators.size + 2)
+
+        setSize(width, INDICATOR_SIZE)
+
+        background = UIBox().apply {
+            applyTheme = {
+                color = Color4.Black
+                alpha = 0.6f
+            }
+        }
+    }
+
+    override fun addResult(type: HitObjectType, accuracy: Float, color: Color4) {
+        indicators.fastForEach { it.alpha = (it.alpha - ALPHA_RAMP).coerceAtLeast(0f) }
+
+        val indicator = indicators[currentIndicatorIndex]
+
+        indicator.alpha = 1f
+        indicator.color = color
+
+        currentIndicatorIndex = (currentIndicatorIndex + 1) % indicators.size
+    }
+
+    override fun onDrawChildren(gl: GL10, camera: Camera) {
+        super.onDrawChildren(gl, camera)
+
+        indicators.fastForEach {
+            indicatorBox.x = INDICATOR_SPACING + it.index * (INDICATOR_SIZE + INDICATOR_SPACING)
+            indicatorBox.color = it.color
+            indicatorBox.alpha = it.alpha
+            indicatorBox.onDraw(gl, camera)
+        }
+    }
+
+    private data class Indicator(val index: Int, var alpha: Float, var color: Color4)
+
+    companion object {
+        private const val INDICATOR_SIZE = 30f
+        private const val INDICATOR_SPACING = 3f
+        private const val ALPHA_RAMP = 0.08f
+    }
+}

--- a/src/com/osudroid/ui/v2/hud/elements/HUDHitErrorMeter.kt
+++ b/src/com/osudroid/ui/v2/hud/elements/HUDHitErrorMeter.kt
@@ -3,6 +3,7 @@ package com.osudroid.ui.v2.hud.elements
 import com.reco1l.framework.Color4
 import com.osudroid.ui.v2.hud.HUDElement
 import com.rian.osu.beatmap.HitWindow
+import com.rian.osu.beatmap.constants.HitObjectType
 import ru.nsu.ccfit.zuev.osu.GlobalManager
 import kotlin.math.abs
 
@@ -12,19 +13,20 @@ sealed class HUDHitErrorMeter : HUDElement() {
     protected val greatColor = Color4(70, 180, 220)
     protected val okColor = Color4(100, 220, 40)
     protected val mehColor = Color4(200, 180, 110)
+    protected val missColor = Color4(255, 9, 9)
 
-    final override fun onAccuracyRegister(accuracy: Float) {
+    final override fun onAccuracyRegister(type: HitObjectType, accuracy: Float) {
         val absAccuracy = abs(accuracy * 1000)
 
         val color = when {
             absAccuracy <= hitWindow.greatWindow -> greatColor
             absAccuracy <= hitWindow.okWindow -> okColor
             absAccuracy <= hitWindow.mehWindow -> mehColor
-            else -> return
+            else -> missColor
         }
 
-        addResult(accuracy, color)
+        addResult(type, accuracy, color)
     }
 
-    protected abstract fun addResult(accuracy: Float, color: Color4)
+    protected abstract fun addResult(type: HitObjectType, accuracy: Float, color: Color4)
 }

--- a/src/com/osudroid/ui/v2/hud/elements/HUDHitErrorMeter.kt
+++ b/src/com/osudroid/ui/v2/hud/elements/HUDHitErrorMeter.kt
@@ -1,156 +1,30 @@
 package com.osudroid.ui.v2.hud.elements
 
-import com.reco1l.andengine.*
-import com.reco1l.andengine.shape.UIBox
 import com.reco1l.framework.Color4
 import com.osudroid.ui.v2.hud.HUDElement
-import com.osudroid.utils.*
-import com.reco1l.andengine.component.*
-import com.reco1l.toolkt.kotlin.*
-import org.anddev.andengine.engine.camera.*
+import com.rian.osu.beatmap.HitWindow
 import ru.nsu.ccfit.zuev.osu.GlobalManager
-import javax.microedition.khronos.opengles.*
 import kotlin.math.abs
 
-class HUDHitErrorMeter : HUDElement() {
+sealed class HUDHitErrorMeter : HUDElement() {
+    protected val hitWindow: HitWindow = GlobalManager.getInstance().gameScene.hitWindow
 
-    private val expiredIndicators = SynchronizedPool<Indicator>(20)
-    private val activeIndicators = mutableListOf<Indicator>()
+    protected val greatColor = Color4(70, 180, 220)
+    protected val okColor = Color4(100, 220, 40)
+    protected val mehColor = Color4(200, 180, 110)
 
-    private val hitWindow = GlobalManager.getInstance().gameScene.hitWindow
+    final override fun onAccuracyRegister(accuracy: Float) {
+        val absAccuracy = abs(accuracy * 1000)
 
-    private val greatColor = Color4(70, 180, 220)
-    private val okColor = Color4(100, 220, 40)
-    private val mehColor = Color4(200, 180, 110)
-
-
-    // Using a shared box for drawing indicators to reduce memory usage.
-    private val indicatorBox = UIBox().apply {
-        anchor = Anchor.Center
-        origin = Anchor.Center
-        setSize(INDICATOR_WIDTH, INDICATOR_HEIGHT - 2f)
-
-        // Used to get anchor working properly.
-        parent = this@HUDHitErrorMeter
-    }
-
-
-    init {
-        setSize(WIDTH, INDICATOR_HEIGHT)
-
-        val mehWindow = UIBox().apply {
-            anchor = Anchor.Center
-            origin = Anchor.Center
-            color = mehColor
-            cornerRadius = BAR_HEIGHT / 2
-            setSize(WIDTH, BAR_HEIGHT)
-
-            depthInfo = DepthInfo.Default
+        val color = when {
+            absAccuracy <= hitWindow.greatWindow -> greatColor
+            absAccuracy <= hitWindow.okWindow -> okColor
+            absAccuracy <= hitWindow.mehWindow -> mehColor
+            else -> return
         }
 
-        val okWindow = UIBox().apply {
-            anchor = Anchor.Center
-            origin = Anchor.Center
-            color = okColor
-            setSize(WIDTH * (hitWindow.okWindow / hitWindow.mehWindow).toFloat(), BAR_HEIGHT)
-
-            depthInfo = DepthInfo.Default
-        }
-
-        val greatWindow = UIBox().apply {
-            anchor = Anchor.Center
-            origin = Anchor.Center
-            setSize(WIDTH * (hitWindow.greatWindow / hitWindow.mehWindow).toFloat(), BAR_HEIGHT)
-            color = greatColor
-
-            clearInfo = ClearInfo.ClearDepthBuffer
-            depthInfo = DepthInfo.Less
-        }
-
-        attachChild(mehWindow)
-        attachChild(okWindow, 0)
-        attachChild(greatWindow, 0)
-
-        // Indicator
-        attachChild(UIBox().apply {
-            anchor = Anchor.Center
-            origin = Anchor.Center
-            setSize(INDICATOR_WIDTH / 2, INDICATOR_HEIGHT)
-        })
-
-        mehWindow.alpha = 0.6f
-        okWindow.alpha = 0.6f
-        greatWindow.alpha = 0.6f
+        addResult(accuracy, color)
     }
 
-
-    override fun onAccuracyRegister(accuracy: Float) {
-
-        val accuracyMs = accuracy * 1000
-
-        if (abs(accuracyMs) > hitWindow.mehWindow) {
-            return
-        }
-
-        val indicator = expiredIndicators.acquire() ?: Indicator(0f, 0f, Color4.White)
-
-        indicator.x = (WIDTH / 2f) * (accuracyMs / hitWindow.mehWindow.toFloat())
-        indicator.alpha = 1f
-        indicator.color = when {
-            abs(accuracyMs) <= hitWindow.greatWindow -> greatColor
-            abs(accuracyMs) <= hitWindow.okWindow -> okColor
-            else -> mehColor
-        }
-
-        activeIndicators.add(indicator)
-    }
-
-
-    //region Indicator update & draw
-
-    override fun onDrawChildren(gl: GL10, camera: Camera) {
-        super.onDrawChildren(gl, camera)
-        activeIndicators.fastForEach {
-            indicatorBox.x = it.x
-            indicatorBox.color = it.color
-            indicatorBox.alpha = it.alpha
-            indicatorBox.onDraw(gl, camera)
-        }
-    }
-
-    override fun onManagedUpdate(deltaTimeSec: Float) {
-        activeIndicators.fastForEach(Indicator::update)
-        super.onManagedUpdate(deltaTimeSec)
-    }
-
-    //endregion
-
-
-    private inner class Indicator(var x: Float, var alpha: Float, var color: Color4) : IPoolable {
-        override var isRecycled = false
-
-        fun update() {
-            if (alpha > 0f) {
-                alpha -= 0.005f
-            }
-
-            if (alpha <= 0f) {
-                alpha = 0f
-                expiredIndicators.release(this)
-                updateThread {
-                    activeIndicators.remove(this)
-                }
-            }
-        }
-    }
-
-
-    companion object {
-
-        private const val WIDTH = 400f
-        private const val BAR_HEIGHT = 10f
-        private const val INDICATOR_HEIGHT = BAR_HEIGHT + 14f
-        private const val INDICATOR_WIDTH = 4f
-
-    }
+    protected abstract fun addResult(accuracy: Float, color: Color4)
 }

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameObjectListener.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameObjectListener.java
@@ -4,6 +4,7 @@ import android.graphics.PointF;
 
 import com.osudroid.game.Cursor;
 import com.reco1l.framework.Color4;
+import com.rian.osu.beatmap.constants.HitObjectType;
 import com.rian.osu.gameplay.GameplayHitSampleInfo;
 
 import java.util.BitSet;
@@ -34,7 +35,7 @@ public interface GameObjectListener {
 
     int getCursorsCount();
 
-    void registerAccuracy(double acc);
+    void registerAccuracy(HitObjectType type, double acc);
     
     void updateAutoBasedPos(float pX, float pY);
 

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -3053,7 +3053,9 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
 
 
     public void registerAccuracy(HitObjectType type, final double acc) {
-        if (acc <= hitWindow.getMehWindow() / 1000) {
+        double mehWindow = hitWindow.getMehWindow() / 1000;
+
+        if (-mehWindow <= acc && acc <= mehWindow) {
             offsetSum += (float) acc;
             offsetRegs++;
 

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -57,6 +57,7 @@ import com.rian.osu.beatmap.ComboColor;
 import com.rian.osu.beatmap.DroidPlayableBeatmap;
 import com.rian.osu.beatmap.HitWindow;
 import com.rian.osu.beatmap.constants.BeatmapCountdown;
+import com.rian.osu.beatmap.constants.HitObjectType;
 import com.rian.osu.beatmap.hitobject.HitCircle;
 import com.rian.osu.beatmap.hitobject.HitObject;
 import com.rian.osu.beatmap.hitobject.Slider;
@@ -3032,11 +3033,13 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
     }
 
 
-    public void registerAccuracy(final double acc) {
+    public void registerAccuracy(HitObjectType type, final double acc) {
         offsetSum += (float) acc;
         offsetRegs++;
 
-        stat.addHitOffset(acc);
+        if (type != HitObjectType.Spinner) {
+            stat.addHitOffset(acc);
+        }
 
         if (replaying) {
             scoringScene.getReplayStat().addHitOffset(acc);

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -3053,15 +3053,17 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
 
 
     public void registerAccuracy(HitObjectType type, final double acc) {
-        offsetSum += (float) acc;
-        offsetRegs++;
+        if (acc <= hitWindow.getMehWindow() / 1000) {
+            offsetSum += (float) acc;
+            offsetRegs++;
 
-        if (type != HitObjectType.Spinner) {
-            stat.addHitOffset(acc);
-        }
+            if (type != HitObjectType.Spinner) {
+                stat.addHitOffset(acc);
+            }
 
-        if (replaying) {
-            scoringScene.getReplayStat().addHitOffset(acc);
+            if (replaying) {
+                scoringScene.getReplayStat().addHitOffset(acc);
+            }
         }
 
         hud.onAccuracyRegister(type, (float) acc);

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -2486,7 +2486,7 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
                 scoreName = "hit0";
                 yield hitWindow.getMehWindow() + 1;
             }
-        };
+        } / 1000;
 
         createHitEffect(pos, scoreName, null);
 

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -2463,15 +2463,34 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
             return;
         }
 
-        String scoreName = switch (score) {
-            case 300 -> registerHit(id, 300, endCombo);
-            case 100 -> registerHit(id, 100, endCombo);
-            case 50 -> registerHit(id, 50, endCombo);
-            default -> "hit0";
+        String scoreName;
+
+        // Simulate a hit for hit error meter registration.
+        float accuracy = (float) switch (score) {
+            case 300 -> {
+                scoreName = registerHit(id, 300, endCombo);
+                yield 0;
+            }
+
+            case 100 -> {
+                scoreName = registerHit(id, 100, endCombo);
+                yield hitWindow.getGreatWindow() + 1;
+            }
+
+            case 50 -> {
+                scoreName = registerHit(id, 50, endCombo);
+                yield hitWindow.getOkWindow() + 1;
+            }
+
+            default -> {
+                scoreName = "hit0";
+                yield hitWindow.getMehWindow() + 1;
+            }
         };
 
         createHitEffect(pos, scoreName, null);
 
+        hud.onAccuracyRegister(HitObjectType.Spinner, accuracy);
         hud.onNoteHit(stat);
     }
 
@@ -3045,7 +3064,7 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
             scoringScene.getReplayStat().addHitOffset(acc);
         }
 
-        hud.onAccuracyRegister((float) acc);
+        hud.onAccuracyRegister(type, (float) acc);
     }
 
 

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameplayHitCircle.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameplayHitCircle.java
@@ -295,6 +295,7 @@ public class GameplayHitCircle extends GameObject {
                 final byte forcedScore = (replayObjectData == null) ? 0 : replayObjectData.result;
 
                 removeFromScene();
+                listener.registerAccuracy(HitObjectType.Normal, mehWindow + 1);
                 listener.onCircleHit(id, 10, position, false, forcedScore, comboColor);
             }
         }

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameplayHitCircle.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameplayHitCircle.java
@@ -9,6 +9,7 @@ import com.reco1l.andengine.Anchor;
 import com.osudroid.ui.v2.game.NumberedCirclePiece;
 import com.reco1l.framework.Color4;
 import com.rian.osu.beatmap.HitWindow;
+import com.rian.osu.beatmap.constants.HitObjectType;
 import com.rian.osu.beatmap.hitobject.HitCircle;
 import com.rian.osu.gameplay.GameplayHitSampleInfo;
 import com.rian.osu.mods.ModHidden;
@@ -223,7 +224,7 @@ public class GameplayHitCircle extends GameObject {
         // If we have clicked circle
         if (replayObjectData != null) {
             if (passedTime - timePreempt + dt / 2 > replayObjectData.accuracy / 1000f) {
-                listener.registerAccuracy(replayObjectData.accuracy / 1000f);
+                listener.registerAccuracy(HitObjectType.Normal, replayObjectData.accuracy / 1000f);
                 startHit = true;
                 successfulHit = Math.abs(replayObjectData.accuracy / 1000f) <= mehWindow;
                 passedTime = -1;
@@ -240,7 +241,7 @@ public class GameplayHitCircle extends GameObject {
 
             if (hittingCursor != null) {
                 double hitOffset = (hittingCursor.getHitTime() - beatmapCircle.startTime) / 1000;
-                listener.registerAccuracy(hitOffset);
+                listener.registerAccuracy(HitObjectType.Normal, hitOffset);
                 startHit = true;
                 successfulHit = Math.abs(hitOffset) <= mehWindow;
                 passedTime = -1;

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameplayHitCircle.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameplayHitCircle.java
@@ -279,6 +279,7 @@ public class GameplayHitCircle extends GameObject {
         if (autoPlay) {
             passedTime = -1;
             // Remove circle and register hit in update thread
+            listener.registerAccuracy(HitObjectType.Normal, 0);
             listener.onCircleHit(id, 0, position, endsCombo, ResultType.HIT300.getId(), comboColor);
             startHit = true;
             successfulHit = true;

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameplaySlider.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameplaySlider.java
@@ -19,6 +19,7 @@ import com.osudroid.ui.v2.game.NumberedCirclePiece;
 import com.osudroid.ui.v2.game.SliderTickContainer;
 import com.reco1l.framework.Color4;
 import com.rian.osu.beatmap.HitWindow;
+import com.rian.osu.beatmap.constants.HitObjectType;
 import com.rian.osu.beatmap.hitobject.BankHitSampleInfo;
 import com.rian.osu.beatmap.hitobject.HitObject;
 import com.rian.osu.beatmap.hitobject.Slider;
@@ -1092,7 +1093,7 @@ public class GameplaySlider extends GameObject {
 
         if (replayObjectData == null || GameHelper.getReplayVersion() >= 6 || mehWindow <= duration) {
             if (-mehWindow <= hitOffset && hitOffset <= getLateHitThreshold()) {
-                listener.registerAccuracy(hitOffset);
+                listener.registerAccuracy(HitObjectType.Slider, hitOffset);
                 playCurrentNestedObjectHitSound();
                 ticksGot++;
                 shouldSnakeOut = true;
@@ -1106,7 +1107,7 @@ public class GameplaySlider extends GameObject {
             // In replays older than version 6, when the 50 hit window is longer than the duration of the slider,
             // the slider head is considered to *not* exist if it was not hit until the slider is over.
             // It is a very weird behavior, but that's what it actually was...
-            listener.registerAccuracy(hitOffset);
+            listener.registerAccuracy(HitObjectType.Slider, hitOffset);
             playCurrentNestedObjectHitSound();
             ticksGot++;
             shouldSnakeOut = true;

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameplaySlider.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameplaySlider.java
@@ -1092,8 +1092,9 @@ public class GameplaySlider extends GameObject {
         double mehWindow = hitWindow.getMehWindow() / 1000;
 
         if (replayObjectData == null || GameHelper.getReplayVersion() >= 6 || mehWindow <= duration) {
+            listener.registerAccuracy(HitObjectType.Slider, hitOffset);
+
             if (-mehWindow <= hitOffset && hitOffset <= getLateHitThreshold()) {
-                listener.registerAccuracy(HitObjectType.Slider, hitOffset);
                 playCurrentNestedObjectHitSound();
                 ticksGot++;
                 shouldSnakeOut = true;


### PR DESCRIPTION
Note that I had to make spinners register accuracy since color hit meter supports spinners. The bar hit error meter filters this out alongside misses.

<img width="2800" height="1260" alt="image" src="https://github.com/user-attachments/assets/4ea72a7e-0dba-43bf-af90-cdce4c95cc41" />
