### PR TITLE
Multiplayer fixes

### DIFF
--- a/src/com/osudroid/multiplayer/Multiplayer.kt
+++ b/src/com/osudroid/multiplayer/Multiplayer.kt
@@ -200,12 +200,9 @@ object Multiplayer {
             return
         }
 
+        // Replace server statistics with local in Head-to-Head mode.
         if (room?.isTeamVersus == false) {
-            // Replace server statistics with local
             val ownScore = GlobalManager.getInstance().gameScene.stat
-
-            // In team mode, this will be null because the server does not send individual scores, though this check has
-            // been made flexible in case the server submits individual scores in the future.
             val ownScoreIndex = list.indexOfFirst { it.playerName == OnlineManager.getInstance().username }.takeUnless { it == -1 }
 
             if (ownScore != null) {

--- a/src/com/osudroid/multiplayer/Multiplayer.kt
+++ b/src/com/osudroid/multiplayer/Multiplayer.kt
@@ -102,6 +102,7 @@ object Multiplayer {
     @Volatile
     private var isWaitingAttemptResponse = false
 
+    private val abandonReconnectionLock = Any()
 
     //region Connection
 
@@ -240,23 +241,24 @@ object Multiplayer {
      * guard in [onReconnectAttempt]) cannot both execute the toast + `back()` sequence.
      */
     private fun abandonReconnection() {
-        // Guard: only the first caller acts.
-        if (!isReconnecting) return
-        isReconnecting = false
+        synchronized(abandonReconnectionLock) {
+            if (!isReconnecting) return
+            isReconnecting = false
 
-        reconnectionJob?.cancel()
-        reconnectionJob = null
+            reconnectionJob?.cancel()
+            reconnectionJob = null
 
-        ToastLogger.showText(
-            "The connection to server has been lost, please check your internet connection.",
-            true
-        )
+            ToastLogger.showText(
+                "The connection to server has been lost, please check your internet connection.",
+                true
+            )
 
-        // Do not interrupt an active game session; the teardown will happen naturally
-        // when the player finishes (or abandons) the game.
-        val gameScene = GlobalManager.getInstance().gameScene
-        if (gameScene == null || GlobalManager.getInstance().engine.scene != gameScene.scene) {
-            updateThread { roomScene?.back() }
+            // Do not interrupt an active game session; the teardown will happen naturally
+            // when the player finishes (or abandons) the game.
+            val gameScene = GlobalManager.getInstance().gameScene
+            if (gameScene == null || GlobalManager.getInstance().engine.scene != gameScene.scene) {
+                updateThread { roomScene?.back() }
+            }
         }
     }
 

--- a/src/com/osudroid/multiplayer/Multiplayer.kt
+++ b/src/com/osudroid/multiplayer/Multiplayer.kt
@@ -216,7 +216,7 @@ object Multiplayer {
         isReconnecting = false
         reconnectionJob?.cancel()
         reconnectionJob = null
-        reconnectionScope?.let { scope -> (scope.coroutineContext[Job.Key])?.cancel() }
+        reconnectionScope?.let { scope -> scope.coroutineContext[Job.Key]?.cancel() }
         reconnectionScope = null
     }
 
@@ -279,7 +279,7 @@ object Multiplayer {
         isReconnecting = true
 
         // Cancel any leftover scope/job from a previous session and create a fresh scope.
-        reconnectionScope?.let { scope -> (scope.coroutineContext[Job.Key])?.cancel() }
+        reconnectionScope?.let { scope -> scope.coroutineContext[Job.Key]?.cancel() }
         reconnectionJob?.cancel()
         val scope = CoroutineScope(Dispatchers.Default)
         reconnectionScope = scope

--- a/src/com/osudroid/multiplayer/Multiplayer.kt
+++ b/src/com/osudroid/multiplayer/Multiplayer.kt
@@ -211,6 +211,7 @@ object Multiplayer {
                     // local player (e.g. username casing mismatch or API mismatch), append the local
                     // score so it remains visible rather than being silently omitted.
                     list.add(ownScore)
+                    list.sortByDescending { it.totalScoreWithMultiplier }
                     log("WARNING: Player score wasn't found in final leaderboard.")
                 } else {
                     list[ownScoreIndex] = ownScore

--- a/src/com/osudroid/multiplayer/Multiplayer.kt
+++ b/src/com/osudroid/multiplayer/Multiplayer.kt
@@ -11,6 +11,7 @@ import com.reco1l.andengine.*
 import com.reco1l.toolkt.kotlin.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.json.JSONArray
@@ -80,7 +81,11 @@ object Multiplayer {
 
     private val logger = MultiplayerLogger()
 
-    private val reconnectionScope by lazy { CoroutineScope(Dispatchers.Default) }
+    /** Scope used for the reconnection loop. A new scope is created per session so the old one can be cancelled cleanly. */
+    private var reconnectionScope: CoroutineScope? = null
+
+    /** Active reconnection coroutine job, so duplicate launches can be cancelled. */
+    private var reconnectionJob: Job? = null
 
 
     @Volatile
@@ -209,6 +214,15 @@ object Multiplayer {
 
     // Reconnection
 
+    /** Cancels any active reconnection coroutine and its scope. Should be called when leaving the room. */
+    fun cancelReconnection() {
+        isReconnecting = false
+        reconnectionJob?.cancel()
+        reconnectionJob = null
+        reconnectionScope?.let { scope -> (scope.coroutineContext[Job.Key])?.cancel() }
+        reconnectionScope = null
+    }
+
     fun onReconnectAttempt(success: Boolean) {
 
         lastAttemptResponseTimeMS = System.currentTimeMillis()
@@ -243,10 +257,16 @@ object Multiplayer {
         }
         isReconnecting = true
 
+        // Cancel any leftover scope/job from a previous session and create a fresh scope.
+        reconnectionScope?.let { scope -> (scope.coroutineContext[Job.Key])?.cancel() }
+        reconnectionJob?.cancel()
+        val scope = CoroutineScope(Dispatchers.Default)
+        reconnectionScope = scope
+
         attemptCount = 0
         reconnectionStartTimeMS = System.currentTimeMillis()
 
-        reconnectionScope.launch {
+        reconnectionJob = scope.launch {
 
             while (isReconnecting) {
                 val currentTime = System.currentTimeMillis()

--- a/src/com/osudroid/multiplayer/Multiplayer.kt
+++ b/src/com/osudroid/multiplayer/Multiplayer.kt
@@ -8,6 +8,7 @@ import com.osudroid.multiplayer.api.data.RoomPlayer
 import com.osudroid.ui.v2.hud.elements.HUDLeaderboard
 import com.osudroid.ui.v2.multi.*
 import com.reco1l.andengine.*
+import com.osudroid.utils.updateThread
 import com.reco1l.toolkt.kotlin.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -247,7 +248,7 @@ object Multiplayer {
         // when the player finishes (or abandons) the game.
         val gameScene = GlobalManager.getInstance().gameScene
         if (gameScene == null || GlobalManager.getInstance().engine.scene != gameScene.scene) {
-            roomScene?.back()
+            updateThread { roomScene?.back() }
         }
     }
 

--- a/src/com/osudroid/multiplayer/Multiplayer.kt
+++ b/src/com/osudroid/multiplayer/Multiplayer.kt
@@ -43,12 +43,14 @@ object Multiplayer {
      * Indicates if player is in multiplayer mode
      */
     @JvmField
+    @Volatile
     var isMultiplayer = false
 
     /**
      * Indicates if the client is waiting for a reconnection.
      */
     @JvmField
+    @Volatile
     var isReconnecting = false
 
     /**
@@ -80,12 +82,16 @@ object Multiplayer {
     private val reconnectionScope by lazy { CoroutineScope(Dispatchers.Default) }
 
 
+    @Volatile
     private var attemptCount = 0
 
+    @Volatile
     private var reconnectionStartTimeMS = 0L
 
+    @Volatile
     private var lastAttemptResponseTimeMS = 0L
 
+    @Volatile
     private var isWaitingAttemptResponse = false
 
 

--- a/src/com/osudroid/multiplayer/Multiplayer.kt
+++ b/src/com/osudroid/multiplayer/Multiplayer.kt
@@ -11,6 +11,7 @@ import com.reco1l.andengine.*
 import com.reco1l.toolkt.kotlin.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.json.JSONArray
 import ru.nsu.ccfit.zuev.osu.GlobalManager
@@ -250,14 +251,27 @@ object Multiplayer {
             while (isReconnecting) {
                 val currentTime = System.currentTimeMillis()
 
-                // Timeout to reconnect was exceed.
+                // Timeout to reconnect was exceeded.
                 if (currentTime - reconnectionStartTimeMS >= 30000) {
                     ToastLogger.showText("The connection to server has been lost, please check your internet connection.", true)
                     roomScene?.back()
                     return@launch
                 }
 
-                if (currentTime - lastAttemptResponseTimeMS < 5000 || isWaitingAttemptResponse) continue
+                // Still waiting for the server to respond to the last attempt — poll cheaply
+                // instead of spinning at 100% CPU.
+                if (isWaitingAttemptResponse) {
+                    delay(250)
+                    continue
+                }
+
+                // Inter-attempt cooldown: sleep for the exact remaining time rather than
+                // busy-spinning until the 5-second window has elapsed.
+                val msSinceLastResponse = currentTime - lastAttemptResponseTimeMS
+                if (msSinceLastResponse < 5000) {
+                    delay(5000 - msSinceLastResponse)
+                    continue
+                }
 
                 try {
                     RoomAPI.connectToRoom(

--- a/src/com/osudroid/multiplayer/Multiplayer.kt
+++ b/src/com/osudroid/multiplayer/Multiplayer.kt
@@ -223,6 +223,37 @@ object Multiplayer {
         reconnectionScope = null
     }
 
+    /**
+     * Permanently gives up on reconnecting: cancels the reconnection loop, shows the error
+     * toast, and navigates back to the lobby (unless gameplay is currently active, in which
+     * case the navigation is deferred to the game-end flow).
+     *
+     * Idempotent — if a second caller races in after the first has already set
+     * [isReconnecting] to `false`, it is a no-op. This ensures the two independent
+     * exit paths (30-second absolute timeout in the coroutine loop and the max-attempt
+     * guard in [onReconnectAttempt]) cannot both execute the toast + `back()` sequence.
+     */
+    private fun abandonReconnection() {
+        // Guard: only the first caller acts.
+        if (!isReconnecting) return
+        isReconnecting = false
+
+        reconnectionJob?.cancel()
+        reconnectionJob = null
+
+        ToastLogger.showText(
+            "The connection to server has been lost, please check your internet connection.",
+            true
+        )
+
+        // Do not interrupt an active game session; the teardown will happen naturally
+        // when the player finishes (or abandons) the game.
+        val gameScene = GlobalManager.getInstance().gameScene
+        if (gameScene == null || GlobalManager.getInstance().engine.scene != gameScene.scene) {
+            roomScene?.back()
+        }
+    }
+
     fun onReconnectAttempt(success: Boolean) {
 
         lastAttemptResponseTimeMS = System.currentTimeMillis()
@@ -236,15 +267,8 @@ object Multiplayer {
 
             roomScene?.chat?.onSystemChatMessage("Failed to reconnect, trying again in 5 seconds...", "#FFBFBF")
         } else {
-            isReconnecting = false
-
-            ToastLogger.showText("The connection to server has been lost, please check your internet connection.", true)
-
-            val gameScene = GlobalManager.getInstance().gameScene
-
-            if (gameScene != null && GlobalManager.getInstance().engine.scene != gameScene.scene) {
-                roomScene?.back()
-            }
+            // Max attempts reached — delegate to the shared exit path.
+            abandonReconnection()
         }
 
         isWaitingAttemptResponse = false
@@ -271,10 +295,9 @@ object Multiplayer {
             while (isReconnecting) {
                 val currentTime = System.currentTimeMillis()
 
-                // Timeout to reconnect was exceeded.
+                // Absolute timeout exceeded — delegate to the shared exit path.
                 if (currentTime - reconnectionStartTimeMS >= 30000) {
-                    ToastLogger.showText("The connection to server has been lost, please check your internet connection.", true)
-                    roomScene?.back()
+                    abandonReconnection()
                     return@launch
                 }
 

--- a/src/com/osudroid/multiplayer/Multiplayer.kt
+++ b/src/com/osudroid/multiplayer/Multiplayer.kt
@@ -13,6 +13,7 @@ import com.reco1l.toolkt.kotlin.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.json.JSONArray
@@ -212,12 +213,11 @@ object Multiplayer {
 
     // Reconnection
 
-    /** Cancels any active reconnection coroutine and its scope. Should be called when leaving the room. */
+    /** Cancels any active reconnection coroutine state. Should be called when leaving the room. */
     fun cancelReconnection() {
         isReconnecting = false
         reconnectionJob?.cancel()
         reconnectionJob = null
-        reconnectionScope?.let { scope -> scope.coroutineContext[Job.Key]?.cancel() }
         reconnectionScope = null
     }
 
@@ -279,10 +279,11 @@ object Multiplayer {
         }
         isReconnecting = true
 
-        // Cancel any leftover scope/job from a previous session and create a fresh scope.
-        reconnectionScope?.let { scope -> scope.coroutineContext[Job.Key]?.cancel() }
+        // Cancel any leftover job from a previous session and create a fresh scope with an
+        // explicit SupervisorJob so the scope itself can be cancelled if needed.
         reconnectionJob?.cancel()
-        val scope = CoroutineScope(Dispatchers.Default)
+        reconnectionJob = null
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         reconnectionScope = scope
 
         attemptCount = 0

--- a/src/com/osudroid/multiplayer/Multiplayer.kt
+++ b/src/com/osudroid/multiplayer/Multiplayer.kt
@@ -200,8 +200,16 @@ object Multiplayer {
         // been made flexible in case the server submits individual scores in the future.
         val ownScoreIndex = list.indexOfFirst { it.playerName == OnlineManager.getInstance().username }.takeUnless { it == -1 }
 
-        if (ownScore != null && ownScoreIndex != null) {
-            list[ownScoreIndex] = ownScore
+        if (ownScore != null) {
+            if (ownScoreIndex == null) {
+                // This should never happen, but if the server leaderboard doesn't include the
+                // local player (e.g. username casing mismatch or API mismatch), append the local
+                // score so it remains visible rather than being silently omitted.
+                list.add(ownScore)
+                log("WARNING: Player score wasn't found in final leaderboard.")
+            } else {
+                list[ownScoreIndex] = ownScore
+            }
         }
 
         finalData = list.toTypedArray()

--- a/src/com/osudroid/multiplayer/Multiplayer.kt
+++ b/src/com/osudroid/multiplayer/Multiplayer.kt
@@ -241,13 +241,11 @@ object Multiplayer {
     }
 
     /**
-     * Permanently gives up on reconnecting: cancels the reconnection loop, shows the error
-     * toast, and navigates back to the lobby (unless gameplay is currently active, in which
-     * case the navigation is deferred to the game-end flow).
+     * Permanently gives up on reconnecting: cancels the reconnection loop, shows the error toast, and navigates back to
+     * the lobby (unless gameplay is currently active, in which case the navigation is deferred to the game-end flow).
      *
-     * Idempotent — if a second caller races in after the first has already set
-     * [isReconnecting] to `false`, it is a no-op. This ensures the two independent
-     * exit paths (30-second absolute timeout in the coroutine loop and the max-attempt
+     * If a second caller races in after the first has already set [isReconnecting] to `false`, it is a no-op.
+     * This ensures the two independent exit paths (30-second absolute timeout in the coroutine loop and the max-attempt
      * guard in [onReconnectAttempt]) cannot both execute the toast + `back()` sequence.
      */
     private fun abandonReconnection() {

--- a/src/com/osudroid/multiplayer/Multiplayer.kt
+++ b/src/com/osudroid/multiplayer/Multiplayer.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.json.JSONArray
@@ -233,9 +234,10 @@ object Multiplayer {
      */
     fun cancelReconnection() {
         isReconnecting = false
-        reconnectionJob?.cancel()
-        reconnectionJob = null
+
+        reconnectionScope?.cancel()
         reconnectionScope = null
+        reconnectionJob = null
     }
 
     /**

--- a/src/com/osudroid/multiplayer/Multiplayer.kt
+++ b/src/com/osudroid/multiplayer/Multiplayer.kt
@@ -194,22 +194,24 @@ object Multiplayer {
 
         if (list.isEmpty()) return
 
-        // Replacing server statistic with local
-        val ownScore = GlobalManager.getInstance().gameScene.stat
+        if (room?.isTeamVersus == false) {
+            // Replace server statistics with local
+            val ownScore = GlobalManager.getInstance().gameScene.stat
 
-        // In team mode, this will be null because the server does not send individual scores, though this check has
-        // been made flexible in case the server submits individual scores in the future.
-        val ownScoreIndex = list.indexOfFirst { it.playerName == OnlineManager.getInstance().username }.takeUnless { it == -1 }
+            // In team mode, this will be null because the server does not send individual scores, though this check has
+            // been made flexible in case the server submits individual scores in the future.
+            val ownScoreIndex = list.indexOfFirst { it.playerName == OnlineManager.getInstance().username }.takeUnless { it == -1 }
 
-        if (ownScore != null) {
-            if (ownScoreIndex == null) {
-                // This should never happen, but if the server leaderboard doesn't include the
-                // local player (e.g. username casing mismatch or API mismatch), append the local
-                // score so it remains visible rather than being silently omitted.
-                list.add(ownScore)
-                log("WARNING: Player score wasn't found in final leaderboard.")
-            } else {
-                list[ownScoreIndex] = ownScore
+            if (ownScore != null) {
+                if (ownScoreIndex == null) {
+                    // This should never happen, but if the server leaderboard doesn't include the
+                    // local player (e.g. username casing mismatch or API mismatch), append the local
+                    // score so it remains visible rather than being silently omitted.
+                    list.add(ownScore)
+                    log("WARNING: Player score wasn't found in final leaderboard.")
+                } else {
+                    list[ownScoreIndex] = ownScore
+                }
             }
         }
 

--- a/src/com/osudroid/multiplayer/Multiplayer.kt
+++ b/src/com/osudroid/multiplayer/Multiplayer.kt
@@ -10,6 +10,7 @@ import com.osudroid.ui.v2.multi.*
 import com.reco1l.andengine.*
 import com.osudroid.utils.updateThread
 import com.reco1l.toolkt.kotlin.*
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -73,7 +74,7 @@ object Multiplayer {
 
     /**
      * Determines if the player is connected to a room. This doesn't ensure that the connection to socket is currently
-     * active it can be under reconnection state.
+     * active; it can be under reconnection state.
      *
      * Note: Any event emitted during reconnection is ignored.
      */
@@ -83,12 +84,15 @@ object Multiplayer {
 
     private val logger = MultiplayerLogger()
 
-    /** Scope used for the reconnection loop. A new scope is created per session so the old one can be cancelled cleanly. */
+    /**
+     * [CoroutineScope] used for reconnection.
+     */
     private var reconnectionScope: CoroutineScope? = null
 
-    /** Active reconnection coroutine job, so duplicate launches can be cancelled. */
+    /**
+     * Active reconnection coroutine [Job].
+     */
     private var reconnectionJob: Job? = null
-
 
     @Volatile
     private var attemptCount = 0
@@ -192,7 +196,9 @@ object Multiplayer {
             list.add(jsonToStatistic(json))
         }
 
-        if (list.isEmpty()) return
+        if (list.isEmpty()) {
+            return
+        }
 
         if (room?.isTeamVersus == false) {
             // Replace server statistics with local
@@ -224,7 +230,9 @@ object Multiplayer {
 
     // Reconnection
 
-    /** Cancels any active reconnection coroutine state. Should be called when leaving the room. */
+    /**
+     * Cancels any active reconnection coroutine state. Should be called when leaving the room.
+     */
     fun cancelReconnection() {
         isReconnecting = false
         reconnectionJob?.cancel()
@@ -292,9 +300,10 @@ object Multiplayer {
         isReconnecting = true
 
         // Cancel any leftover job from a previous session and create a fresh scope with an
-        // explicit SupervisorJob so the scope itself can be cancelled if needed.
+        // explicit SupervisorJob so the scope itself can be canceled if needed.
         reconnectionJob?.cancel()
         reconnectionJob = null
+
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         reconnectionScope = scope
 
@@ -315,7 +324,7 @@ object Multiplayer {
                 // Still waiting for the server to respond to the last attempt — poll cheaply
                 // instead of spinning at 100% CPU.
                 if (isWaitingAttemptResponse) {
-                    delay(250)
+                    delay(250.milliseconds)
                     continue
                 }
 
@@ -323,7 +332,7 @@ object Multiplayer {
                 // busy-spinning until the 5-second window has elapsed.
                 val msSinceLastResponse = currentTime - lastAttemptResponseTimeMS
                 if (msSinceLastResponse < 5000) {
-                    delay(5000 - msSinceLastResponse)
+                    delay((5000 - msSinceLastResponse).milliseconds)
                     continue
                 }
 

--- a/src/com/osudroid/multiplayer/Multiplayer.kt
+++ b/src/com/osudroid/multiplayer/Multiplayer.kt
@@ -193,16 +193,13 @@ object Multiplayer {
 
         // Replacing server statistic with local
         val ownScore = GlobalManager.getInstance().gameScene.stat
+
+        // In team mode, this will be null because the server does not send individual scores, though this check has
+        // been made flexible in case the server submits individual scores in the future.
         val ownScoreIndex = list.indexOfFirst { it.playerName == OnlineManager.getInstance().username }.takeUnless { it == -1 }
 
-        if (ownScore != null) {
-            // This should never happen
-            if (ownScoreIndex == null) {
-                list.add(ownScore)
-                log("WARNING: Player score wasn't found in final leaderboard.")
-            } else {
-                list[ownScoreIndex] = ownScore
-            }
+        if (ownScore != null && ownScoreIndex != null) {
+            list[ownScoreIndex] = ownScore
         }
 
         finalData = list.toTypedArray()

--- a/src/com/osudroid/multiplayer/api/LobbyAPI.kt
+++ b/src/com/osudroid/multiplayer/api/LobbyAPI.kt
@@ -74,8 +74,8 @@ object LobbyAPI {
                         maxPlayers = json.getInt("maxPlayers"),
                         mods = RoomMods(json.getJSONArray("mods")),
                         gameplaySettings = parseGameplaySettings(json.getJSONObject("gameplaySettings")),
-                        teamMode = TeamMode[json.getInt("teamMode")],
-                        winCondition = WinCondition.from(json.getInt("winCondition")),
+                        teamMode = TeamMode[json.getInt("teamMode")] ?: TeamMode.HeadToHead,
+                        winCondition = WinCondition.from(json.getInt("winCondition")) ?: WinCondition.ScoreV1,
                         playerCount = json.getInt("playerCount"),
                         playerNames = json.getString("playerNames"),
                         status = RoomStatus[json.getInt("status")]

--- a/src/com/osudroid/multiplayer/api/RoomAPI.kt
+++ b/src/com/osudroid/multiplayer/api/RoomAPI.kt
@@ -337,6 +337,7 @@ object RoomAPI {
             val s = socket
             socket = null
             s?.off()
+            s?.disconnect()
         }
     }
 

--- a/src/com/osudroid/multiplayer/api/RoomAPI.kt
+++ b/src/com/osudroid/multiplayer/api/RoomAPI.kt
@@ -275,6 +275,7 @@ object RoomAPI {
                 val s = socket
                 socket = null
                 s?.off()
+                s?.disconnect()
                 return@Listener
             }
 

--- a/src/com/osudroid/multiplayer/api/RoomAPI.kt
+++ b/src/com/osudroid/multiplayer/api/RoomAPI.kt
@@ -418,9 +418,7 @@ object RoomAPI {
     }
 
     private fun createDisconnectListener(expectedSocket: Socket) = Listener {
-        if (socket !== expectedSocket) {
-            return@Listener
-        }
+        if (socket !== expectedSocket) return@Listener
 
         Multiplayer.log("RECEIVED: disconnect -> ${it.contentToString()}")
 
@@ -431,6 +429,11 @@ object RoomAPI {
             // Socket was manually disconnected by either server or client.
             byUser = reason == "io server disconnect" || reason == "io client disconnect"
         )
+
+        socket = null
+
+        expectedSocket.off()
+        expectedSocket.disconnect()
     }
 
 

--- a/src/com/osudroid/multiplayer/api/RoomAPI.kt
+++ b/src/com/osudroid/multiplayer/api/RoomAPI.kt
@@ -233,7 +233,10 @@ object RoomAPI {
 
     // Server-to-client events
 
-    private val initialConnection = Listener {
+    private fun createInitialConnectionListener(expectedSocket: Socket) = Listener {
+        if (socket !== expectedSocket) {
+            return@Listener
+        }
 
         val json = it[0] as? JSONObject ?: run {
             Multiplayer.log("WARNING: initialConnection — unexpected payload type: ${it.contentToString()}")
@@ -271,15 +274,14 @@ object RoomAPI {
                 Multiplayer.log("ERROR: initialConnection — local player UID not found in server player list. Disconnecting.")
                 roomEventListener?.onRoomConnectFail("Server did not include local player in room state.")
 
-                val s = socket
                 socket = null
 
-                s?.off()
-                s?.disconnect()
+                expectedSocket.off()
+                expectedSocket.disconnect()
                 return@Listener
             }
 
-            socket?.apply {
+            expectedSocket.apply {
                 on("beatmapChanged", beatmapChanged)
                 on("hostChanged", hostChanged)
                 on("playerKicked", playerKicked)
@@ -334,11 +336,10 @@ object RoomAPI {
 
             roomEventListener?.onRoomConnectFail("Unexpected error processing server room state: ${e.message}")
 
-            val s = socket
             socket = null
 
-            s?.off()
-            s?.disconnect()
+            expectedSocket.off()
+            expectedSocket.disconnect()
         }
     }
 
@@ -387,7 +388,9 @@ object RoomAPI {
         roomEventListener?.onRoomFinalLeaderboard(array)
     }
 
-    private val error = Listener {
+    private fun createErrorListener(expectedSocket: Socket) = Listener {
+        if (socket !== expectedSocket) return@Listener
+
         Multiplayer.log("RECEIVED: error -> ${it.contentToString()}")
 
         val error = it[0] as? String ?: run {
@@ -399,19 +402,26 @@ object RoomAPI {
 
     // Default listeners
 
-    private val connectError = Listener {
+    private fun createConnectErrorListener(expectedSocket: Socket) = Listener {
+        if (socket !== expectedSocket) {
+            return@Listener
+        }
+
         Multiplayer.log("RECEIVED: connect_error -> ${it.contentToString()}")
 
         roomEventListener?.onRoomConnectFail(it[0].toString())
 
-        val s = socket
         socket = null
 
-        s?.off()
-        s?.disconnect()
+        expectedSocket.off()
+        expectedSocket.disconnect()
     }
 
-    private val disconnect = Listener {
+    private fun createDisconnectListener(expectedSocket: Socket) = Listener {
+        if (socket !== expectedSocket) {
+            return@Listener
+        }
+
         Multiplayer.log("RECEIVED: disconnect -> ${it.contentToString()}")
 
         val reason = it.getOrNull(0) as? String
@@ -473,11 +483,11 @@ object RoomAPI {
 
         newSocket.apply {
 
-            on("initialConnection", initialConnection)
-            on("error", error)
+            on("initialConnection", createInitialConnectionListener(this))
+            on("error", createErrorListener(this))
 
-            on(Socket.EVENT_CONNECT_ERROR, connectError)
-            on(Socket.EVENT_DISCONNECT, disconnect)
+            on(Socket.EVENT_CONNECT_ERROR, createConnectErrorListener(this))
+            on(Socket.EVENT_DISCONNECT, createDisconnectListener(this))
 
         }.connect()
     }

--- a/src/com/osudroid/multiplayer/api/RoomAPI.kt
+++ b/src/com/osudroid/multiplayer/api/RoomAPI.kt
@@ -15,6 +15,7 @@ import com.osudroid.multiplayer.api.data.parseGameplaySettings
 import com.osudroid.multiplayer.api.data.parsePlayer
 import com.osudroid.multiplayer.api.data.parsePlayers
 import com.osudroid.ui.v2.multi.RoomScene
+import com.osudroid.utils.updateThread
 import ru.nsu.ccfit.zuev.osu.SecurityUtils
 import io.socket.client.IO
 import io.socket.client.Socket
@@ -328,7 +329,10 @@ object RoomAPI {
             Multiplayer.player = localPlayer
             Multiplayer.roomScene = scene
 
-            scene.onRoomConnect(room)
+            // onRoomConnect triggers UI mutations (updateInformation, updatePlayerList, show, etc.).
+            // Calling it directly here would run those mutations on the socket EventThread, which
+            // is not safe for the AndEngine scene graph.  Dispatch to the update thread instead.
+            updateThread { scene.onRoomConnect(room) }
 
         } catch (e: Exception) {
             Multiplayer.log("ERROR: initialConnection handler threw an exception: ${e.javaClass.simpleName} — ${e.message}")

--- a/src/com/osudroid/multiplayer/api/RoomAPI.kt
+++ b/src/com/osudroid/multiplayer/api/RoomAPI.kt
@@ -286,7 +286,27 @@ object RoomAPI {
                 on("allPlayersScoreSubmitted", allPlayersScoreSubmitted)
             }
 
-            val scene = RoomScene(room)
+            // During reconnection we must NOT create a new RoomScene.  Creating one would:
+            //   • replace RoomAPI.roomEventListener / playerEventListener with a scene that
+            //     is never displayed (SI-1 — the ghost-scene bug), and
+            //   • leave the on-screen scene as a dead UI shell that can never receive events.
+            // Instead, update the existing scene's room reference in-place and re-register it
+            // as the active listener, then forward the connect event to it.
+            val existingScene = if (Multiplayer.isReconnecting) Multiplayer.roomScene else null
+
+            val scene = if (existingScene != null) {
+                // Reuse the displayed scene.  Update its room reference so all subsequent reads
+                // of `this.room` inside event handlers see the fresh server state.
+                existingScene.room = room
+                // Re-register the existing scene as the event listener in case something
+                // inadvertently replaced it while the reconnection was in flight.
+                playerEventListener = existingScene
+                roomEventListener = existingScene
+                existingScene
+            } else {
+                // Fresh connection: build and register a brand-new scene as normal.
+                RoomScene(room)
+            }
 
             Multiplayer.room = room
             Multiplayer.player = localPlayer

--- a/src/com/osudroid/multiplayer/api/RoomAPI.kt
+++ b/src/com/osudroid/multiplayer/api/RoomAPI.kt
@@ -61,20 +61,34 @@ object RoomAPI {
     private val hostChanged = Listener {
 
         Multiplayer.log("RECEIVED: hostChanged -> ${it.contentToString()}")
-        roomEventListener?.onRoomHostChange((it[0] as String).toLong())
+        val uid = (it[0] as? String)?.toLongOrNull() ?: run {
+            Multiplayer.log("WARNING: hostChanged — unexpected payload type: ${it.contentToString()}")
+            return@Listener
+        }
+        roomEventListener?.onRoomHostChange(uid)
     }
 
     private val playerKicked = Listener {
 
         Multiplayer.log("RECEIVED: playerKicked -> ${it.contentToString()}")
-        playerEventListener?.onPlayerKick((it[0] as String).toLong())
+        val uid = (it[0] as? String)?.toLongOrNull() ?: run {
+            Multiplayer.log("WARNING: playerKicked — unexpected payload type: ${it.contentToString()}")
+            return@Listener
+        }
+        playerEventListener?.onPlayerKick(uid)
     }
 
     private val playerModsChanged = Listener {
         Multiplayer.log("RECEIVED: playerModsChanged -> ${it.contentToString()}")
 
-        val id = (it[0] as String).toLong()
-        val mods = it[1] as JSONArray
+        val id = (it[0] as? String)?.toLongOrNull() ?: run {
+            Multiplayer.log("WARNING: playerModsChanged — unexpected id type: ${it.contentToString()}")
+            return@Listener
+        }
+        val mods = it[1] as? JSONArray ?: run {
+            Multiplayer.log("WARNING: playerModsChanged — unexpected mods type: ${it.contentToString()}")
+            return@Listener
+        }
 
         playerEventListener?.onPlayerModsChange(id, RoomMods(mods))
     }
@@ -82,22 +96,35 @@ object RoomAPI {
     private val roomModsChanged = Listener {
         Multiplayer.log("RECEIVED: roomModsChanged -> ${it.contentToString()}")
 
-        val mods = it[0] as JSONArray
+        val mods = it[0] as? JSONArray ?: run {
+            Multiplayer.log("WARNING: roomModsChanged — unexpected payload type: ${it.contentToString()}")
+            return@Listener
+        }
         roomEventListener?.onRoomModsChange(RoomMods(mods))
     }
 
     private val roomGameplaySettingsChanged = Listener {
         Multiplayer.log("RECEIVED: roomGameplaySettingsChanged -> ${it.contentToString()}")
 
-        val json = it[0] as JSONObject
+        val json = it[0] as? JSONObject ?: run {
+            Multiplayer.log("WARNING: roomGameplaySettingsChanged — unexpected payload type: ${it.contentToString()}")
+            return@Listener
+        }
         roomEventListener?.onRoomGameplaySettingsChange(parseGameplaySettings(json))
     }
 
     private val playerStatusChanged = Listener {
         //Multiplayer.log("RECEIVED: playerStatusChanged -> ${it.contentToString()}")
 
-        val id = (it[0] as String).toLong()
-        val status = PlayerStatus[it[1] as Int]
+        val id = (it[0] as? String)?.toLongOrNull() ?: run {
+            Multiplayer.log("WARNING: playerStatusChanged — unexpected id type: ${it.contentToString()}")
+            return@Listener
+        }
+        val statusOrdinal = it[1] as? Int ?: run {
+            Multiplayer.log("WARNING: playerStatusChanged — unexpected status type: ${it.contentToString()}")
+            return@Listener
+        }
+        val status = PlayerStatus[statusOrdinal]
 
         playerEventListener?.onPlayerStatusChange(id, status)
     }
@@ -105,22 +132,40 @@ object RoomAPI {
     private val teamModeChanged = Listener {
         Multiplayer.log("RECEIVED: teamModeChanged -> ${it.contentToString()}")
 
-        val mode = TeamMode[it[0] as Int]
+        val ordinal = it[0] as? Int ?: run {
+            Multiplayer.log("WARNING: teamModeChanged — unexpected payload type: ${it.contentToString()}")
+            return@Listener
+        }
+        val mode = TeamMode[ordinal]
         roomEventListener?.onRoomTeamModeChange(mode)
     }
 
     private val winConditionChanged = Listener {
         Multiplayer.log("RECEIVED: winConditionChanged -> ${it.contentToString()}")
 
-        val condition = WinCondition.from(it[0] as Int)
+        val ordinal = it[0] as? Int ?: run {
+            Multiplayer.log("WARNING: winConditionChanged — unexpected payload type: ${it.contentToString()}")
+            return@Listener
+        }
+        val condition = WinCondition.from(ordinal)
         roomEventListener?.onRoomWinConditionChange(condition)
     }
 
     private val teamChanged = Listener {
         Multiplayer.log("RECEIVED: teamChanged -> ${it.contentToString()}")
 
-        val id = (it[0] as String).toLong()
-        val team = if (it[1] == null) null else RoomTeam[it[1] as Int]
+        val id = (it[0] as? String)?.toLongOrNull() ?: run {
+            Multiplayer.log("WARNING: teamChanged — unexpected id type: ${it.contentToString()}")
+            return@Listener
+        }
+        val team = when {
+            it[1] == null -> null
+            it[1] is Int  -> RoomTeam[it[1] as Int]
+            else -> {
+                Multiplayer.log("WARNING: teamChanged — unexpected team type: ${it.contentToString()}")
+                return@Listener
+            }
+        }
 
         playerEventListener?.onPlayerTeamChange(id, team)
     }
@@ -128,13 +173,21 @@ object RoomAPI {
     private val roomNameChanged = Listener {
 
         Multiplayer.log("RECEIVED: roomNameChanged -> ${it.contentToString()}")
-        roomEventListener?.onRoomNameChange(it[0] as String)
+        val name = it[0] as? String ?: run {
+            Multiplayer.log("WARNING: roomNameChanged — unexpected payload type: ${it.contentToString()}")
+            return@Listener
+        }
+        roomEventListener?.onRoomNameChange(name)
     }
 
     private val maxPlayersChanged = Listener {
 
         Multiplayer.log("RECEIVED: maxPlayersChanged -> ${it.contentToString()}")
-        roomEventListener?.onRoomMaxPlayersChange((it[0] as String).toInt())
+        val maxPlayers = (it[0] as? String)?.toIntOrNull() ?: run {
+            Multiplayer.log("WARNING: maxPlayersChanged — unexpected payload type: ${it.contentToString()}")
+            return@Listener
+        }
+        roomEventListener?.onRoomMaxPlayersChange(maxPlayers)
     }
 
     private val playBeatmap = Listener {
@@ -147,7 +200,11 @@ object RoomAPI {
 
         //Multiplayer.log("RECEIVED: chatMessage -> ${it.contentToString()}")
 
-        roomEventListener?.onRoomChatMessage((it[0] as? String)?.toLongOrNull(), it[1] as String)
+        val message = it[1] as? String ?: run {
+            Multiplayer.log("WARNING: chatMessage — unexpected message type: ${it.contentToString()}")
+            return@Listener
+        }
+        roomEventListener?.onRoomChatMessage((it[0] as? String)?.toLongOrNull(), message)
     }
 
     private val liveScoreData = Listener {
@@ -162,69 +219,98 @@ object RoomAPI {
 
     private val initialConnection = Listener {
 
-        val json = it[0] as JSONObject
+        val json = it[0] as? JSONObject ?: run {
+            Multiplayer.log("WARNING: initialConnection — unexpected payload type: ${it.contentToString()}")
+            return@Listener
+        }
 
         Multiplayer.log("RECEIVED: initialConnection\n${json.toString(3)}")
 
-        val players = parsePlayers(json.getJSONArray("players"), json.getInt("maxPlayers"))
-        val activePlayers = players.filterNotNull()
+        try {
+            val players = parsePlayers(json.getJSONArray("players"), json.getInt("maxPlayers"))
+            val activePlayers = players.filterNotNull()
 
-        val room = Room(
-            id = json.getString("id").toLong(),
-            name = json.getString("name"),
-            isLocked = json.getBoolean("isLocked"),
-            maxPlayers = json.getInt("maxPlayers"),
-            mods = RoomMods(json.getJSONArray("mods")),
-            gameplaySettings = parseGameplaySettings(json.getJSONObject("gameplaySettings")),
-            teamMode = TeamMode[json.getInt("teamMode")],
-            winCondition = WinCondition.from(json.getInt("winCondition")),
-            playerCount = activePlayers.size,
-            playerNames = activePlayers.joinToString(separator = ", ") { p -> p.name },
-            sessionID = json.getString("sessionId")
-        )
+            val room = Room(
+                id = json.getString("id").toLong(),
+                name = json.getString("name"),
+                isLocked = json.getBoolean("isLocked"),
+                maxPlayers = json.getInt("maxPlayers"),
+                mods = RoomMods(json.getJSONArray("mods")),
+                gameplaySettings = parseGameplaySettings(json.getJSONObject("gameplaySettings")),
+                teamMode = TeamMode[json.getInt("teamMode")],
+                winCondition = WinCondition.from(json.getInt("winCondition")),
+                playerCount = activePlayers.size,
+                playerNames = activePlayers.joinToString(separator = ", ") { p -> p.name },
+                sessionID = json.getString("sessionId")
+            )
 
-        room.players = players
-        room.host = json.getJSONObject("host").getString("id").toLong()
-        room.beatmap = parseBeatmap(json.optJSONObject("beatmap"))
-        room.status = RoomStatus[json.getInt("status")]
+            room.players = players
+            room.host = json.getJSONObject("host").getString("id").toLong()
+            room.beatmap = parseBeatmap(json.optJSONObject("beatmap"))
+            room.status = RoomStatus[json.getInt("status")]
 
-        socket?.apply {
-            on("beatmapChanged", beatmapChanged)
-            on("hostChanged", hostChanged)
-            on("playerKicked", playerKicked)
-            on("playerModsChanged", playerModsChanged)
-            on("roomModsChanged", roomModsChanged)
-            on("roomGameplaySettingsChanged", roomGameplaySettingsChanged)
-            on("playerStatusChanged", playerStatusChanged)
-            on("teamModeChanged", teamModeChanged)
-            on("winConditionChanged", winConditionChanged)
-            on("teamChanged", teamChanged)
-            on("roomNameChanged", roomNameChanged)
-            on("maxPlayersChanged", maxPlayersChanged)
-            on("playBeatmap", playBeatmap)
-            on("chatMessage", chatMessage)
-            on("liveScoreData", liveScoreData)
-            on("playerJoined", playerJoined)
-            on("playerLeft", playerLeft)
-            on("allPlayersBeatmapLoadComplete", allPlayersBeatmapLoadComplete)
-            on("allPlayersSkipRequested", allPlayersSkipRequested)
-            on("allPlayersScoreSubmitted", allPlayersScoreSubmitted)
+            // Locate our own player entry before registering further listeners.
+            // If the server sends a player list that does not include our UID (malformed
+            // payload or API mismatch) we cannot safely proceed — disconnect and surface
+            // an error rather than crashing with NullPointerException.
+            val localPlayer = room.playersMap[OnlineManager.getInstance().userId]
+            if (localPlayer == null) {
+                Multiplayer.log("ERROR: initialConnection — local player UID not found in server player list. Disconnecting.")
+                roomEventListener?.onRoomConnectFail("Server did not include local player in room state.")
+                val s = socket
+                socket = null
+                s?.off()
+                return@Listener
+            }
+
+            socket?.apply {
+                on("beatmapChanged", beatmapChanged)
+                on("hostChanged", hostChanged)
+                on("playerKicked", playerKicked)
+                on("playerModsChanged", playerModsChanged)
+                on("roomModsChanged", roomModsChanged)
+                on("roomGameplaySettingsChanged", roomGameplaySettingsChanged)
+                on("playerStatusChanged", playerStatusChanged)
+                on("teamModeChanged", teamModeChanged)
+                on("winConditionChanged", winConditionChanged)
+                on("teamChanged", teamChanged)
+                on("roomNameChanged", roomNameChanged)
+                on("maxPlayersChanged", maxPlayersChanged)
+                on("playBeatmap", playBeatmap)
+                on("chatMessage", chatMessage)
+                on("liveScoreData", liveScoreData)
+                on("playerJoined", playerJoined)
+                on("playerLeft", playerLeft)
+                on("allPlayersBeatmapLoadComplete", allPlayersBeatmapLoadComplete)
+                on("allPlayersSkipRequested", allPlayersSkipRequested)
+                on("allPlayersScoreSubmitted", allPlayersScoreSubmitted)
+            }
+
+            val scene = RoomScene(room)
+
+            Multiplayer.room = room
+            Multiplayer.player = localPlayer
+            Multiplayer.roomScene = scene
+
+            scene.onRoomConnect(room)
+
+        } catch (e: Exception) {
+            Multiplayer.log("ERROR: initialConnection handler threw an exception: ${e.javaClass.simpleName} — ${e.message}")
+            Multiplayer.log(e)
+            roomEventListener?.onRoomConnectFail("Unexpected error processing server room state: ${e.message}")
+            val s = socket
+            socket = null
+            s?.off()
         }
-
-        val scene = RoomScene(room)
-
-        Multiplayer.room = room
-        Multiplayer.player = room.playersMap[OnlineManager.getInstance().userId]!!
-        Multiplayer.roomScene = scene
-        
-
-        scene.onRoomConnect(room)
     }
 
     private val playerJoined = Listener {
         Multiplayer.log("RECEIVED: playerJoined -> ${it.contentToString()}")
 
-        val json = it[0] as JSONObject
+        val json = it[0] as? JSONObject ?: run {
+            Multiplayer.log("WARNING: playerJoined — unexpected payload type: ${it.contentToString()}")
+            return@Listener
+        }
         val player = parsePlayer(json)
 
         playerEventListener?.onPlayerJoin(player)
@@ -233,7 +319,11 @@ object RoomAPI {
     private val playerLeft = Listener {
 
         Multiplayer.log("RECEIVED: playerLeft -> ${it.contentToString()}")
-        playerEventListener?.onPlayerLeft((it[0] as String).toLong())
+        val uid = (it[0] as? String)?.toLongOrNull() ?: run {
+            Multiplayer.log("WARNING: playerLeft — unexpected payload type: ${it.contentToString()}")
+            return@Listener
+        }
+        playerEventListener?.onPlayerLeft(uid)
     }
 
     private val allPlayersBeatmapLoadComplete = Listener {
@@ -250,7 +340,10 @@ object RoomAPI {
 
     private val allPlayersScoreSubmitted = Listener {
 
-        val array = it[0] as JSONArray
+        val array = it[0] as? JSONArray ?: run {
+            Multiplayer.log("WARNING: allPlayersScoreSubmitted — unexpected payload type: ${it.contentToString()}")
+            return@Listener
+        }
 
         Multiplayer.log("RECEIVED: allPlayersScoreSubmitted\n${array.toString(3)}")
         roomEventListener?.onRoomFinalLeaderboard(array)
@@ -259,7 +352,10 @@ object RoomAPI {
     private val error = Listener {
         Multiplayer.log("RECEIVED: error -> ${it.contentToString()}")
 
-        val error = it[0] as String
+        val error = it[0] as? String ?: run {
+            Multiplayer.log("WARNING: error — unexpected payload type: ${it.contentToString()}")
+            return@Listener
+        }
         roomEventListener?.onServerError(error)
     }
 

--- a/src/com/osudroid/multiplayer/api/RoomAPI.kt
+++ b/src/com/osudroid/multiplayer/api/RoomAPI.kt
@@ -407,6 +407,7 @@ object RoomAPI {
         val s = socket
         socket = null
         s?.off()
+        s?.disconnect()
     }
 
     private val disconnect = Listener {

--- a/src/com/osudroid/multiplayer/api/RoomAPI.kt
+++ b/src/com/osudroid/multiplayer/api/RoomAPI.kt
@@ -124,7 +124,10 @@ object RoomAPI {
             Multiplayer.log("WARNING: playerStatusChanged — unexpected status type: ${it.contentToString()}")
             return@Listener
         }
-        val status = PlayerStatus[statusOrdinal]
+        val status = PlayerStatus[statusOrdinal] ?: run {
+            Multiplayer.log("WARNING: playerStatusChanged — unknown PlayerStatus ordinal $statusOrdinal, ignoring event")
+            return@Listener
+        }
 
         playerEventListener?.onPlayerStatusChange(id, status)
     }
@@ -136,7 +139,10 @@ object RoomAPI {
             Multiplayer.log("WARNING: teamModeChanged — unexpected payload type: ${it.contentToString()}")
             return@Listener
         }
-        val mode = TeamMode[ordinal]
+        val mode = TeamMode[ordinal] ?: run {
+            Multiplayer.log("WARNING: teamModeChanged — unknown TeamMode ordinal $ordinal, ignoring event")
+            return@Listener
+        }
         roomEventListener?.onRoomTeamModeChange(mode)
     }
 
@@ -147,7 +153,10 @@ object RoomAPI {
             Multiplayer.log("WARNING: winConditionChanged — unexpected payload type: ${it.contentToString()}")
             return@Listener
         }
-        val condition = WinCondition.from(ordinal)
+        val condition = WinCondition.from(ordinal) ?: run {
+            Multiplayer.log("WARNING: winConditionChanged — unknown WinCondition ordinal $ordinal, ignoring event")
+            return@Listener
+        }
         roomEventListener?.onRoomWinConditionChange(condition)
     }
 
@@ -160,7 +169,13 @@ object RoomAPI {
         }
         val team = when {
             it[1] == null -> null
-            it[1] is Int  -> RoomTeam[it[1] as Int]
+            it[1] is Int  -> {
+                val n = it[1] as Int
+                RoomTeam[n] ?: run {
+                    Multiplayer.log("WARNING: teamChanged — unknown RoomTeam ordinal $n, ignoring event")
+                    return@Listener
+                }
+            }
             else -> {
                 Multiplayer.log("WARNING: teamChanged — unexpected team type: ${it.contentToString()}")
                 return@Listener
@@ -237,8 +252,8 @@ object RoomAPI {
                 maxPlayers = json.getInt("maxPlayers"),
                 mods = RoomMods(json.getJSONArray("mods")),
                 gameplaySettings = parseGameplaySettings(json.getJSONObject("gameplaySettings")),
-                teamMode = TeamMode[json.getInt("teamMode")],
-                winCondition = WinCondition.from(json.getInt("winCondition")),
+                teamMode = TeamMode[json.getInt("teamMode")] ?: TeamMode.HeadToHead,
+                winCondition = WinCondition.from(json.getInt("winCondition")) ?: WinCondition.ScoreV1,
                 playerCount = activePlayers.size,
                 playerNames = activePlayers.joinToString(separator = ", ") { p -> p.name },
                 sessionID = json.getString("sessionId")

--- a/src/com/osudroid/multiplayer/api/RoomAPI.kt
+++ b/src/com/osudroid/multiplayer/api/RoomAPI.kt
@@ -42,6 +42,7 @@ object RoomAPI {
     var roomEventListener: IRoomEventListener? = null
 
 
+    @Volatile
     private var socket: Socket? = null
 
 
@@ -187,7 +188,7 @@ object RoomAPI {
         room.beatmap = parseBeatmap(json.optJSONObject("beatmap"))
         room.status = RoomStatus[json.getInt("status")]
 
-        socket!!.apply {
+        socket?.apply {
             on("beatmapChanged", beatmapChanged)
             on("hostChanged", hostChanged)
             on("playerKicked", playerKicked)
@@ -269,8 +270,11 @@ object RoomAPI {
 
         roomEventListener?.onRoomConnectFail(it[0].toString())
 
-        socket?.off()
+        // Capture the reference before nulling so a concurrent connectToRoom() that has
+        // already assigned a new socket is not accidentally cleared.
+        val s = socket
         socket = null
+        s?.off()
     }
 
     private val disconnect = Listener {
@@ -295,9 +299,12 @@ object RoomAPI {
     fun connectToRoom(roomId: Long, userId: Long, gameSessionId: String, roomPassword: String? = null,
                       multiplayerSessionID: String? = null) {
 
-        // Clearing previous socket in case of reconnection.
-        socket?.off()
+        // Capture and clear the old socket reference BEFORE creating the new one.
+        // This means any late callbacks still firing on the old socket will read null
+        // from the field and cannot accidentally wipe out the new socket reference.
+        val oldSocket = socket
         socket = null
+        oldSocket?.off()
 
         val url = "${LobbyAPI.HOST}/$roomId"
         val auth = mutableMapOf<String, String>()
@@ -321,7 +328,7 @@ object RoomAPI {
 
         Multiplayer.log("Starting connection -> $roomId, $userId")
 
-        socket = if (BuildSettings.MOCK_MULTIPLAYER) MockSocket(userId) else IO.socket(url, IO.Options().also {
+        val newSocket = if (BuildSettings.MOCK_MULTIPLAYER) MockSocket(userId) else IO.socket(url, IO.Options().also {
             it.auth = auth
 
             // Explicitly not allow the socket to reconnect as we are using our own
@@ -330,7 +337,9 @@ object RoomAPI {
             it.reconnection = false
         })
 
-        socket!!.apply {
+        socket = newSocket
+
+        newSocket.apply {
 
             on("initialConnection", initialConnection)
             on("error", error)
@@ -400,7 +409,10 @@ object RoomAPI {
      * Notify all clients to start loading beatmap.
      */
     fun notifyMatchPlay() {
-        socket!!.emit("playBeatmap")
+        socket?.emit("playBeatmap") ?: run {
+            Multiplayer.log("WARNING: Tried to emit event 'playBeatmap' while socket is null.")
+            return
+        }
         Multiplayer.log("EMITTED: playBeatmap")
     }
 
@@ -544,7 +556,10 @@ object RoomAPI {
      * Notify beatmap finish load.
      */
     fun notifyBeatmapLoaded() {
-        socket!!.emit("beatmapLoadComplete")
+        socket?.emit("beatmapLoadComplete") ?: run {
+            Multiplayer.log("WARNING: Tried to emit event 'beatmapLoadComplete' while socket is null.")
+            return
+        }
         Multiplayer.log("EMITTED: beatmapLoadComplete")
     }
 
@@ -552,7 +567,10 @@ object RoomAPI {
      * Request skip.
      */
     fun requestSkip() {
-        socket!!.emit("skipRequested")
+        socket?.emit("skipRequested") ?: run {
+            Multiplayer.log("WARNING: Tried to emit event 'skipRequested' while socket is null.")
+            return
+        }
         Multiplayer.log("EMITTED: skipRequested")
     }
 

--- a/src/com/osudroid/multiplayer/api/RoomAPI.kt
+++ b/src/com/osudroid/multiplayer/api/RoomAPI.kt
@@ -265,16 +265,15 @@ object RoomAPI {
             room.beatmap = parseBeatmap(json.optJSONObject("beatmap"))
             room.status = RoomStatus[json.getInt("status")]
 
-            // Locate our own player entry before registering further listeners.
-            // If the server sends a player list that does not include our UID (malformed
-            // payload or API mismatch) we cannot safely proceed — disconnect and surface
-            // an error rather than crashing with NullPointerException.
             val localPlayer = room.playersMap[OnlineManager.getInstance().userId]
+
             if (localPlayer == null) {
                 Multiplayer.log("ERROR: initialConnection — local player UID not found in server player list. Disconnecting.")
                 roomEventListener?.onRoomConnectFail("Server did not include local player in room state.")
+
                 val s = socket
                 socket = null
+
                 s?.off()
                 s?.disconnect()
                 return@Listener
@@ -303,43 +302,41 @@ object RoomAPI {
                 on("allPlayersScoreSubmitted", allPlayersScoreSubmitted)
             }
 
-            // During reconnection we must NOT create a new RoomScene.  Creating one would:
-            //   • replace RoomAPI.roomEventListener / playerEventListener with a scene that
-            //     is never displayed (SI-1 — the ghost-scene bug), and
-            //   • leave the on-screen scene as a dead UI shell that can never receive events.
-            // Instead, update the existing scene's room reference in-place and re-register it
-            // as the active listener, then forward the connect event to it.
+            // During reconnection, reuse the RoomScene. Creating a new one would:
+            // - replace roomEventListener / playerEventListener with a scene that is never displayed (see
+            //   onRoomConnect for more details; essentially, its show() method is never called during reconnection), and
+            // - leave the on-screen scene as a dead UI shell that can never receive events.
+            // Instead, update the existing scene's room reference in-place and re-register it as the active listener,
+            // then forward the connect event to it.
             val existingScene = if (Multiplayer.isReconnecting) Multiplayer.roomScene else null
 
             val scene = if (existingScene != null) {
-                // Reuse the displayed scene.  Update its room reference so all subsequent reads
-                // of `this.room` inside event handlers see the fresh server state.
                 existingScene.room = room
+
                 // Re-register the existing scene as the event listener in case something
                 // inadvertently replaced it while the reconnection was in flight.
                 playerEventListener = existingScene
                 roomEventListener = existingScene
+
                 existingScene
-            } else {
-                // Fresh connection: build and register a brand-new scene as normal.
-                RoomScene(room)
-            }
+            } else RoomScene(room)
 
             Multiplayer.room = room
             Multiplayer.player = localPlayer
             Multiplayer.roomScene = scene
 
-            // onRoomConnect triggers UI mutations (updateInformation, updatePlayerList, show, etc.).
-            // Calling it directly here would run those mutations on the socket EventThread, which
-            // is not safe for the AndEngine scene graph.  Dispatch to the update thread instead.
+            // onRoomConnect triggers UI mutations (updateInformation, updatePlayerList, show, etc.), so we move its
+            // operations to the update thread.
             updateThread { scene.onRoomConnect(room) }
-
         } catch (e: Exception) {
             Multiplayer.log("ERROR: initialConnection handler threw an exception: ${e.javaClass.simpleName} — ${e.message}")
             Multiplayer.log(e)
+
             roomEventListener?.onRoomConnectFail("Unexpected error processing server room state: ${e.message}")
+
             val s = socket
             socket = null
+
             s?.off()
             s?.disconnect()
         }
@@ -407,10 +404,9 @@ object RoomAPI {
 
         roomEventListener?.onRoomConnectFail(it[0].toString())
 
-        // Capture the reference before nulling so a concurrent connectToRoom() that has
-        // already assigned a new socket is not accidentally cleared.
         val s = socket
         socket = null
+
         s?.off()
         s?.disconnect()
     }
@@ -436,12 +432,9 @@ object RoomAPI {
      */
     fun connectToRoom(roomId: Long, userId: Long, gameSessionId: String, roomPassword: String? = null,
                       multiplayerSessionID: String? = null) {
-
-        // Capture and clear the old socket reference BEFORE creating the new one.
-        // This means any late callbacks still firing on the old socket will read null
-        // from the field and cannot accidentally wipe out the new socket reference.
         val oldSocket = socket
         socket = null
+
         oldSocket?.off()
         oldSocket?.disconnect()
 
@@ -493,17 +486,12 @@ object RoomAPI {
      * Disconnect from socket.
      */
     fun disconnect() {
-
-        if (socket == null) {
-            return
-        }
-
         socket?.apply {
-
             Multiplayer.log("Disconnected from socket.")
             off()
             disconnect()
         }
+
         socket = null
     }
 

--- a/src/com/osudroid/multiplayer/api/RoomAPI.kt
+++ b/src/com/osudroid/multiplayer/api/RoomAPI.kt
@@ -439,6 +439,7 @@ object RoomAPI {
         val oldSocket = socket
         socket = null
         oldSocket?.off()
+        oldSocket?.disconnect()
 
         val url = "${LobbyAPI.HOST}/$roomId"
         val auth = mutableMapOf<String, String>()

--- a/src/com/osudroid/multiplayer/api/data/Parsing.kt
+++ b/src/com/osudroid/multiplayer/api/data/Parsing.kt
@@ -6,31 +6,25 @@ import org.json.JSONObject
 
 
 /**
- * Parse a [JSONObject] of player to [RoomPlayer]
+ * Parse a [JSONObject] of player to [RoomPlayer].
  */
 fun parsePlayer(o: JSONObject) = RoomPlayer(
     id = o.getString("id").toLong(),
     name = o.getString("username"),
-    // Unknown PlayerStatus ordinals (EH-1) fall back to NotReady so the player is visible
-    // but not ready, which is the safest state.
     status = PlayerStatus[o.getInt("status")] ?: PlayerStatus.NotReady,
-    // Unknown RoomTeam ordinals return null; team is nullable so no fallback needed.
-    team = if (o.isNull("team")) null else o.getInt("team").let { n -> RoomTeam[n] },
+    team = if (o.isNull("team")) null else RoomTeam[o.getInt("team")],
     mods = RoomMods(o.getJSONArray("mods"))
 )
 
 /**
- * Parse a [JSONArray] of players to an array of [RoomPlayer?] of exactly [size] elements.
+ * Parse a [JSONArray] of players to an array of [RoomPlayer]s of exactly [size] elements.
  *
- * Null elements represent empty room slots.  Any mismatch between [array]'s actual length and
- * [size] is logged (EH-4):
- * - `array.length() > size` — excess entries are silently dropped (server bug / API mismatch).
- * - `array.length() < size` — trailing slots become null (normal for partially-filled rooms,
- *   but logged at DEBUG level so unexpected under-sends are observable).
+ * `null` elements represent empty room slots.
  */
 fun parsePlayers(array: JSONArray?, size: Int): Array<RoomPlayer?> {
     if (array != null) {
         val actual = array.length()
+
         when {
             actual > size -> Log.w(
                 "Parsing",
@@ -44,6 +38,7 @@ fun parsePlayers(array: JSONArray?, size: Int): Array<RoomPlayer?> {
             )
         }
     }
+
     return Array(size) { i ->
         parsePlayer(array?.optJSONObject(i) ?: return@Array null)
     }

--- a/src/com/osudroid/multiplayer/api/data/Parsing.kt
+++ b/src/com/osudroid/multiplayer/api/data/Parsing.kt
@@ -1,5 +1,6 @@
 package com.osudroid.multiplayer.api.data
 
+import android.util.Log
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -19,10 +20,33 @@ fun parsePlayer(o: JSONObject) = RoomPlayer(
 )
 
 /**
- * Parse a [JSONArray] of players to [RoomPlayer]
+ * Parse a [JSONArray] of players to an array of [RoomPlayer?] of exactly [size] elements.
+ *
+ * Null elements represent empty room slots.  Any mismatch between [array]'s actual length and
+ * [size] is logged (EH-4):
+ * - `array.length() > size` — excess entries are silently dropped (server bug / API mismatch).
+ * - `array.length() < size` — trailing slots become null (normal for partially-filled rooms,
+ *   but logged at DEBUG level so unexpected under-sends are observable).
  */
-fun parsePlayers(array: JSONArray?, size: Int) = Array(size) { i ->
-    parsePlayer(array?.optJSONObject(i) ?: return@Array null)
+fun parsePlayers(array: JSONArray?, size: Int): Array<RoomPlayer?> {
+    if (array != null) {
+        val actual = array.length()
+        when {
+            actual > size -> Log.w(
+                "Parsing",
+                "parsePlayers: array has $actual entries but maxPlayers=$size; " +
+                "${actual - size} excess player(s) beyond slot boundary will be ignored (EH-4)"
+            )
+            actual < size -> Log.d(
+                "Parsing",
+                "parsePlayers: array has $actual entries for a $size-slot room; " +
+                "${size - actual} trailing slot(s) treated as empty (EH-4)"
+            )
+        }
+    }
+    return Array(size) { i ->
+        parsePlayer(array?.optJSONObject(i) ?: return@Array null)
+    }
 }
 
 /**

--- a/src/com/osudroid/multiplayer/api/data/Parsing.kt
+++ b/src/com/osudroid/multiplayer/api/data/Parsing.kt
@@ -10,7 +10,10 @@ import org.json.JSONObject
 fun parsePlayer(o: JSONObject) = RoomPlayer(
     id = o.getString("id").toLong(),
     name = o.getString("username"),
-    status = PlayerStatus[o.getInt("status")],
+    // Unknown PlayerStatus ordinals (EH-1) fall back to NotReady so the player is visible
+    // but not ready, which is the safest state.
+    status = PlayerStatus[o.getInt("status")] ?: PlayerStatus.NotReady,
+    // Unknown RoomTeam ordinals return null; team is nullable so no fallback needed.
     team = if (o.isNull("team")) null else o.getInt("team").let { n -> RoomTeam[n] },
     mods = RoomMods(o.getJSONArray("mods"))
 )

--- a/src/com/osudroid/multiplayer/api/data/PlayerStatus.kt
+++ b/src/com/osudroid/multiplayer/api/data/PlayerStatus.kt
@@ -28,9 +28,7 @@ enum class PlayerStatus {
 
     companion object {
         /**
-         * Returns the [PlayerStatus] for [ordinal], or `null` if the ordinal is not recognised
-         * (e.g. the server added a new status that this client does not know about).
-         * Callers must handle the `null` case instead of crashing with AIOOBE (EH-1).
+         * Returns the [PlayerStatus] for [ordinal], or `null` if the ordinal is not recognized.
          */
         operator fun get(ordinal: Int): PlayerStatus? = entries.getOrNull(ordinal)
     }

--- a/src/com/osudroid/multiplayer/api/data/PlayerStatus.kt
+++ b/src/com/osudroid/multiplayer/api/data/PlayerStatus.kt
@@ -27,6 +27,11 @@ enum class PlayerStatus {
 
 
     companion object {
-        operator fun get(ordinal: Int) = entries[ordinal]
+        /**
+         * Returns the [PlayerStatus] for [ordinal], or `null` if the ordinal is not recognised
+         * (e.g. the server added a new status that this client does not know about).
+         * Callers must handle the `null` case instead of crashing with AIOOBE (EH-1).
+         */
+        operator fun get(ordinal: Int): PlayerStatus? = entries.getOrNull(ordinal)
     }
 }

--- a/src/com/osudroid/multiplayer/api/data/Room.kt
+++ b/src/com/osudroid/multiplayer/api/data/Room.kt
@@ -198,7 +198,9 @@ data class Room(
 
     /**
      * Atomically resize the players array. Players whose slot index falls within the new size
-     * are preserved; those beyond it are silently dropped (the server is authoritative).
+     * are preserved; those beyond it are truncated (the server is authoritative on capacity).
+     * Callers are expected to identify and surface any truncated players **before** calling
+     * this method — see [com.osudroid.ui.v2.multi.RoomScene.onRoomMaxPlayersChange] (SI-2).
      * Callers outside this class must use this instead of assigning [players] directly so the
      * operation is covered by the same monitor that guards [addPlayer] / [removePlayer].
      */

--- a/src/com/osudroid/multiplayer/api/data/Room.kt
+++ b/src/com/osudroid/multiplayer/api/data/Room.kt
@@ -132,9 +132,10 @@ data class Room(
             ?: players.filterNotNull().associateByTo(HashMap()) { it.id }.also { _playersMap = it }
 
     // Backing field for the playersMap cache.  Null means the cache is stale.
-    // @Volatile so the null-write in addPlayer/removePlayer/resizePlayers is immediately
-    // visible to threads that read playersMap without going through the lock
-    // (e.g. a quick null-check before acquiring).
+    // @Volatile ensures invalidation writes in addPlayer/removePlayer/resizePlayers are
+    // promptly visible to any direct field reads or future unsynchronized fast-paths.
+    // The current playersMap getter is still @Synchronized and rebuilds the cache under the
+    // lock.
     @Volatile
     private var _playersMap: Map<Long, RoomPlayer>? = null
 

--- a/src/com/osudroid/multiplayer/api/data/Room.kt
+++ b/src/com/osudroid/multiplayer/api/data/Room.kt
@@ -67,8 +67,11 @@ data class Room(
     /**
      * The array containing the players, null values are empty slots. The array size corresponds to [maxPlayers].
      *
-     * Marked @Volatile so that when [sortPlayers] (or [resizePlayers]) replaces the array reference,
-     * all threads immediately see the new reference without a stale cached copy.
+     * Slot indices mirror the server's layout exactly: index `i` here corresponds to slot `i` on the
+     * server.  The array is never re-sorted locally so the two views never diverge (SI-3).
+     *
+     * Marked @Volatile so that when [resizePlayers] replaces the array reference all threads
+     * immediately see the new reference without a stale cached copy.
      * Compound read-modify-write operations must still go through a @Synchronized method.
      */
     @Volatile
@@ -80,7 +83,9 @@ data class Room(
     var host: Long = -1
         @Synchronized set(value) {
             field = value
-            sortPlayers()
+            // NOTE: sortPlayers() used to be called here, but sorting shifts players out of
+            // their server-assigned slot positions (SI-3).  Host assignment does not change
+            // which players are present, so no array mutation or cache invalidation is needed.
         }
 
     /**
@@ -117,7 +122,7 @@ data class Room(
      * Get the players list in map format using UIDs as keys.
      *
      * Backed by a cache that is invalidated whenever the players array is mutated
-     * (see [sortPlayers] and [resizePlayers]).  Callers that already hold the lock
+     * (see [addPlayer], [removePlayer], and [resizePlayers]).  Callers that already hold the lock
      * (e.g. every @Synchronized method in this class) get the cached map for free
      * on repeated accesses within the same event; callers on other threads pay at
      * most one rebuild per mutation event.
@@ -127,7 +132,7 @@ data class Room(
             ?: players.filterNotNull().associateByTo(HashMap()) { it.id }.also { _playersMap = it }
 
     // Backing field for the playersMap cache.  Null means the cache is stale.
-    // @Volatile so the null-write in sortPlayers/resizePlayers is immediately
+    // @Volatile so the null-write in addPlayer/removePlayer/resizePlayers is immediately
     // visible to threads that read playersMap without going through the lock
     // (e.g. a quick null-check before acquiring).
     @Volatile
@@ -148,6 +153,9 @@ data class Room(
 
     /**
      * Special handling to add a player in the array.
+     *
+     * The player is placed in the first available null slot and the array is NOT re-sorted,
+     * preserving server-assigned slot positions for all existing players (SI-3).
      *
      * @return `true` if it was successfully added, `false` it if wasn't or if it was already in the array (this can
      * happen due to reconnection).
@@ -171,12 +179,15 @@ data class Room(
         }
 
         players[index] = player
-        sortPlayers()
+        _playersMap = null
         return !wasAlready
     }
 
     /**
      * Special handling to remove a player in the array.
+     *
+     * The vacated slot is set to null in-place; the array is NOT re-sorted so that
+     * all remaining players keep their server-assigned slot positions (SI-3).
      *
      * @return The removed player or `null` if it wasn't on the array.
      */
@@ -187,7 +198,7 @@ data class Room(
 
         if (removed != null) {
             players[index] = null
-            sortPlayers()
+            _playersMap = null
         } else {
             Multiplayer.log("WARNING: Tried to remove a player with invalid index: $index")
         }
@@ -207,16 +218,6 @@ data class Room(
     @Synchronized
     fun resizePlayers(newSize: Int) {
         players = players.copyOf(newSize)
-        _playersMap = null
-    }
-
-    /**
-     * Sort players array placing non-null first.
-     * Also invalidates the [playersMap] cache since the array content has changed.
-     */
-    @Synchronized
-    private fun sortPlayers() {
-        players = players.sortedWith { a, b -> (a == null).compareTo(b == null) }.toTypedArray()
         _playersMap = null
     }
 }

--- a/src/com/osudroid/multiplayer/api/data/Room.kt
+++ b/src/com/osudroid/multiplayer/api/data/Room.kt
@@ -65,29 +65,27 @@ data class Room(
     val sessionID: String? = null
 ) {
     /**
-     * The array containing the players, null values are empty slots. The array size corresponds to [maxPlayers].
+     * The players in this [Room]. `null` values are empty slots. The array size corresponds to [maxPlayers].
      *
      * Slot indices mirror the server's layout exactly: index `i` here corresponds to slot `i` on the
-     * server.  The array is never re-sorted locally so the two views never diverge (SI-3).
+     * server. The array is never re-sorted locally so the two views never diverge.
      *
-     * Marked @Volatile so that when [resizePlayers] replaces the array reference all threads
-     * immediately see the new reference without a stale cached copy.
-     * Compound read-modify-write operations must still go through a @Synchronized method.
+     * Marked [Volatile] so that when [resizePlayers] replaces the array reference, all threads immediately see the new
+     * reference without a stale cached copy. **Compound read-modify-write operations must still go through a
+     * [synchronized] method** (see [addPlayer], [removePlayer], and [resizePlayers]).
      */
     @Volatile
     var players: Array<RoomPlayer?> = arrayOfNulls(maxPlayers)
+        @Synchronized set(value) {
+            field = value
+            _playersMap = null
+        }
 
     /**
      * The host/room owner UID.
      */
     @Volatile
     var host: Long = -1
-        @Synchronized set(value) {
-            field = value
-            // NOTE: sortPlayers() used to be called here, but sorting shifts players out of
-            // their server-assigned slot positions (SI-3).  Host assignment does not change
-            // which players are present, so no array mutation or cache invalidation is needed.
-        }
 
     /**
      * The current beatmap.
@@ -120,46 +118,34 @@ data class Room(
         @Synchronized get() = activePlayers.filter { it.status == PlayerStatus.Ready }
 
     /**
-     * Get the players list in map format using UIDs as keys.
-     *
-     * Backed by a cache that is invalidated whenever the players array is mutated
-     * (see [addPlayer], [removePlayer], and [resizePlayers]).  Callers that already hold the lock
-     * (e.g. every @Synchronized method in this class) get the cached map for free
-     * on repeated accesses within the same event; callers on other threads pay at
-     * most one rebuild per mutation event.
+     * All players in this [Room], mapped by their user ID.
      */
-    val playersMap: Map<Long, RoomPlayer>
+    val playersMap
         @Synchronized get() = _playersMap
             ?: players.filterNotNull().associateByTo(HashMap()) { it.id }.also { _playersMap = it }
 
-    // Backing field for the playersMap cache.  Null means the cache is stale.
-    // @Volatile ensures invalidation writes in addPlayer/removePlayer/resizePlayers are
-    // promptly visible to any direct field reads or future unsynchronized fast-paths.
-    // The current playersMap getter is still @Synchronized and rebuilds the cache under the
-    // lock.
     @Volatile
     private var _playersMap: Map<Long, RoomPlayer>? = null
 
     /**
-     * Get the players list of a team in a map format.
+     * All [players] in this [Room], grouped by their team.
      */
     val teamMap
         @Synchronized get() = activePlayers.groupBy { it.team }
 
     /**
-     * Determines if the room team mode is team vs team.
+     * Whether this [Room] is in Team VS mode.
      */
     val isTeamVersus
         get() = teamMode == TeamMode.TeamVersus
 
-
     /**
-     * Special handling to add a player in the array.
+     * Special handling to add a player to this [Room].
      *
-     * The player is placed in the first available null slot and the array is NOT re-sorted,
-     * preserving server-assigned slot positions for all existing players (SI-3).
+     * The player is placed in the first available `null` slot and [players] is NOT re-sorted to preserve
+     * server-assigned slot positions for all existing players.
      *
-     * @return `true` if it was successfully added, `false` it if wasn't or if it was already in the array (this can
+     * @return `true` if it was successfully added, `false` it if wasn't or if it was already in [players] (this can
      * happen due to reconnection).
      */
     @Synchronized
@@ -186,12 +172,12 @@ data class Room(
     }
 
     /**
-     * Special handling to remove a player in the array.
+     * Special handling to remove a player from this [Room].
      *
-     * The vacated slot is set to null in-place; the array is NOT re-sorted so that
-     * all remaining players keep their server-assigned slot positions (SI-3).
+     * The vacated slot is set to `null` in-place; [players] is NOT re-sorted so that all remaining players keep their
+     * server-assigned slot positions.
      *
-     * @return The removed player or `null` if it wasn't on the array.
+     * @return The removed player, or `null` if it wasn't in [players].
      */
     @Synchronized
     fun removePlayer(uid: Long): RoomPlayer? {
@@ -208,18 +194,18 @@ data class Room(
         return removed
     }
 
-
     /**
-     * Atomically resize the players array. Players whose slot index falls within the new size
-     * are preserved; those beyond it are truncated (the server is authoritative on capacity).
+     * Atomically resizes [players]. Players whose slot index falls within the new size are preserved; those beyond it
+     * are truncated (the server is authoritative on capacity).
+     *
      * Callers are expected to identify and surface any truncated players **before** calling
-     * this method — see [com.osudroid.ui.v2.multi.RoomScene.onRoomMaxPlayersChange] (SI-2).
+     * this method — see [com.osudroid.ui.v2.multi.RoomScene.onRoomMaxPlayersChange].
+     *
      * Callers outside this class must use this instead of assigning [players] directly so the
      * operation is covered by the same monitor that guards [addPlayer] / [removePlayer].
      */
     @Synchronized
     fun resizePlayers(newSize: Int) {
         players = players.copyOf(newSize)
-        _playersMap = null
     }
 }

--- a/src/com/osudroid/multiplayer/api/data/Room.kt
+++ b/src/com/osudroid/multiplayer/api/data/Room.kt
@@ -80,6 +80,7 @@ data class Room(
     /**
      * The host/room owner UID.
      */
+    @Volatile
     var host: Long = -1
         @Synchronized set(value) {
             field = value

--- a/src/com/osudroid/multiplayer/api/data/Room.kt
+++ b/src/com/osudroid/multiplayer/api/data/Room.kt
@@ -65,15 +65,20 @@ data class Room(
     val sessionID: String? = null
 ) {
     /**
-     * The array containing the players, null values are empty slots. The array size correspond to [maxPlayers].
+     * The array containing the players, null values are empty slots. The array size corresponds to [maxPlayers].
+     *
+     * Marked @Volatile so that when [sortPlayers] (or [resizePlayers]) replaces the array reference,
+     * all threads immediately see the new reference without a stale cached copy.
+     * Compound read-modify-write operations must still go through a @Synchronized method.
      */
+    @Volatile
     var players: Array<RoomPlayer?> = arrayOfNulls(maxPlayers)
 
     /**
      * The host/room owner UID.
      */
     var host: Long = -1
-        set(value) {
+        @Synchronized set(value) {
             field = value
             sortPlayers()
         }
@@ -100,25 +105,25 @@ data class Room(
      * Besides [players] it provides an array trimmed with no empty slots.
      */
     val activePlayers
-        get() = players.filterNotNull()
+        @Synchronized get() = players.filterNotNull()
 
     /**
      * Returns an array of all players that are in READY status.
      */
     val readyPlayers
-        get() = activePlayers.filter { it.status == PlayerStatus.Ready }
+        @Synchronized get() = activePlayers.filter { it.status == PlayerStatus.Ready }
 
     /**
      * Get the players list in map format using UIDs as keys.
      */
     val playersMap
-        get() = activePlayers.associateBy { it.id }
+        @Synchronized get() = activePlayers.associateBy { it.id }
 
     /**
      * Get the players list of a team in a map format.
      */
     val teamMap
-        get() = activePlayers.groupBy { it.team }
+        @Synchronized get() = activePlayers.groupBy { it.team }
 
     /**
      * Determines if the room team mode is team vs team.
@@ -133,6 +138,7 @@ data class Room(
      * @return `true` if it was successfully added, `false` it if wasn't or if it was already in the array (this can
      * happen due to reconnection).
      */
+    @Synchronized
     fun addPlayer(player: RoomPlayer): Boolean {
         /** @see [RoomPlayer.equals] */
         var index = players.indexOf(player)
@@ -160,6 +166,7 @@ data class Room(
      *
      * @return The removed player or `null` if it wasn't on the array.
      */
+    @Synchronized
     fun removePlayer(uid: Long): RoomPlayer? {
         val index = players.indexOfFirst { it != null && it.id == uid }
         val removed = players.getOrNull(index)
@@ -176,8 +183,20 @@ data class Room(
 
 
     /**
+     * Atomically resize the players array. Players whose slot index falls within the new size
+     * are preserved; those beyond it are silently dropped (the server is authoritative).
+     * Callers outside this class must use this instead of assigning [players] directly so the
+     * operation is covered by the same monitor that guards [addPlayer] / [removePlayer].
+     */
+    @Synchronized
+    fun resizePlayers(newSize: Int) {
+        players = players.copyOf(newSize)
+    }
+
+    /**
      * Sort players array placing non-null first.
      */
+    @Synchronized
     private fun sortPlayers() {
         players = players.sortedWith { a, b -> (a == null).compareTo(b == null) }.toTypedArray()
     }

--- a/src/com/osudroid/multiplayer/api/data/Room.kt
+++ b/src/com/osudroid/multiplayer/api/data/Room.kt
@@ -115,9 +115,23 @@ data class Room(
 
     /**
      * Get the players list in map format using UIDs as keys.
+     *
+     * Backed by a cache that is invalidated whenever the players array is mutated
+     * (see [sortPlayers] and [resizePlayers]).  Callers that already hold the lock
+     * (e.g. every @Synchronized method in this class) get the cached map for free
+     * on repeated accesses within the same event; callers on other threads pay at
+     * most one rebuild per mutation event.
      */
-    val playersMap
-        @Synchronized get() = activePlayers.associateBy { it.id }
+    val playersMap: Map<Long, RoomPlayer>
+        @Synchronized get() = _playersMap
+            ?: players.filterNotNull().associateByTo(HashMap()) { it.id }.also { _playersMap = it }
+
+    // Backing field for the playersMap cache.  Null means the cache is stale.
+    // @Volatile so the null-write in sortPlayers/resizePlayers is immediately
+    // visible to threads that read playersMap without going through the lock
+    // (e.g. a quick null-check before acquiring).
+    @Volatile
+    private var _playersMap: Map<Long, RoomPlayer>? = null
 
     /**
      * Get the players list of a team in a map format.
@@ -191,13 +205,16 @@ data class Room(
     @Synchronized
     fun resizePlayers(newSize: Int) {
         players = players.copyOf(newSize)
+        _playersMap = null
     }
 
     /**
      * Sort players array placing non-null first.
+     * Also invalidates the [playersMap] cache since the array content has changed.
      */
     @Synchronized
     private fun sortPlayers() {
         players = players.sortedWith { a, b -> (a == null).compareTo(b == null) }.toTypedArray()
+        _playersMap = null
     }
 }

--- a/src/com/osudroid/multiplayer/api/data/RoomMods.kt
+++ b/src/com/osudroid/multiplayer/api/data/RoomMods.kt
@@ -1,6 +1,5 @@
 package com.osudroid.multiplayer.api.data
 
-import com.osudroid.multiplayer.Multiplayer
 import com.rian.osu.utils.ModHashMap
 import com.rian.osu.utils.ModUtils
 import org.json.JSONArray
@@ -9,28 +8,27 @@ class RoomMods @JvmOverloads constructor(val json: String = "") : ModHashMap(Mod
 
     constructor(array: JSONArray) : this(array.toString())
 
-    override fun equals(other: Any?): Boolean {
+    /**
+     * Compares two [RoomMods] instances taking the free-mod setting into account.
+     *
+     * In free-mod mode only the required (non-free) mods need to match; individual
+     * player mods are irrelevant for room-level equality.  This is intentionally a
+     * separate named method rather than overriding [equals] so that [equals] remains
+     * a pure, deterministic, context-free operation.
+     *
+     * @param other The other [RoomMods] to compare against.
+     * @param isFreeMod Whether the room currently has free-mod enabled.
+     */
+    fun equalsWithContext(other: RoomMods, isFreeMod: Boolean): Boolean {
+        if (other === this) return true
 
-        if (other === this) {
-            return true
-        }
-
-        if (other !is RoomMods) {
-            return false
-        }
-
-        val gameplaySettings = Multiplayer.room?.gameplaySettings
-
-        if (gameplaySettings?.isFreeMod == true) {
+        if (isFreeMod) {
             val requiredMods = filter { !it.value.isValidForMultiplayerAsFreeMod }
             val otherRequiredMods = other.filter { !it.value.isValidForMultiplayerAsFreeMod }
-
-            return requiredMods.size == otherRequiredMods.size && requiredMods.values.containsAll(otherRequiredMods.values)
+            return requiredMods.size == otherRequiredMods.size &&
+                requiredMods.values.containsAll(otherRequiredMods.values)
         }
 
-        return super.equals(other)
+        return this == other
     }
-
-    // Auto-generated this will help to check instance equality aka ===
-    override fun hashCode() = super.hashCode()
 }

--- a/src/com/osudroid/multiplayer/api/data/RoomMods.kt
+++ b/src/com/osudroid/multiplayer/api/data/RoomMods.kt
@@ -11,10 +11,9 @@ class RoomMods @JvmOverloads constructor(val json: String = "") : ModHashMap(Mod
     /**
      * Compares two [RoomMods] instances taking the free-mod setting into account.
      *
-     * In free-mod mode only the required (non-free) mods need to match; individual
-     * player mods are irrelevant for room-level equality.  This is intentionally a
-     * separate named method rather than overriding [equals] so that [equals] remains
-     * a pure, deterministic, context-free operation.
+     * In free-mod, only the required (non-free) mods need to match; individual player mods are irrelevant for
+     * room-level equality. This is intentionally a separate named method rather than overriding [equals] so that
+     * [equals] remains a pure, deterministic, context-free operation.
      *
      * @param other The other [RoomMods] to compare against.
      * @param isFreeMod Whether the room currently has free-mod enabled.
@@ -25,6 +24,7 @@ class RoomMods @JvmOverloads constructor(val json: String = "") : ModHashMap(Mod
         if (isFreeMod) {
             val requiredMods = filter { !it.value.isValidForMultiplayerAsFreeMod }
             val otherRequiredMods = other.filter { !it.value.isValidForMultiplayerAsFreeMod }
+
             return requiredMods.size == otherRequiredMods.size &&
                 requiredMods.values.containsAll(otherRequiredMods.values)
         }

--- a/src/com/osudroid/multiplayer/api/data/RoomStatus.kt
+++ b/src/com/osudroid/multiplayer/api/data/RoomStatus.kt
@@ -23,7 +23,7 @@ enum class RoomStatus {
 
     companion object {
         /**
-         * Returns the [RoomStatus] for [ordinal], or `null` if the ordinal is not recognised (EH-1).
+         * Returns the [RoomStatus] for [ordinal], or `null` if the ordinal is not recognized.
          */
         operator fun get(ordinal: Int): RoomStatus? = entries.getOrNull(ordinal)
     }

--- a/src/com/osudroid/multiplayer/api/data/RoomStatus.kt
+++ b/src/com/osudroid/multiplayer/api/data/RoomStatus.kt
@@ -22,6 +22,9 @@ enum class RoomStatus {
 
 
     companion object {
-        operator fun get(ordinal: Int) = entries[ordinal]
+        /**
+         * Returns the [RoomStatus] for [ordinal], or `null` if the ordinal is not recognised (EH-1).
+         */
+        operator fun get(ordinal: Int): RoomStatus? = entries.getOrNull(ordinal)
     }
 }

--- a/src/com/osudroid/multiplayer/api/data/RoomTeam.kt
+++ b/src/com/osudroid/multiplayer/api/data/RoomTeam.kt
@@ -23,6 +23,9 @@ enum class RoomTeam {
 
 
     companion object {
-        operator fun get(ordinal: Int) = entries[ordinal]
+        /**
+         * Returns the [RoomTeam] for [ordinal], or `null` if the ordinal is not recognised (EH-1).
+         */
+        operator fun get(ordinal: Int): RoomTeam? = entries.getOrNull(ordinal)
     }
 }

--- a/src/com/osudroid/multiplayer/api/data/RoomTeam.kt
+++ b/src/com/osudroid/multiplayer/api/data/RoomTeam.kt
@@ -24,7 +24,7 @@ enum class RoomTeam {
 
     companion object {
         /**
-         * Returns the [RoomTeam] for [ordinal], or `null` if the ordinal is not recognised (EH-1).
+         * Returns the [RoomTeam] for [ordinal], or `null` if the ordinal is not recognized.
          */
         operator fun get(ordinal: Int): RoomTeam? = entries.getOrNull(ordinal)
     }

--- a/src/com/osudroid/multiplayer/api/data/TeamMode.kt
+++ b/src/com/osudroid/multiplayer/api/data/TeamMode.kt
@@ -17,6 +17,9 @@ enum class TeamMode {
 
 
     companion object {
-        operator fun get(ordinal: Int) = entries[ordinal]
+        /**
+         * Returns the [TeamMode] for [ordinal], or `null` if the ordinal is not recognised (EH-1).
+         */
+        operator fun get(ordinal: Int): TeamMode? = entries.getOrNull(ordinal)
     }
 }

--- a/src/com/osudroid/multiplayer/api/data/TeamMode.kt
+++ b/src/com/osudroid/multiplayer/api/data/TeamMode.kt
@@ -18,7 +18,7 @@ enum class TeamMode {
 
     companion object {
         /**
-         * Returns the [TeamMode] for [ordinal], or `null` if the ordinal is not recognised (EH-1).
+         * Returns the [TeamMode] for [ordinal], or `null` if the ordinal is not recognized.
          */
         operator fun get(ordinal: Int): TeamMode? = entries.getOrNull(ordinal)
     }

--- a/src/com/osudroid/multiplayer/api/data/WinCondition.kt
+++ b/src/com/osudroid/multiplayer/api/data/WinCondition.kt
@@ -31,6 +31,9 @@ enum class WinCondition {
 
 
     companion object {
-        fun from(ordinal: Int) = entries[ordinal]
+        /**
+         * Returns the [WinCondition] for [ordinal], or `null` if the ordinal is not recognised (EH-1).
+         */
+        fun from(ordinal: Int): WinCondition? = entries.getOrNull(ordinal)
     }
 }

--- a/src/com/osudroid/multiplayer/api/data/WinCondition.kt
+++ b/src/com/osudroid/multiplayer/api/data/WinCondition.kt
@@ -32,7 +32,7 @@ enum class WinCondition {
 
     companion object {
         /**
-         * Returns the [WinCondition] for [ordinal], or `null` if the ordinal is not recognised (EH-1).
+         * Returns the [WinCondition] for [ordinal], or `null` if the ordinal is not recognized.
          */
         fun from(ordinal: Int): WinCondition? = entries.getOrNull(ordinal)
     }

--- a/src/com/osudroid/ui/v1/SettingsFragment.kt
+++ b/src/com/osudroid/ui/v1/SettingsFragment.kt
@@ -592,7 +592,7 @@ class SettingsFragment : SettingsFragment() {
             value = Multiplayer.player!!.team?.ordinal?.toString()
 
             setOnPreferenceChangeListener { _, newValue ->
-                RoomAPI.setPlayerTeam(RoomTeam[(newValue as String).toInt()])
+                RoomAPI.setPlayerTeam(RoomTeam[(newValue as String).toInt()] ?: return@setOnPreferenceChangeListener false)
                 true
             }
         }
@@ -666,7 +666,7 @@ class SettingsFragment : SettingsFragment() {
             value = Multiplayer.room!!.teamMode.ordinal.toString()
 
             setOnPreferenceChangeListener { _, newValue ->
-                RoomAPI.setRoomTeamMode(TeamMode[(newValue as String).toInt()])
+                RoomAPI.setRoomTeamMode(TeamMode[(newValue as String).toInt()] ?: return@setOnPreferenceChangeListener false)
                 true
             }
         }
@@ -675,7 +675,7 @@ class SettingsFragment : SettingsFragment() {
             value = Multiplayer.room!!.winCondition.ordinal.toString()
 
             setOnPreferenceChangeListener { _, newValue ->
-                RoomAPI.setRoomWinCondition(WinCondition.from((newValue as String).toInt()))
+                RoomAPI.setRoomWinCondition(WinCondition.from((newValue as String).toInt()) ?: return@setOnPreferenceChangeListener false)
                 true
             }
         }

--- a/src/com/osudroid/ui/v2/BeatmapInfoLayout.kt
+++ b/src/com/osudroid/ui/v2/BeatmapInfoLayout.kt
@@ -1,9 +1,12 @@
 package com.osudroid.ui.v2
 
+import android.util.Log
 import com.osudroid.beatmaps.BeatmapCache
 import com.osudroid.data.*
 import com.osudroid.multiplayer.api.data.*
 import com.osudroid.ui.v2.modmenu.*
+import com.osudroid.utils.async
+import com.osudroid.utils.updateThread
 import com.reco1l.andengine.*
 import com.reco1l.andengine.container.*
 import com.reco1l.andengine.sprite.*
@@ -14,10 +17,13 @@ import com.reco1l.toolkt.*
 import com.rian.osu.*
 import com.rian.osu.utils.ModUtils.applyModsToBeatmapDifficulty
 import com.rian.osu.utils.ModUtils.calculateRateWithMods
+import kotlinx.coroutines.Job
 import ru.nsu.ccfit.zuev.osu.*
 import java.text.*
 import java.util.*
 import kotlin.math.roundToInt
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ensureActive
 
 class BeatmapInfoLayout : UILinearContainer() {
 
@@ -40,6 +46,9 @@ class BeatmapInfoLayout : UILinearContainer() {
 
     private lateinit var starRatingBadge: StarRatingBadge
     private lateinit var versionText: UIText
+
+    private var calculationJob: Job? = null
+    private var displayedBeatmap: BeatmapInfo? = null
 
 
     init {
@@ -177,11 +186,14 @@ class BeatmapInfoLayout : UILinearContainer() {
      * Change the displayed difficulty statistics.
      */
     fun setDifficultyStatistics(beatmapInfo: BeatmapInfo?) {
-        circlesBadge.value = beatmapInfo?.hitCircleCount?.toString() ?: "0"
-        slidersBadge.value = beatmapInfo?.sliderCount?.toString() ?: "0"
-        spinnersBadge.value = beatmapInfo?.spinnerCount?.toString() ?: "0"
+        displayedBeatmap = beatmapInfo
+        calculationJob?.cancel()
+        calculationJob = null
 
         if (beatmapInfo == null) {
+            circlesBadge.value = "0"
+            slidersBadge.value = "0"
+            spinnersBadge.value = "0"
             arText.value = "0.00"
             odText.value = "0.00"
             csText.value = "0.00"
@@ -192,23 +204,49 @@ class BeatmapInfoLayout : UILinearContainer() {
             return
         }
 
-        if (beatmapInfo.needsDifficultyCalculation) {
-            val beatmap = try {
-                BeatmapCache.getBeatmap(
-                    beatmapInfo,
-                    true,
-                    Config.getDifficultyAlgorithm().toGameMode()
-                )
-            } catch (_: Exception) {
-                null
-            }
+        updateDisplay(beatmapInfo)
 
-            if (beatmap != null) {
-                val newInfo = BeatmapInfo(beatmap, beatmapInfo.dateImported, true)
-                beatmapInfo.apply(newInfo)
-                DatabaseManager.beatmapInfoTable.update(newInfo)
+        if (beatmapInfo.needsDifficultyCalculation) {
+            calculationJob = async {
+                val beatmap = try {
+                    BeatmapCache.getBeatmap(
+                        beatmapInfo,
+                        true,
+                        Config.getDifficultyAlgorithm().toGameMode(),
+                        this
+                    )
+                } catch (e: Exception) {
+                    if (e is CancellationException) {
+                        throw e
+                    }
+
+                    Log.e("BeatmapInfoLayout", "Failed to calculate difficulty for ${beatmapInfo.filename}", e)
+                    null
+                }
+
+                ensureActive()
+
+                if (beatmap != null) {
+                    val newInfo = BeatmapInfo(beatmap, beatmapInfo.dateImported, true, this)
+                    beatmapInfo.apply(newInfo)
+                    DatabaseManager.beatmapInfoTable.update(newInfo)
+
+                    ensureActive()
+
+                    updateThread {
+                        if (displayedBeatmap === beatmapInfo) {
+                            updateDisplay(beatmapInfo)
+                        }
+                    }
+                }
             }
         }
+    }
+
+    private fun updateDisplay(beatmapInfo: BeatmapInfo) {
+        circlesBadge.value = beatmapInfo.hitCircleCount.toString()
+        slidersBadge.value = beatmapInfo.sliderCount.toString()
+        spinnersBadge.value = beatmapInfo.spinnerCount.toString()
 
         val mods = ModMenu.enabledMods
         val totalSpeedMultiplier = calculateRateWithMods(mods.values, Double.POSITIVE_INFINITY)

--- a/src/com/osudroid/ui/v2/BeatmapInfoLayout.kt
+++ b/src/com/osudroid/ui/v2/BeatmapInfoLayout.kt
@@ -243,6 +243,11 @@ class BeatmapInfoLayout : UILinearContainer() {
         }
     }
 
+    fun cancelCalculation() {
+        calculationJob?.cancel()
+        calculationJob = null
+    }
+
     private fun updateDisplay(beatmapInfo: BeatmapInfo) {
         circlesBadge.value = beatmapInfo.hitCircleCount.toString()
         slidersBadge.value = beatmapInfo.sliderCount.toString()

--- a/src/com/osudroid/ui/v2/BeatmapInfoLayout.kt
+++ b/src/com/osudroid/ui/v2/BeatmapInfoLayout.kt
@@ -1,5 +1,6 @@
 package com.osudroid.ui.v2
 
+import com.osudroid.beatmaps.BeatmapCache
 import com.osudroid.data.*
 import com.osudroid.multiplayer.api.data.*
 import com.osudroid.ui.v2.modmenu.*
@@ -176,7 +177,6 @@ class BeatmapInfoLayout : UILinearContainer() {
      * Change the displayed difficulty statistics.
      */
     fun setDifficultyStatistics(beatmapInfo: BeatmapInfo?) {
-
         circlesBadge.value = beatmapInfo?.hitCircleCount?.toString() ?: "0"
         slidersBadge.value = beatmapInfo?.sliderCount?.toString() ?: "0"
         spinnersBadge.value = beatmapInfo?.spinnerCount?.toString() ?: "0"
@@ -190,6 +190,24 @@ class BeatmapInfoLayout : UILinearContainer() {
             bpmBadge.text = "0"
             lengthBadge.text = "00:00"
             return
+        }
+
+        if (beatmapInfo.needsDifficultyCalculation) {
+            val beatmap = try {
+                BeatmapCache.getBeatmap(
+                    beatmapInfo,
+                    true,
+                    Config.getDifficultyAlgorithm().toGameMode()
+                )
+            } catch (_: Exception) {
+                null
+            }
+
+            if (beatmap != null) {
+                val newInfo = BeatmapInfo(beatmap, beatmapInfo.dateImported, true)
+                beatmapInfo.apply(newInfo)
+                DatabaseManager.beatmapInfoTable.update(newInfo)
+            }
         }
 
         val mods = ModMenu.enabledMods

--- a/src/com/osudroid/ui/v2/modmenu/ModMenu.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModMenu.kt
@@ -440,7 +440,7 @@ object ModMenu : UIScene() {
 
         if (Multiplayer.isConnected) {
             Multiplayer.roomScene?.chat?.show()
-            Multiplayer.roomScene?.isWaitingForModsChange = true
+            Multiplayer.roomScene?.isWaitingForModsChange?.set(true)
 
             // The room mods are the same as the host mods
             if (Multiplayer.isRoomHost) {
@@ -448,7 +448,7 @@ object ModMenu : UIScene() {
             } else if (updatePlayerMods) {
                 setPlayerMods(enabledMods.serializeMods())
             } else {
-                Multiplayer.roomScene?.isWaitingForModsChange = false
+                Multiplayer.roomScene?.isWaitingForModsChange?.set(false)
             }
         }
 

--- a/src/com/osudroid/ui/v2/modmenu/ModMenu.kt
+++ b/src/com/osudroid/ui/v2/modmenu/ModMenu.kt
@@ -2,6 +2,8 @@ package com.osudroid.ui.v2.modmenu
 
 import com.edlplan.framework.easing.Easing
 import com.osudroid.beatmaps.BeatmapCache
+import com.osudroid.data.BeatmapInfo
+import com.osudroid.data.DatabaseManager
 import com.reco1l.andengine.*
 import com.reco1l.andengine.component.UIComponent.Companion.MatchContent
 import com.reco1l.andengine.component.UIComponent.Companion.FillParent
@@ -355,6 +357,12 @@ object ModMenu : UIScene() {
             if (beatmap == null) {
                 songMenu.setStarsDisplay(0f)
                 return@scope
+            }
+
+            if (selectedBeatmap.needsDifficultyCalculation) {
+                val newInfo = BeatmapInfo(beatmap, selectedBeatmap.dateImported, true)
+                selectedBeatmap.apply(newInfo)
+                DatabaseManager.beatmapInfoTable.update(newInfo)
             }
 
             enabledMods.values.filterIsInstance<IModRequiresOriginalBeatmap>().fastForEach { mod ->

--- a/src/com/osudroid/ui/v2/multi/LobbyScene.kt
+++ b/src/com/osudroid/ui/v2/multi/LobbyScene.kt
@@ -231,9 +231,6 @@ class LobbyScene : UIScene() {
 
             isFetching = false
         }) {
-
-            // Pre-fetch UI setup must happen on the update thread — the scene graph
-            // is not thread-safe and must not be mutated from a background coroutine.
             updateThread {
                 messageContainer.apply {
                     detachChildren()

--- a/src/com/osudroid/ui/v2/multi/LobbyScene.kt
+++ b/src/com/osudroid/ui/v2/multi/LobbyScene.kt
@@ -232,18 +232,22 @@ class LobbyScene : UIScene() {
             isFetching = false
         }) {
 
-            messageContainer.apply {
-                detachChildren()
+            // Pre-fetch UI setup must happen on the update thread — the scene graph
+            // is not thread-safe and must not be mutated from a background coroutine.
+            updateThread {
+                messageContainer.apply {
+                    detachChildren()
 
-                +CircularProgressBar().apply {
-                    anchor = Anchor.Center
-                    origin = Anchor.Center
-                    size = Vec2(48f, 48f)
+                    +CircularProgressBar().apply {
+                        anchor = Anchor.Center
+                        origin = Anchor.Center
+                        size = Vec2(48f, 48f)
+                    }
                 }
-            }
 
-            switchContainers(messageContainer)
-            roomContainer.detachChildren()
+                switchContainers(messageContainer)
+                roomContainer.detachChildren()
+            }
 
             val list = LobbyAPI.getRooms(
                 query = searchQuery,

--- a/src/com/osudroid/ui/v2/multi/RoomChat.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomChat.kt
@@ -74,9 +74,6 @@ class RoomChat : UILinearContainer() {
         get() = UIEngine.current.overlay
 
     init {
-        // At any given time, there should be only one chat instance in the overlay.
-        // Two or more instances of these can present after a player successfully reconnects.
-        overlay.detachChildren { it is RoomChat }
 
         // Force the main container to fill the entire screen so that the chat can be closed by
         // tapping outside of it (see onAreaTouched).

--- a/src/com/osudroid/ui/v2/multi/RoomChat.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomChat.kt
@@ -304,6 +304,7 @@ class RoomChat : UILinearContainer() {
 
             linearContainer {
                 width = FillParent
+                height = FillParent
                 orientation = Orientation.Horizontal
 
                 tagText = text {
@@ -315,6 +316,8 @@ class RoomChat : UILinearContainer() {
 
                 messageText = text {
                     width = FillParent
+                    height = FillParent
+                    clipToBounds = true
                     anchor = Anchor.CenterLeft
                     origin = Anchor.CenterLeft
                     applyTheme = { color = it.accentColor }

--- a/src/com/osudroid/ui/v2/multi/RoomChat.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomChat.kt
@@ -340,7 +340,7 @@ class RoomChat : UILinearContainer() {
                     text = "${if (lastMessage is PlayerMessage) lastMessage.player.name else StringTable.get(R.string.multiplayer_room_chat_system)}: "
                     color = if (lastMessage is PlayerMessage) getPlayerTagColor(lastMessage.player) else Theme.current.accentColor
                 }
-                messageText.text = lastMessage.content
+                messageText.text = lastMessage.content.substringBefore('\n')
             }
         }
 

--- a/src/com/osudroid/ui/v2/multi/RoomPlayerCard.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomPlayerCard.kt
@@ -137,13 +137,13 @@ class RoomPlayerCard : UILinearContainer() {
             nameText.text = player.name
             nameText.spacing = 6f
 
-            hostIcon.detachSelf()
-            mutedIcon.detachSelf()
-
             nameText.trailingIcon = when {
                 player.id == room.host && player.isMuted -> UILinearContainer().apply {
                     orientation = Orientation.Horizontal
                     spacing = 6f
+
+                    hostIcon.detachSelf()
+                    mutedIcon.detachSelf()
 
                     +hostIcon
                     +mutedIcon

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -766,9 +766,15 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
 
         if (uid != null) {
 
+            // Look up the sender.  If they are not yet in playersMap the most likely cause is
+            // that chatMessage arrived on the EventThread just before the playerJoined event
+            // that was queued right behind it (EH-3).  Rather than silently discarding the
+            // message, build a temporary stub player so the text is displayed in the chat log.
+            // The stub uses "#uid" as its name; once playerJoined fires, any subsequent
+            // messages from that player will show their real username.
             val player = room.playersMap[uid] ?: run {
-                Multiplayer.log("WARNING: Unable to find user by ID on chat message")
-                return
+                Multiplayer.log("WARNING: chatMessage from unknown UID $uid — displaying with stub name (EH-3)")
+                RoomPlayer(id = uid, name = "#$uid", status = PlayerStatus.NotReady, team = null, mods = RoomMods())
             }
 
             if (!player.isMuted) {

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -1043,6 +1043,17 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
 
         val player = Multiplayer.player ?: return
 
+        if (player.status == PlayerStatus.MissingBeatmap) {
+            // This client does not have the beatmap and will never call startGame(), so
+            // GameScene.onGameLoad() will never fire and notifyBeatmapLoaded() would never be
+            // sent.  The server waits for every client's beatmapLoadComplete before sending
+            // allPlayersBeatmapLoadComplete, so one missing-beatmap client would block the
+            // match for everyone (EH-5).  Send the ACK immediately so the server can proceed
+            // once all other players have loaded.
+            Multiplayer.log("INFO: MissingBeatmap — sending immediate beatmapLoadComplete ACK (EH-5)")
+            RoomAPI.notifyBeatmapLoaded()
+        }
+
         updateThread {
             val global = GlobalManager.getInstance()
             if (player.status != PlayerStatus.MissingBeatmap && global.engine.scene != global.gameScene.scene) {

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -116,7 +116,14 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
     /**
      * Running job that force-starts the game if `allPlayersBeatmapLoadComplete` is not received
      * within [BEATMAP_LOAD_TIMEOUT_MS] ms after `playBeatmap` was received (EH-2).
+     *
+     * `@Volatile` is required because this field is written from three different threads:
+     * - socket EventThread  → [startBeatmapLoadTimeout] / [cancelBeatmapLoadTimeout]
+     * - AndEngine update thread → [cancelBeatmapLoadTimeout] (called from [back])
+     * - [matchScope] coroutine (Dispatchers.Default) → set to `null` after the delay fires
+     * Without `@Volatile` the JVM memory model gives no visibility guarantee across threads.
      */
+    @Volatile
     private var beatmapLoadTimeoutJob: Job? = null
 
 

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -721,10 +721,16 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
         GlobalManager.getInstance().engine.scene = this
 
         if (!isWaitingForBeatmapChange) {
+            // onRoomBeatmapChange sets engine.scene = this just above, so it will always
+            // find the scene active and call invalidateStatus() internally.  Do NOT call
+            // invalidateStatus() again afterwards — that would emit a redundant
+            // setPlayerStatus to the server (SI-4).
             onRoomBeatmapChange(room.beatmap)
         }
+        // When isWaitingForBeatmapChange == true a beatmap change is already in flight.
+        // Emitting a status now would race the imminent onRoomBeatmapChange callback that
+        // will call invalidateStatus() with the correct beatmap context.
 
-        invalidateStatus()
         chat.show()
     }
 

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -724,9 +724,17 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
 
     // Navigation
 
-    override fun back() {
-        // Cancel the reconnection scope/job before setting isReconnecting = false so the
-        // coroutine's loop exits and the scope is cleaned up (ML-2).
+    /**
+     * Tears down all multiplayer state: cancels reconnection, nulls event listeners,
+     * disconnects the socket, cancels pending jobs, and hides the chat.
+     *
+     * This is the common teardown path shared by [back] (which also navigates to the lobby)
+     * and the kicked-during-game handler (which must NOT navigate since the game scene must
+     * be allowed to finish).
+     *
+     * **Must be called on the AndEngine update thread.**
+     */
+    private fun teardownSession() {
         Multiplayer.cancelReconnection()
 
         // Null out event listeners before disconnect so any queued socket events that
@@ -743,7 +751,10 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
         Multiplayer.roomScene = null
         Multiplayer.player = null
         chat.hide()
+    }
 
+    override fun back() {
+        teardownSession()
         UIEngine.current.scene = LobbyScene()
     }
 
@@ -1211,7 +1222,19 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
 
             updateThread {
                 if (GlobalManager.getInstance().engine.scene == GlobalManager.getInstance().gameScene.scene) {
+                    // Kicked while a game is in progress.  We cannot navigate away from the
+                    // game scene immediately — doing so would abruptly interrupt gameplay.
+                    // Instead:
+                    //   1. Show the toast so the player knows why they were kicked.
+                    //   2. Tear down all multiplayer state (disconnect socket, null globals,
+                    //      cancel coroutines, hide chat) so live-score events stop firing.
+                    //   3. Clear isMultiplayer so the scoring scene and GameScene treat the
+                    //      remainder of the game as a solo session — submitFinalScore() will
+                    //      not be called, and ScoringScene.back() will return to SongMenu
+                    //      rather than trying to re-enter the (now-disconnected) room.
                     mainThread { ToastLogger.showText(R.string.multiplayer_room_kicked_gameplay, true) }
+                    teardownSession()
+                    Multiplayer.isMultiplayer = false
                     return@updateThread
                 }
 

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -24,6 +24,11 @@ import com.osudroid.ui.v2.modmenu.ModMenu
 import com.osudroid.utils.async
 import com.osudroid.utils.mainThread
 import com.osudroid.utils.updateThread
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import com.reco1l.andengine.Anchor
 import com.reco1l.andengine.Axes
 import com.reco1l.andengine.UIEngine
@@ -94,6 +99,19 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
      */
     @JvmField
     var isWaitingForModsChange = false
+
+    /**
+     * Coroutine scope used for the beatmap-load timeout job (EH-2).
+     * A dedicated scope is used so that cancelling the job is cheap and cannot interfere with
+     * other coroutines.
+     */
+    private val matchScope = CoroutineScope(Dispatchers.Default)
+
+    /**
+     * Running job that force-starts the game if `allPlayersBeatmapLoadComplete` is not received
+     * within [BEATMAP_LOAD_TIMEOUT_MS] ms after `playBeatmap` was received (EH-2).
+     */
+    private var beatmapLoadTimeoutJob: Job? = null
 
 
     /**
@@ -702,6 +720,9 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
     override fun back() {
         Multiplayer.isReconnecting = false
 
+        // Cancel any pending beatmap-load timeout so it cannot fire after teardown (EH-2).
+        cancelBeatmapLoadTimeout()
+
         runSafe { RoomAPI.disconnect() }
 
         Multiplayer.room = null
@@ -1031,10 +1052,21 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
             }
         }
 
+        // Start a safety timer: if allPlayersBeatmapLoadComplete is never received (e.g. one
+        // client crashes mid-load without a clean disconnect) the match would hang forever for
+        // everyone.  Force-set isReadyToStart after the timeout so the game proceeds regardless
+        // (EH-2).
+        startBeatmapLoadTimeout()
+
         updatePlayerList()
     }
 
     override fun onRoomMatchStart() {
+
+        // allPlayersBeatmapLoadComplete received — the server confirmed all clients are ready.
+        // Cancel the safety timeout so it cannot fire spuriously after the game has already
+        // started (EH-2).
+        cancelBeatmapLoadTimeout()
 
         updateThread {
             if (GlobalManager.getInstance().engine.scene is GameLoaderScene) {
@@ -1065,6 +1097,50 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
 
     override fun onRoomFinalLeaderboard(leaderboard: JSONArray) {
         Multiplayer.onFinalLeaderboard(leaderboard)
+    }
+
+
+    // Beatmap-load timeout (EH-2)
+
+    /**
+     * Starts a safety timer that force-starts gameplay if [onRoomMatchStart] is not received
+     * within [BEATMAP_LOAD_TIMEOUT_MS] milliseconds.  This prevents the entire lobby from
+     * hanging indefinitely when one client stops responding mid-load without a clean disconnect.
+     */
+    private fun startBeatmapLoadTimeout() {
+        beatmapLoadTimeoutJob?.cancel()
+        beatmapLoadTimeoutJob = matchScope.launch {
+            delay(BEATMAP_LOAD_TIMEOUT_MS)
+            Multiplayer.log(
+                "WARNING: allPlayersBeatmapLoadComplete not received within " +
+                "${BEATMAP_LOAD_TIMEOUT_MS}ms — force-starting game (EH-2)"
+            )
+            updateThread {
+                if (GlobalManager.getInstance().engine.scene is GameLoaderScene) {
+                    GlobalManager.getInstance().gameScene.isReadyToStart = true
+                }
+            }
+            beatmapLoadTimeoutJob = null
+        }
+    }
+
+    /**
+     * Cancels the pending beatmap-load timeout, if any.
+     * Call this when [onRoomMatchStart] is received or when the room is torn down.
+     */
+    private fun cancelBeatmapLoadTimeout() {
+        beatmapLoadTimeoutJob?.cancel()
+        beatmapLoadTimeoutJob = null
+    }
+
+
+    companion object {
+        /**
+         * How long (ms) to wait for `allPlayersBeatmapLoadComplete` before force-starting the
+         * game.  30 s gives slow devices enough time to finish loading while still providing a
+         * meaningful upper bound on how long other players can be blocked (EH-2).
+         */
+        private const val BEATMAP_LOAD_TIMEOUT_MS = 30_000L
     }
 
 

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -943,17 +943,13 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
             updateBeatmap(beatmap)
         }
 
-        // songService (MediaPlayer) must be called from the main Android thread, not the
-        // AndEngine update thread or the socket EventThread.
-        mainThread {
-            if (selectedBeatmap == null) {
-                GlobalManager.getInstance().songService.stop()
-                return@mainThread
-            }
-
-            GlobalManager.getInstance().songService.preLoad(selectedBeatmap.audioPath)
-            GlobalManager.getInstance().songService.play()
+        if (selectedBeatmap == null) {
+            GlobalManager.getInstance().songService.stop()
+            return
         }
+
+        GlobalManager.getInstance().songService.preLoad(selectedBeatmap.audioPath)
+        GlobalManager.getInstance().songService.play()
     }
 
     override fun onRoomHostChange(uid: Long) {

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -518,28 +518,25 @@ class RoomScene(
         modsIndicator.mods = room.mods.values
     }
 
-    fun updatePlayerList() {
-
+    fun updatePlayerList() = updateThread {
         val shouldReload = currentPlayers.size != room.playersMap.size
-            || !currentPlayers.all { room.playersMap.containsKey(it) }
+                || !currentPlayers.all { room.playersMap.containsKey(it) }
 
-        updateThread {
-            playersContainer.apply {
+        playersContainer.apply {
 
-                if (shouldReload) {
-                    detachChildren()
+            if (shouldReload) {
+                detachChildren()
 
-                    room.activePlayers.forEach {
-                        +RoomPlayerCard().apply {
-                            updateState(room, it)
-                        }
+                room.activePlayers.forEach {
+                    +RoomPlayerCard().apply {
+                        updateState(room, it)
                     }
-                    currentPlayers = room.playersMap.keys.toLongArray()
-                } else {
-                    room.activePlayers.forEachIndexed { index, player ->
-                        val card = getChild(index) as RoomPlayerCard
-                        card.updateState(room, player)
-                    }
+                }
+                currentPlayers = room.playersMap.keys.toLongArray()
+            } else {
+                room.activePlayers.forEachIndexed { index, player ->
+                    val card = getChild(index) as RoomPlayerCard
+                    card.updateState(room, player)
                 }
             }
         }

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -941,7 +941,8 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
 
         room.host = uid
 
-        chat.onSystemChatMessage(StringTable.format(R.string.multiplayer_room_new_host, room.playersMap[uid]?.name.toString()), "#459FFF")
+        val newHostName = room.playersMap[uid]?.name ?: "#$uid"
+        chat.onSystemChatMessage(StringTable.format(R.string.multiplayer_room_new_host, newHostName), "#459FFF")
 
         updateThread {
             ModMenu.back(false)

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -57,7 +57,6 @@ import com.reco1l.framework.math.Vec4
 import com.reco1l.osu.ui.MessageDialog
 import com.reco1l.toolkt.kotlin.runSafe
 import com.rian.osu.mods.ModScoreV2
-import kotlin.time.Duration.Companion.milliseconds
 import org.json.JSONArray
 import ru.nsu.ccfit.zuev.osu.Config
 import ru.nsu.ccfit.zuev.osu.GlobalManager

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -1075,10 +1075,10 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
             return
         }
 
-        val player = room.removePlayer(uid)
+        val removedPlayer = room.removePlayer(uid)
 
-        if (player != null) {
-            chat.onSystemChatMessage(StringTable.format(R.string.multiplayer_room_player_kicked, player.name, player.id), "#FFBFBF")
+        if (removedPlayer != null) {
+            chat.onSystemChatMessage(StringTable.format(R.string.multiplayer_room_player_kicked, removedPlayer.name, removedPlayer.id), "#FFBFBF")
         }
 
         updateInformation()

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -720,6 +720,11 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
     override fun back() {
         Multiplayer.isReconnecting = false
 
+        // Null out event listeners before disconnect so any queued socket events that
+        // arrive after teardown find no listener to call (ML-1).
+        RoomAPI.roomEventListener = null
+        RoomAPI.playerEventListener = null
+
         // Cancel any pending beatmap-load timeout so it cannot fire after teardown (EH-2).
         cancelBeatmapLoadTimeout()
 

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -854,10 +854,14 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
         updateThread {
             updateBackground(selectedBeatmap?.backgroundPath)
             updateBeatmap(beatmap)
+        }
 
+        // songService (MediaPlayer) must be called from the main Android thread, not the
+        // AndEngine update thread or the socket EventThread.
+        mainThread {
             if (selectedBeatmap == null) {
                 GlobalManager.getInstance().songService.stop()
-                return@updateThread
+                return@mainThread
             }
 
             GlobalManager.getInstance().songService.preLoad(selectedBeatmap.audioPath)

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -79,18 +79,19 @@ class RoomScene(
      * This is only used if [com.osudroid.multiplayer.Multiplayer.player] is the room host.
      */
     @JvmField
-    var isWaitingForBeatmapChange = false
+    val isWaitingForBeatmapChange = AtomicBoolean(false)
 
     /**
      * Indicates that the player can change its status. Its purpose is to await for server changes.
      */
+    @JvmField
     val isWaitingForStatusChange = AtomicBoolean(false)
 
     /**
      * Indicates that the player can change its mods. Its purpose is to await for server changes.
      */
     @JvmField
-    var isWaitingForModsChange = false
+    val isWaitingForModsChange = AtomicBoolean(false)
 
     /**
      * The room chat.
@@ -733,7 +734,7 @@ class RoomScene(
 
         GlobalManager.getInstance().engine.scene = this
 
-        if (!isWaitingForBeatmapChange) {
+        if (!isWaitingForBeatmapChange.get()) {
             // onRoomBeatmapChange sets engine.scene = this just above, so it will always
             // find the scene active and call invalidateStatus() internally.  Do NOT call
             // invalidateStatus() again afterwards — that would emit a redundant
@@ -789,7 +790,7 @@ class RoomScene(
         ModMenu.clear()
         ModMenu.setMods(newRoom.mods, newRoom.gameplaySettings.isFreeMod)
 
-        isWaitingForModsChange = true
+        isWaitingForModsChange.set(true)
 
         RoomAPI.setPlayerMods(ModMenu.enabledMods.serializeMods())
 
@@ -823,9 +824,9 @@ class RoomScene(
 
         if (!byUser) {
             // Setting await locks to avoid player emitting events that will be ignored.
-            isWaitingForBeatmapChange = true
+            isWaitingForBeatmapChange.set(true)
             isWaitingForStatusChange.set(true)
-            isWaitingForModsChange = true
+            isWaitingForModsChange.set(true)
 
             chat.onSystemChatMessage(StringTable.get(R.string.multiplayer_room_reconnecting), "#FFBFBF")
             Multiplayer.onReconnect()
@@ -876,7 +877,7 @@ class RoomScene(
 
         if (GlobalManager.getInstance().engine.scene != this) {
             updateThread { updateBeatmapInfo() }
-            isWaitingForBeatmapChange = false
+            isWaitingForBeatmapChange.set(false)
             return
         }
 
@@ -886,7 +887,7 @@ class RoomScene(
         }
 
         invalidateStatus()
-        isWaitingForBeatmapChange = false
+        isWaitingForBeatmapChange.set(false)
 
         val selectedBeatmap = GlobalManager.getInstance().selectedBeatmap
         updateThread {
@@ -931,7 +932,7 @@ class RoomScene(
 
         room.mods = mods
 
-        isWaitingForModsChange = true
+        isWaitingForModsChange.set(true)
 
         updateThread {
             // Apply the new room mods to ModMenu first so that enabledMods is up-to-date
@@ -950,7 +951,7 @@ class RoomScene(
 
         updatePlayerList()
 
-        isWaitingForModsChange = true
+        isWaitingForModsChange.set(true)
 
         updateThread {
             updateButtons()
@@ -978,7 +979,7 @@ class RoomScene(
 
         val player = Multiplayer.player ?: return
         if (uid == player.id) {
-            isWaitingForModsChange = false
+            isWaitingForModsChange.set(false)
             updateThread { updateBeatmapInfo() }
         }
     }
@@ -1001,7 +1002,7 @@ class RoomScene(
         updateThread { updateInformation() }
 
         if (Multiplayer.isRoomHost) {
-            isWaitingForModsChange = true
+            isWaitingForModsChange.set(true)
 
             // If win condition is Score V2 we add the mod.
             val roomMods = room.mods.apply {

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -898,8 +898,8 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
     override fun onRoomMaxPlayersChange(maxPlayers: Int) {
         // Before shrinking the array, surface any players that would be silently
         // truncated so the chat keeps an audit trail and the displayed player list
-        // stays consistent (SI-2).  After sorting, non-null entries always come
-        // first, so any active player beyond the new limit sits at index >= maxPlayers.
+        // stays consistent (SI-2).  The player array preserves server slot indices,
+        // so any active player beyond the new limit is in a slot with index >= maxPlayers.
         if (maxPlayers < room.players.size) {
             room.players.drop(maxPlayers).filterNotNull().forEach { dropped ->
                 chat.onSystemChatMessage(

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -808,7 +808,7 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
 
     override fun onRoomMaxPlayersChange(maxPlayers: Int) {
         room.maxPlayers = maxPlayers
-        room.players = room.players.copyOf(maxPlayers)
+        room.resizePlayers(maxPlayers)
 
         updateInformation()
         updatePlayerList()

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -831,6 +831,19 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
     }
 
     override fun onRoomMaxPlayersChange(maxPlayers: Int) {
+        // Before shrinking the array, surface any players that would be silently
+        // truncated so the chat keeps an audit trail and the displayed player list
+        // stays consistent (SI-2).  After sorting, non-null entries always come
+        // first, so any active player beyond the new limit sits at index >= maxPlayers.
+        if (maxPlayers < room.players.size) {
+            room.players.drop(maxPlayers).filterNotNull().forEach { dropped ->
+                chat.onSystemChatMessage(
+                    StringTable.format(R.string.multiplayer_room_player_left, dropped.name, dropped.id),
+                    "#459FFF"
+                )
+            }
+        }
+
         room.maxPlayers = maxPlayers
         room.resizePlayers(maxPlayers)
 

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -385,7 +385,7 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
                     isSelected = true
                     onActionUp = callback@{
 
-                        if (isWaitingForStatusChange || !Multiplayer.isRoomHost || Multiplayer.player!!.status != PlayerStatus.Ready) {
+                        if (isWaitingForStatusChange || !Multiplayer.isRoomHost || Multiplayer.player?.status != PlayerStatus.Ready) {
                             return@callback
                         }
 
@@ -430,7 +430,14 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
                         ResourceManager.getInstance().getSound("menuclick")?.play()
                         isWaitingForStatusChange = true
 
-                        when (Multiplayer.player!!.status) {
+                        // Guard: if back() nulled player between the isWaitingForStatusChange check
+                        // and here, reset the flag and exit instead of crashing.
+                        val player = Multiplayer.player ?: run {
+                            isWaitingForStatusChange = false
+                            return@callback
+                        }
+
+                        when (player.status) {
 
                             PlayerStatus.NotReady -> {
                                 if (room.beatmap == null) {
@@ -439,7 +446,7 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
                                     return@callback
                                 }
 
-                                if (room.teamMode == TeamMode.TeamVersus && Multiplayer.player!!.team == null) {
+                                if (room.teamMode == TeamMode.TeamVersus && player.team == null) {
                                     ToastLogger.showText(R.string.multiplayer_room_cannot_ready_no_team, true)
                                     isWaitingForStatusChange = false
                                     return@callback
@@ -533,27 +540,31 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
     }
 
     private fun updateButtons() {
+        // Guard: player is nulled by back() when the scene is tearing down; any
+        // concurrent call (socket EventThread or update thread) must exit cleanly.
+        val player = Multiplayer.player ?: return
+
         statusButton.apply {
             setText(
-                when (Multiplayer.player!!.status) {
+                when (player.status) {
                     PlayerStatus.NotReady -> R.string.multiplayer_room_ready
                     PlayerStatus.Ready -> R.string.multiplayer_room_not_ready
                     else -> R.string.multiplayer_room_unable_status
                 }
             )
 
-            isEnabled = when (Multiplayer.player!!.status) {
+            isEnabled = when (player.status) {
                 PlayerStatus.Ready, PlayerStatus.NotReady -> true
                 else -> false
             }
 
-            isSelected = Multiplayer.player!!.status == PlayerStatus.NotReady
+            isSelected = player.status == PlayerStatus.NotReady
         }
 
         val playersReady = room.activePlayers.filter { it.status == PlayerStatus.Ready }
 
         startButton.apply {
-            isVisible = Multiplayer.isRoomHost && Multiplayer.player!!.status == PlayerStatus.Ready
+            isVisible = Multiplayer.isRoomHost && player.status == PlayerStatus.Ready
 
             // isVisible does only hide the button, but we also need to disable it.
             isEnabled = isVisible
@@ -659,6 +670,9 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
             return
         }
 
+        // Guard: player is nulled by back(); if we race past the reconnecting check, exit cleanly.
+        val player = Multiplayer.player ?: return
+
         isWaitingForStatusChange = true
 
         var newStatus = PlayerStatus.NotReady
@@ -667,7 +681,7 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
             newStatus = PlayerStatus.MissingBeatmap
         }
 
-        if (Multiplayer.player!!.status != newStatus) {
+        if (player.status != newStatus) {
             RoomAPI.setPlayerStatus(newStatus)
         } else {
             isWaitingForStatusChange = false
@@ -756,7 +770,8 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
 
             // If the status returned by server is PLAYING then it means the match was forced to start while the player
             // was disconnected.
-            if (Multiplayer.player!!.status == PlayerStatus.Playing) {
+            val player = Multiplayer.player ?: return
+            if (player.status == PlayerStatus.Playing) {
                 // Handling special case when the beatmap could have been changed and match was started while player was
                 // disconnected.
                 if (GlobalManager.getInstance().selectedBeatmap != null) {
@@ -912,7 +927,8 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
 
         updatePlayerList()
 
-        if (uid == Multiplayer.player!!.id) {
+        val player = Multiplayer.player ?: return
+        if (uid == player.id) {
             isWaitingForModsChange = false
             updateBeatmapInfo()
         }
@@ -960,8 +976,9 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
     override fun onRoomMatchPlay() {
 
         val global = GlobalManager.getInstance()
+        val player = Multiplayer.player ?: return
 
-        if (Multiplayer.player!!.status != PlayerStatus.MissingBeatmap && global.engine.scene != global.gameScene.scene) {
+        if (player.status != PlayerStatus.MissingBeatmap && global.engine.scene != global.gameScene.scene) {
 
             if (GlobalManager.getInstance().selectedBeatmap == null) {
                 Multiplayer.log("WARNING: Attempt to start match with null track.")
@@ -1033,7 +1050,9 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
 
     override fun onPlayerKick(uid: Long) {
 
-        if (uid == Multiplayer.player!!.id) {
+        val player = Multiplayer.player ?: return
+
+        if (uid == player.id) {
 
             Multiplayer.log("Kicked from room.")
 
@@ -1070,7 +1089,8 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
 
         room.playersMap[uid]!!.status = status
 
-        if (uid == Multiplayer.player!!.id) {
+        val player = Multiplayer.player
+        if (player != null && uid == player.id) {
             isWaitingForStatusChange = false
         }
 

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -705,6 +705,7 @@ class RoomScene(
      */
     private fun teardownSession() {
         Multiplayer.cancelReconnection()
+        beatmapInfoLayout.cancelCalculation()
 
         // Null out event listeners before disconnect so any queued socket events that
         // arrive after teardown find no listener to call.

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -857,17 +857,10 @@ class RoomScene(
     }
 
     override fun onRoomMaxPlayersChange(maxPlayers: Int) {
-        // Before shrinking the array, surface any players that would be silently
-        // truncated so the chat keeps an audit trail and the displayed player list
-        // stays consistent (SI-2).  The player array preserves server slot indices,
-        // so any active player beyond the new limit is in a slot with index >= maxPlayers.
-        if (maxPlayers < room.players.size) {
-            room.players.drop(maxPlayers).filterNotNull().forEach { dropped ->
-                chat.onSystemChatMessage(
-                    StringTable.format(R.string.multiplayer_room_player_left, dropped.name, dropped.id),
-                    "#459FFF"
-                )
-            }
+        // The server caps maxPlayers to the current player count, so this case should only happen if the server
+        // rejected the change and sent back the current maxPlayers value. In that case we don't need to update anything.
+        if (maxPlayers == room.players.size) {
+            return
         }
 
         room.maxPlayers = maxPlayers

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -1,6 +1,7 @@
 package com.osudroid.ui.v2.multi
 
 import com.osudroid.BuildSettings
+import java.util.concurrent.atomic.AtomicBoolean
 import com.osudroid.beatmaplisting.BeatmapDownloader
 import com.osudroid.beatmaplisting.BeatmapListing
 import com.osudroid.multiplayer.Multiplayer
@@ -90,9 +91,14 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
 
     /**
      * Indicates that the player can change its status, its purpose is to await server changes.
+     *
+     * An [AtomicBoolean] is used so that the check-then-set in the touch handler is a single
+     * atomic [AtomicBoolean.compareAndSet] operation, preventing two rapid taps from both
+     * slipping through before either one sets the flag.  It also guarantees cross-thread
+     * visibility: the socket EventThread writes this field (e.g. on disconnect, beatmap change)
+     * while the AndEngine update thread reads it in the touch callback.
      */
-    @JvmField
-    var isWaitingForStatusChange = false
+    val isWaitingForStatusChange = AtomicBoolean(false)
 
     /**
      * Indicates that the player can change its mods, its purpose is to await server changes.
@@ -412,7 +418,7 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
                     isSelected = true
                     onActionUp = callback@{
 
-                        if (isWaitingForStatusChange || !Multiplayer.isRoomHost || Multiplayer.player?.status != PlayerStatus.Ready) {
+                        if (isWaitingForStatusChange.get() || !Multiplayer.isRoomHost || Multiplayer.player?.status != PlayerStatus.Ready) {
                             return@callback
                         }
 
@@ -450,17 +456,18 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
                     setText(R.string.multiplayer_room_not_ready)
                     onActionUp = callback@{
 
-                        if (isWaitingForStatusChange) {
+                        // Atomic guard: only the first tap wins even if two ACTION_UP events
+                        // are delivered before the server reply clears the flag.
+                        if (!isWaitingForStatusChange.compareAndSet(false, true)) {
                             return@callback
                         }
 
                         ResourceManager.getInstance().getSound("menuclick")?.play()
-                        isWaitingForStatusChange = true
 
                         // Guard: if back() nulled player between the isWaitingForStatusChange check
                         // and here, reset the flag and exit instead of crashing.
                         val player = Multiplayer.player ?: run {
-                            isWaitingForStatusChange = false
+                            isWaitingForStatusChange.set(false)
                             return@callback
                         }
 
@@ -469,13 +476,13 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
                             PlayerStatus.NotReady -> {
                                 if (room.beatmap == null) {
                                     ToastLogger.showText(R.string.multiplayer_room_cannot_ready_changing_beatmap, true)
-                                    isWaitingForStatusChange = false
+                                    isWaitingForStatusChange.set(false)
                                     return@callback
                                 }
 
                                 if (room.teamMode == TeamMode.TeamVersus && player.team == null) {
                                     ToastLogger.showText(R.string.multiplayer_room_cannot_ready_no_team, true)
-                                    isWaitingForStatusChange = false
+                                    isWaitingForStatusChange.set(false)
                                     return@callback
                                 }
 
@@ -486,10 +493,10 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
 
                             PlayerStatus.MissingBeatmap -> {
                                 ToastLogger.showText(R.string.multiplayer_room_cannot_ready_missing_beatmap, true)
-                                isWaitingForStatusChange = false
+                                isWaitingForStatusChange.set(false)
                             }
 
-                            else -> isWaitingForStatusChange = false /*This case can never happen, the PLAYING status is set when a game starts*/
+                            else -> isWaitingForStatusChange.set(false) /*This case can never happen, the PLAYING status is set when a game starts*/
                         }
                     }
                     statusButton = this
@@ -700,7 +707,7 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
         // Guard: player is nulled by back(); if we race past the reconnecting check, exit cleanly.
         val player = Multiplayer.player ?: return
 
-        isWaitingForStatusChange = true
+        isWaitingForStatusChange.set(true)
 
         var newStatus = PlayerStatus.NotReady
 
@@ -711,7 +718,7 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
         if (player.status != newStatus) {
             RoomAPI.setPlayerStatus(newStatus)
         } else {
-            isWaitingForStatusChange = false
+            isWaitingForStatusChange.set(false)
         }
     }
 
@@ -840,7 +847,7 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
         if (!byUser) {
             // Setting await locks to avoid player emitting events that will be ignored.
             isWaitingForBeatmapChange = true
-            isWaitingForStatusChange = true
+            isWaitingForStatusChange.set(true)
             isWaitingForModsChange = true
 
             chat.onSystemChatMessage(StringTable.get(R.string.multiplayer_room_reconnecting), "#FFBFBF")
@@ -1014,7 +1021,7 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
         updateThread { updateInformation() }
         updatePlayerList()
 
-        isWaitingForStatusChange = true
+        isWaitingForStatusChange.set(true)
         invalidateStatus()
     }
 
@@ -1242,7 +1249,7 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
 
         val player = Multiplayer.player
         if (player != null && uid == player.id) {
-            isWaitingForStatusChange = false
+            isWaitingForStatusChange.set(false)
         }
 
         updateThread { updateInformation() }

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -986,10 +986,12 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
 
         isWaitingForModsChange = true
 
-        RoomAPI.setPlayerMods(ModMenu.enabledMods.serializeMods())
-
         updateThread {
+            // Apply the new room mods to ModMenu first so that enabledMods is up-to-date
+            // before we serialize and emit to the server.  Serializing before setMods() runs
+            // would send the previous (stale) mods payload to the server.
             ModMenu.setMods(mods, room.gameplaySettings.isFreeMod)
+            RoomAPI.setPlayerMods(ModMenu.enabledMods.serializeMods())
             updateInformation()
         }
     }

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -25,12 +25,6 @@ import com.osudroid.ui.v2.modmenu.ModMenu
 import com.osudroid.utils.async
 import com.osudroid.utils.mainThread
 import com.osudroid.utils.updateThread
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import java.util.concurrent.atomic.AtomicReference
 import com.reco1l.andengine.Anchor
 import com.reco1l.andengine.Axes
 import com.reco1l.andengine.UIEngine
@@ -98,28 +92,6 @@ class RoomScene(
      */
     @JvmField
     var isWaitingForModsChange = false
-
-    /**
-     * [CoroutineScope] used for the beatmap-load timeout job.
-     *
-     * A dedicated [CoroutineScope] is used so that cancelling the [Job] is cheap and cannot interfere with other
-     * coroutines.
-     */
-    private val matchScope = CoroutineScope(Dispatchers.Default)
-
-    /**
-     * Running job that force-starts the game if `allPlayersBeatmapLoadComplete` is not received
-     * within [BEATMAP_LOAD_TIMEOUT_MS] ms after `playBeatmap` was received (EH-2).
-     *
-     * An [AtomicReference] is used because this field is accessed from three different threads:
-     * - socket EventThread  → [startBeatmapLoadTimeout] / [cancelBeatmapLoadTimeout]
-     * - AndEngine update thread → [cancelBeatmapLoadTimeout] (called from [teardownSession])
-     * - [matchScope] coroutine (Dispatchers.Default) → reads and potentially replaces the reference
-     * [AtomicReference] gives a single atomic swap operation (getAndSet/set) with full
-     * visibility guarantees, avoiding the check-then-act race that a plain @Volatile var has.
-     */
-    private val beatmapLoadTimeoutJob = AtomicReference<Job?>(null)
-
 
     /**
      * The room chat.
@@ -743,9 +715,6 @@ class RoomScene(
         RoomAPI.roomEventListener = null
         RoomAPI.playerEventListener = null
 
-        // Cancel any pending beatmap-load timeout so it cannot fire after teardown.
-        cancelBeatmapLoadTimeout()
-
         runSafe { RoomAPI.disconnect() }
 
         Multiplayer.room = null
@@ -791,15 +760,14 @@ class RoomScene(
     override fun onRoomChatMessage(uid: Long?, message: String) {
 
         if (uid != null) {
-
-            // Look up the sender.  If they are not yet in playersMap the most likely cause is
+            // Look up the sender. If they are not yet in playersMap the most likely cause is
             // that chatMessage arrived on the EventThread just before the playerJoined event
-            // that was queued right behind it (EH-3).  Rather than silently discarding the
+            // that was queued right behind it (EH-3). Rather than silently discarding the
             // message, build a temporary stub player so the text is displayed in the chat log.
             // The stub uses "#uid" as its name; once playerJoined fires, any subsequent
             // messages from that player will show their real username.
             val player = room.playersMap[uid] ?: run {
-                Multiplayer.log("WARNING: chatMessage from unknown UID $uid — displaying with stub name (EH-3)")
+                Multiplayer.log("WARNING: chatMessage from unknown UID $uid — displaying with stub name")
                 RoomPlayer(id = uid, name = "#$uid", status = PlayerStatus.NotReady, team = null, mods = RoomMods())
             }
 
@@ -1094,22 +1062,10 @@ class RoomScene(
             }
         }
 
-        // Start a safety timer: if allPlayersBeatmapLoadComplete is never received (e.g. one
-        // client crashes mid-load without a clean disconnect) the match would hang forever for
-        // everyone.  Force-set isReadyToStart after the timeout so the game proceeds regardless
-        // (EH-2).
-        startBeatmapLoadTimeout()
-
         updatePlayerList()
     }
 
     override fun onRoomMatchStart() {
-
-        // allPlayersBeatmapLoadComplete received — the server confirmed all clients are ready.
-        // Cancel the safety timeout so it cannot fire spuriously after the game has already
-        // started (EH-2).
-        cancelBeatmapLoadTimeout()
-
         updateThread {
             if (GlobalManager.getInstance().engine.scene is GameLoaderScene) {
                 GlobalManager.getInstance().gameScene.isReadyToStart = true
@@ -1140,52 +1096,6 @@ class RoomScene(
     override fun onRoomFinalLeaderboard(leaderboard: JSONArray) {
         Multiplayer.onFinalLeaderboard(leaderboard)
     }
-
-
-    // Beatmap-load timeout (EH-2)
-
-    /**
-     * Starts a safety timer that force-starts gameplay if [onRoomMatchStart] is not received
-     * within [BEATMAP_LOAD_TIMEOUT_MS] milliseconds.  This prevents the entire lobby from
-     * hanging indefinitely when one client stops responding mid-load without a clean disconnect.
-     */
-    private fun startBeatmapLoadTimeout() {
-        beatmapLoadTimeoutJob.getAndSet(null)?.cancel()
-
-        beatmapLoadTimeoutJob.set(matchScope.launch {
-            delay(BEATMAP_LOAD_TIMEOUT_MS.milliseconds)
-
-            Multiplayer.log(
-                "WARNING: allPlayersBeatmapLoadComplete not received within " +
-                "${BEATMAP_LOAD_TIMEOUT_MS}ms — force-starting game (EH-2)"
-            )
-
-            updateThread {
-                if (GlobalManager.getInstance().engine.scene is GameLoaderScene) {
-                    GlobalManager.getInstance().gameScene.isReadyToStart = true
-                }
-            }
-        })
-    }
-
-    /**
-     * Cancels the pending beatmap-load timeout, if any.
-     * Call this when [onRoomMatchStart] is received or when the room is torn down.
-     */
-    private fun cancelBeatmapLoadTimeout() {
-        beatmapLoadTimeoutJob.getAndSet(null)?.cancel()
-    }
-
-
-    companion object {
-        /**
-         * How long (ms) to wait for `allPlayersBeatmapLoadComplete` before force-starting the
-         * game.  30 s gives slow devices enough time to finish loading while still providing a
-         * meaningful upper bound on how long other players can be blocked (EH-2).
-         */
-        private const val BEATMAP_LOAD_TIMEOUT_MS = 30_000L
-    }
-
 
     // Player related events
 

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -63,6 +63,7 @@ import com.reco1l.framework.math.Vec4
 import com.reco1l.osu.ui.MessageDialog
 import com.reco1l.toolkt.kotlin.runSafe
 import com.rian.osu.mods.ModScoreV2
+import kotlin.time.Duration.Companion.milliseconds
 import org.json.JSONArray
 import ru.nsu.ccfit.zuev.osu.Config
 import ru.nsu.ccfit.zuev.osu.GlobalManager
@@ -72,18 +73,15 @@ import ru.nsu.ccfit.zuev.osu.ToastLogger
 import ru.nsu.ccfit.zuev.osu.helper.StringTable
 import ru.nsu.ccfit.zuev.osuplus.R
 
-class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListener {
-
+class RoomScene(
     /**
-     * The room this scene is showing. Updated in-place when the socket reconnects so that the
-     * displayed scene keeps receiving events rather than being silently replaced by an off-screen
-     * ghost scene (SI-1).
+     * The [Room] this [RoomScene] is showing. Updated in-place when the socket reconnects so that this [RoomScene] can
+     * be reused and update its current state accordingly.
      */
-    var room: Room = room
-        internal set
-
+    var room: Room
+) : UIScene(), IRoomEventListener, IPlayerEventListener {
     /**
-     * Indicates that the host can change beatmap (it should be false while a change request was done)
+     * Indicates that the host can change beatmap. **This must be `false` when waiting for a beatmap change request**.
      *
      * This is only used if [com.osudroid.multiplayer.Multiplayer.player] is the room host.
      */
@@ -91,26 +89,21 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
     var isWaitingForBeatmapChange = false
 
     /**
-     * Indicates that the player can change its status, its purpose is to await server changes.
-     *
-     * An [AtomicBoolean] is used so that the check-then-set in the touch handler is a single
-     * atomic [AtomicBoolean.compareAndSet] operation, preventing two rapid taps from both
-     * slipping through before either one sets the flag.  It also guarantees cross-thread
-     * visibility: the socket EventThread writes this field (e.g. on disconnect, beatmap change)
-     * while the AndEngine update thread reads it in the touch callback.
+     * Indicates that the player can change its status. Its purpose is to await for server changes.
      */
     val isWaitingForStatusChange = AtomicBoolean(false)
 
     /**
-     * Indicates that the player can change its mods, its purpose is to await server changes.
+     * Indicates that the player can change its mods. Its purpose is to await for server changes.
      */
     @JvmField
     var isWaitingForModsChange = false
 
     /**
-     * Coroutine scope used for the beatmap-load timeout job (EH-2).
-     * A dedicated scope is used so that cancelling the job is cheap and cannot interfere with
-     * other coroutines.
+     * [CoroutineScope] used for the beatmap-load timeout job.
+     *
+     * A dedicated [CoroutineScope] is used so that cancelling the [Job] is cheap and cannot interfere with other
+     * coroutines.
      */
     private val matchScope = CoroutineScope(Dispatchers.Default)
 
@@ -740,17 +733,17 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
      * and the kicked-during-game handler (which must NOT navigate since the game scene must
      * be allowed to finish).
      *
-     * **Must be called on the AndEngine update thread.**
+     * **Must be called on the update thread.**
      */
     private fun teardownSession() {
         Multiplayer.cancelReconnection()
 
         // Null out event listeners before disconnect so any queued socket events that
-        // arrive after teardown find no listener to call (ML-1).
+        // arrive after teardown find no listener to call.
         RoomAPI.roomEventListener = null
         RoomAPI.playerEventListener = null
 
-        // Cancel any pending beatmap-load timeout so it cannot fire after teardown (EH-2).
+        // Cancel any pending beatmap-load timeout so it cannot fire after teardown.
         cancelBeatmapLoadTimeout()
 
         runSafe { RoomAPI.disconnect() }
@@ -1158,12 +1151,15 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
      */
     private fun startBeatmapLoadTimeout() {
         beatmapLoadTimeoutJob.getAndSet(null)?.cancel()
+
         beatmapLoadTimeoutJob.set(matchScope.launch {
-            delay(BEATMAP_LOAD_TIMEOUT_MS)
+            delay(BEATMAP_LOAD_TIMEOUT_MS.milliseconds)
+
             Multiplayer.log(
                 "WARNING: allPlayersBeatmapLoadComplete not received within " +
                 "${BEATMAP_LOAD_TIMEOUT_MS}ms — force-starting game (EH-2)"
             )
+
             updateThread {
                 if (GlobalManager.getInstance().engine.scene is GameLoaderScene) {
                     GlobalManager.getInstance().gameScene.isReadyToStart = true
@@ -1226,7 +1222,7 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
 
             updateThread {
                 if (GlobalManager.getInstance().engine.scene == GlobalManager.getInstance().gameScene.scene) {
-                    // Kicked while a game is in progress.  We cannot navigate away from the
+                    // Kicked while a game is in progress. We cannot navigate away from the
                     // game scene immediately — doing so would abruptly interrupt gameplay.
                     // Instead:
                     //   1. Show the toast so the player knows why they were kicked.
@@ -1236,9 +1232,10 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
                     //      remainder of the game as a solo session — submitFinalScore() will
                     //      not be called, and ScoringScene.back() will return to SongMenu
                     //      rather than trying to re-enter the (now-disconnected) room.
-                    mainThread { ToastLogger.showText(R.string.multiplayer_room_kicked_gameplay, true) }
+                    ToastLogger.showText(R.string.multiplayer_room_kicked_gameplay, true)
                     teardownSession()
                     Multiplayer.isMultiplayer = false
+
                     return@updateThread
                 }
 

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -923,7 +923,11 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
     /**This method is used purely to update UI in other clients*/
     override fun onPlayerModsChange(uid: Long, mods: RoomMods) {
 
-        room.playersMap[uid]!!.mods = mods
+        val target = room.playersMap[uid] ?: run {
+            Multiplayer.log("WARNING: onPlayerModsChange — unknown uid $uid, player may have already left")
+            return
+        }
+        target.mods = mods
 
         updatePlayerList()
 
@@ -1087,7 +1091,11 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
 
     override fun onPlayerStatusChange(uid: Long, status: PlayerStatus) {
 
-        room.playersMap[uid]!!.status = status
+        val target = room.playersMap[uid] ?: run {
+            Multiplayer.log("WARNING: onPlayerStatusChange — unknown uid $uid, player may have already left")
+            return
+        }
+        target.status = status
 
         val player = Multiplayer.player
         if (player != null && uid == player.id) {
@@ -1100,7 +1108,11 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
 
     override fun onPlayerTeamChange(uid: Long, team: RoomTeam?) {
 
-        room.playersMap[uid]!!.team = team
+        val target = room.playersMap[uid] ?: run {
+            Multiplayer.log("WARNING: onPlayerTeamChange — unknown uid $uid, player may have already left")
+            return
+        }
+        target.team = team
 
         updatePlayerList()
         updateInformation()

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -22,6 +22,7 @@ import com.osudroid.ui.v2.GameLoaderScene
 import com.osudroid.ui.v2.ModsIndicator
 import com.osudroid.ui.v2.modmenu.ModMenu
 import com.osudroid.utils.async
+import com.osudroid.utils.mainThread
 import com.osudroid.utils.updateThread
 import com.reco1l.andengine.Anchor
 import com.reco1l.andengine.Axes
@@ -723,7 +724,7 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
     // Communication
 
     override fun onServerError(error: String) {
-        ToastLogger.showText(error, true)
+        mainThread { ToastLogger.showText(error, true) }
     }
 
     override fun onRoomChatMessage(uid: Long?, message: String) {
@@ -799,7 +800,7 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
             return
         }
 
-        back()
+        updateThread { back() }
     }
 
     override fun onRoomConnectFail(error: String?) {
@@ -810,7 +811,7 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
             return
         }
 
-        back()
+        updateThread { back() }
     }
 
 
@@ -818,14 +819,14 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
 
     override fun onRoomNameChange(name: String) {
         room.name = name
-        updateInformation()
+        updateThread { updateInformation() }
     }
 
     override fun onRoomMaxPlayersChange(maxPlayers: Int) {
         room.maxPlayers = maxPlayers
         room.resizePlayers(maxPlayers)
 
-        updateInformation()
+        updateThread { updateInformation() }
         updatePlayerList()
     }
 
@@ -836,30 +837,32 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
         GlobalManager.getInstance().selectedBeatmap = LibraryManager.findBeatmapByMD5(beatmap?.md5)
 
         if (GlobalManager.getInstance().engine.scene != this) {
-            updateBeatmapInfo()
+            updateThread { updateBeatmapInfo() }
             isWaitingForBeatmapChange = false
             return
         }
 
         // Notify to the host when other players can't download the beatmap.
         if (Multiplayer.isRoomHost && beatmap != null && beatmap.parentSetID == null) {
-            ToastLogger.showText(R.string.multiplayer_room_beatmap_unavailable, false)
+            mainThread { ToastLogger.showText(R.string.multiplayer_room_beatmap_unavailable, false) }
         }
 
         invalidateStatus()
-
-        updateBackground(GlobalManager.getInstance().selectedBeatmap?.backgroundPath)
-        updateBeatmap(beatmap)
-
         isWaitingForBeatmapChange = false
 
-        if (GlobalManager.getInstance().selectedBeatmap == null) {
-            GlobalManager.getInstance().songService.stop()
-            return
-        }
+        val selectedBeatmap = GlobalManager.getInstance().selectedBeatmap
+        updateThread {
+            updateBackground(selectedBeatmap?.backgroundPath)
+            updateBeatmap(beatmap)
 
-        GlobalManager.getInstance().songService.preLoad(GlobalManager.getInstance().selectedBeatmap!!.audioPath)
-        GlobalManager.getInstance().songService.play()
+            if (selectedBeatmap == null) {
+                GlobalManager.getInstance().songService.stop()
+                return@updateThread
+            }
+
+            GlobalManager.getInstance().songService.preLoad(selectedBeatmap.audioPath)
+            GlobalManager.getInstance().songService.play()
+        }
     }
 
     override fun onRoomHostChange(uid: Long) {
@@ -872,10 +875,10 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
             ModMenu.back(false)
             ModMenu.updateModButtonVisibility()
             ModMenu.updateCustomizationMenuEnabledStates()
+            updateButtons()
         }
 
         updatePlayerList()
-        updateButtons()
     }
 
 
@@ -889,13 +892,14 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
 
         room.mods = mods
 
-        ModMenu.setMods(mods, room.gameplaySettings.isFreeMod)
-
         isWaitingForModsChange = true
 
         RoomAPI.setPlayerMods(ModMenu.enabledMods.serializeMods())
 
-        updateInformation()
+        updateThread {
+            ModMenu.setMods(mods, room.gameplaySettings.isFreeMod)
+            updateInformation()
+        }
     }
 
     override fun onRoomGameplaySettingsChange(settings: RoomGameplaySettings) {
@@ -903,13 +907,13 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
 
         room.gameplaySettings = settings
 
-        updateButtons()
-        updateInformation()
         updatePlayerList()
 
         isWaitingForModsChange = true
 
         updateThread {
+            updateButtons()
+            updateInformation()
             ModMenu.back(false)
 
             if (wasFreeMod != settings.isFreeMod) {
@@ -934,7 +938,7 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
         val player = Multiplayer.player ?: return
         if (uid == player.id) {
             isWaitingForModsChange = false
-            updateBeatmapInfo()
+            updateThread { updateBeatmapInfo() }
         }
     }
 
@@ -942,7 +946,7 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
 
         room.teamMode = mode
 
-        updateInformation()
+        updateThread { updateInformation() }
         updatePlayerList()
 
         isWaitingForStatusChange = true
@@ -953,7 +957,7 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
 
         room.winCondition = winCondition
 
-        updateInformation()
+        updateThread { updateInformation() }
 
         if (Multiplayer.isRoomHost) {
             isWaitingForModsChange = true
@@ -979,19 +983,21 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
 
     override fun onRoomMatchPlay() {
 
-        val global = GlobalManager.getInstance()
         val player = Multiplayer.player ?: return
 
-        if (player.status != PlayerStatus.MissingBeatmap && global.engine.scene != global.gameScene.scene) {
+        updateThread {
+            val global = GlobalManager.getInstance()
+            if (player.status != PlayerStatus.MissingBeatmap && global.engine.scene != global.gameScene.scene) {
 
-            if (GlobalManager.getInstance().selectedBeatmap == null) {
-                Multiplayer.log("WARNING: Attempt to start match with null track.")
-                return
+                if (global.selectedBeatmap == null) {
+                    Multiplayer.log("WARNING: Attempt to start match with null track.")
+                    return@updateThread
+                }
+
+                global.songMenu.stopMusic()
+                global.gameScene.startGame(global.selectedBeatmap, null, ModMenu.enabledMods)
+
             }
-
-            global.songMenu.stopMusic()
-            global.gameScene.startGame(global.selectedBeatmap, null, ModMenu.enabledMods)
-
         }
 
         updatePlayerList()
@@ -999,8 +1005,10 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
 
     override fun onRoomMatchStart() {
 
-        if (GlobalManager.getInstance().engine.scene is GameLoaderScene) {
-            GlobalManager.getInstance().gameScene.isReadyToStart = true
+        updateThread {
+            if (GlobalManager.getInstance().engine.scene is GameLoaderScene) {
+                GlobalManager.getInstance().gameScene.isReadyToStart = true
+            }
         }
 
         updatePlayerList()
@@ -1008,11 +1016,13 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
 
     override fun onRoomMatchSkip() {
 
-        if (GlobalManager.getInstance().engine.scene != GlobalManager.getInstance().gameScene.scene) {
-            return
-        }
+        updateThread {
+            if (GlobalManager.getInstance().engine.scene != GlobalManager.getInstance().gameScene.scene) {
+                return@updateThread
+            }
 
-        GlobalManager.getInstance().gameScene.skip()
+            GlobalManager.getInstance().gameScene.skip()
+        }
     }
 
 
@@ -1036,7 +1046,7 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
             chat.onSystemChatMessage(StringTable.format(R.string.multiplayer_room_player_joined, player.name, player.id), "#459FFF")
         }
 
-        updateInformation()
+        updateThread { updateInformation() }
         updatePlayerList()
     }
 
@@ -1048,7 +1058,7 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
             chat.onSystemChatMessage(StringTable.format(R.string.multiplayer_room_player_left, player.name, player.id), "#459FFF")
         }
 
-        updateInformation()
+        updateThread { updateInformation() }
         updatePlayerList()
     }
 
@@ -1060,22 +1070,24 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
 
             Multiplayer.log("Kicked from room.")
 
-            if (GlobalManager.getInstance().engine.scene == GlobalManager.getInstance().gameScene.scene) {
-                ToastLogger.showText(R.string.multiplayer_room_kicked_gameplay, true)
-                return
-            }
-
-            back()
-
-            UIMessageDialog().apply dialog@{
-                title = StringTable.get(R.string.multiplayer_room_kicked_title)
-                text = StringTable.get(R.string.multiplayer_room_kicked_message)
-
-                addButton {
-                    setText(R.string.multiplayer_room_kicked_close)
-                    onActionUp = { this@dialog.hide() }
+            updateThread {
+                if (GlobalManager.getInstance().engine.scene == GlobalManager.getInstance().gameScene.scene) {
+                    mainThread { ToastLogger.showText(R.string.multiplayer_room_kicked_gameplay, true) }
+                    return@updateThread
                 }
-            }.show()
+
+                back()
+
+                UIMessageDialog().apply dialog@{
+                    title = StringTable.get(R.string.multiplayer_room_kicked_title)
+                    text = StringTable.get(R.string.multiplayer_room_kicked_message)
+
+                    addButton {
+                        setText(R.string.multiplayer_room_kicked_close)
+                        onActionUp = { this@dialog.hide() }
+                    }
+                }.show()
+            }
             return
         }
 
@@ -1085,7 +1097,7 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
             chat.onSystemChatMessage(StringTable.format(R.string.multiplayer_room_player_kicked, removedPlayer.name, removedPlayer.id), "#FFBFBF")
         }
 
-        updateInformation()
+        updateThread { updateInformation() }
         updatePlayerList()
     }
 
@@ -1102,7 +1114,7 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
             isWaitingForStatusChange = false
         }
 
-        updateInformation()
+        updateThread { updateInformation() }
         updatePlayerList()
     }
 
@@ -1115,7 +1127,7 @@ class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventLis
         target.team = team
 
         updatePlayerList()
-        updateInformation()
+        updateThread { updateInformation() }
     }
 
 }

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -65,7 +65,15 @@ import ru.nsu.ccfit.zuev.osu.ToastLogger
 import ru.nsu.ccfit.zuev.osu.helper.StringTable
 import ru.nsu.ccfit.zuev.osuplus.R
 
-class RoomScene(val room: Room) : UIScene(), IRoomEventListener, IPlayerEventListener {
+class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListener {
+
+    /**
+     * The room this scene is showing. Updated in-place when the socket reconnects so that the
+     * displayed scene keeps receiving events rather than being silently replaced by an off-screen
+     * ghost scene (SI-1).
+     */
+    var room: Room = room
+        internal set
 
     /**
      * Indicates that the host can change beatmap (it should be false while a change request was done)

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -857,9 +857,9 @@ class RoomScene(
     }
 
     override fun onRoomMaxPlayersChange(maxPlayers: Int) {
-        // The server caps maxPlayers to the current player count, so this case should only happen if the server
-        // rejected the change and sent back the current maxPlayers value. In that case we don't need to update anything.
-        if (maxPlayers == room.players.size) {
+        // The server caps maxPlayers to the current amount of players in the lobby.
+        // If the server sends back the current maxPlayers value, we don't need to update anything.
+        if (maxPlayers == room.maxPlayers) {
             return
         }
 

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -718,7 +718,9 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
     // Navigation
 
     override fun back() {
-        Multiplayer.isReconnecting = false
+        // Cancel the reconnection scope/job before setting isReconnecting = false so the
+        // coroutine's loop exits and the scope is cleaned up (ML-2).
+        Multiplayer.cancelReconnection()
 
         // Null out event listeners before disconnect so any queued socket events that
         // arrive after teardown find no listener to call (ML-1).

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -951,7 +951,7 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
 
     override fun onRoomModsChange(mods: RoomMods) {
 
-        if (mods != room.mods) {
+        if (!mods.equalsWithContext(room.mods, room.gameplaySettings.isFreeMod)) {
             invalidateStatus()
         }
 

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicReference
 import com.reco1l.andengine.Anchor
 import com.reco1l.andengine.Axes
 import com.reco1l.andengine.UIEngine
@@ -117,14 +118,14 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
      * Running job that force-starts the game if `allPlayersBeatmapLoadComplete` is not received
      * within [BEATMAP_LOAD_TIMEOUT_MS] ms after `playBeatmap` was received (EH-2).
      *
-     * `@Volatile` is required because this field is written from three different threads:
+     * An [AtomicReference] is used because this field is accessed from three different threads:
      * - socket EventThread  → [startBeatmapLoadTimeout] / [cancelBeatmapLoadTimeout]
-     * - AndEngine update thread → [cancelBeatmapLoadTimeout] (called from [back])
-     * - [matchScope] coroutine (Dispatchers.Default) → set to `null` after the delay fires
-     * Without `@Volatile` the JVM memory model gives no visibility guarantee across threads.
+     * - AndEngine update thread → [cancelBeatmapLoadTimeout] (called from [teardownSession])
+     * - [matchScope] coroutine (Dispatchers.Default) → reads and potentially replaces the reference
+     * [AtomicReference] gives a single atomic swap operation (getAndSet/set) with full
+     * visibility guarantees, avoiding the check-then-act race that a plain @Volatile var has.
      */
-    @Volatile
-    private var beatmapLoadTimeoutJob: Job? = null
+    private val beatmapLoadTimeoutJob = AtomicReference<Job?>(null)
 
 
     /**
@@ -1158,8 +1159,8 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
      * hanging indefinitely when one client stops responding mid-load without a clean disconnect.
      */
     private fun startBeatmapLoadTimeout() {
-        beatmapLoadTimeoutJob?.cancel()
-        beatmapLoadTimeoutJob = matchScope.launch {
+        beatmapLoadTimeoutJob.getAndSet(null)?.cancel()
+        beatmapLoadTimeoutJob.set(matchScope.launch {
             delay(BEATMAP_LOAD_TIMEOUT_MS)
             Multiplayer.log(
                 "WARNING: allPlayersBeatmapLoadComplete not received within " +
@@ -1170,8 +1171,7 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
                     GlobalManager.getInstance().gameScene.isReadyToStart = true
                 }
             }
-            beatmapLoadTimeoutJob = null
-        }
+        })
     }
 
     /**
@@ -1179,8 +1179,7 @@ class RoomScene(room: Room) : UIScene(), IRoomEventListener, IPlayerEventListene
      * Call this when [onRoomMatchStart] is received or when the room is torn down.
      */
     private fun cancelBeatmapLoadTimeout() {
-        beatmapLoadTimeoutJob?.cancel()
-        beatmapLoadTimeoutJob = null
+        beatmapLoadTimeoutJob.getAndSet(null)?.cancel()
     }
 
 

--- a/src/ru/nsu/ccfit/zuev/osu/DifficultyAlgorithm.java
+++ b/src/ru/nsu/ccfit/zuev/osu/DifficultyAlgorithm.java
@@ -1,5 +1,7 @@
 package ru.nsu.ccfit.zuev.osu;
 
+import com.rian.osu.GameMode;
+
 /**
  * Represents the algorithm used to calculate the difficulty of a beatmap.
  */
@@ -22,5 +24,15 @@ public enum DifficultyAlgorithm {
      */
     public static DifficultyAlgorithm parse(int value) {
         return value == 1 ? standard : droid;
+    }
+
+    /**
+     * Converts this {@link DifficultyAlgorithm} to its {@link GameMode} equivalent.
+     */
+    public GameMode toGameMode() {
+        return switch (this) {
+            case droid -> GameMode.Droid;
+            case standard -> GameMode.Standard;
+        };
     }
 }

--- a/src/ru/nsu/ccfit/zuev/osu/LibraryManager.java
+++ b/src/ru/nsu/ccfit/zuev/osu/LibraryManager.java
@@ -145,7 +145,7 @@ public class LibraryManager {
 
         for (var osuFile : osuFiles) {
             try {
-                var data = new BeatmapParser(osuFile).parse(true);
+                var data = new BeatmapParser(osuFile).parse(false);
                 var beatmapInfo = BeatmapInfo(data, directory.lastModified(), false);
 
                 if (data.getEvents().videoFilename != null && Config.isDeleteUnsupportedVideos()) {

--- a/src/ru/nsu/ccfit/zuev/osu/LibraryManager.java
+++ b/src/ru/nsu/ccfit/zuev/osu/LibraryManager.java
@@ -145,7 +145,7 @@ public class LibraryManager {
 
         for (var osuFile : osuFiles) {
             try {
-                var data = new BeatmapParser(osuFile).parse(false);
+                var data = new BeatmapParser(osuFile).parse(true);
                 var beatmapInfo = BeatmapInfo(data, directory.lastModified(), false);
 
                 if (data.getEvents().videoFilename != null && Config.isDeleteUnsupportedVideos()) {

--- a/src/ru/nsu/ccfit/zuev/osu/menu/SongMenu.java
+++ b/src/ru/nsu/ccfit/zuev/osu/menu/SongMenu.java
@@ -1304,7 +1304,7 @@ public class SongMenu implements IUpdateHandler, MenuItemListener,
         }
 
         // Locking host from change beatmap before the server responses to beatmapChange
-        Multiplayer.roomScene.isWaitingForBeatmapChange = true;
+        Multiplayer.roomScene.isWaitingForBeatmapChange.set(true);
 
         if (!Multiplayer.isConnected()) {
             return;
@@ -1332,7 +1332,7 @@ public class SongMenu implements IUpdateHandler, MenuItemListener,
         }
 
         // Locking host from change beatmap before the server responses to beatmapChange
-        Multiplayer.roomScene.isWaitingForBeatmapChange = true;
+        Multiplayer.roomScene.isWaitingForBeatmapChange.set(true);
 
         if (!Multiplayer.isConnected()) {
             return;


### PR DESCRIPTION
This PR is a bunch of fixes and optimizations for multiplayer.

## Thread Safety / Race Conditions

### Reconnection state variables are not `@Volatile` (https://github.com/osudroid/osu-droid/pull/624/commits/bb9759cdd00c0282fa88258358ab8ac891da8b20)

https://github.com/osudroid/osu-droid/blob/f7070960326169a2a37121619424d5414f8f4370/src/com/osudroid/multiplayer/Multiplayer.kt#L83-L89

These are written from socket.io's EventThread (`onReconnectAttempt()`) and read from the `reconnectionScope` coroutine (`Dispatchers.Default`). None of them are `@Volatile` or guarded by a lock. The JVM memory model does not guarantee visibility of plain `var` writes across threads. This means the reconnection loop can spin indefinitely on a stale `isReconnecting = false` that was written on another thread.

`isMultiplayer` and `isReconnecting` in the `Multiplayer` singleton carry the same problem. It is written by the socket.io thread, read by UI/update threads.

### `RoomAPI.socket` field is unsynchronized across threads (https://github.com/osudroid/osu-droid/pull/624/commits/5ce997f08d1b93c9eee209adf4bdf2562c908d6f)

- `socket` is assigned in `RoomAPI.connectToRoom()` (called from a coroutine on `Dispatchers.Default`).
- It is read and called by socket.io's EventThread callbacks.
- It is nulled in the `connectError` listener (EventThread) and in `disconnect()` (potentially called from any thread).

A disconnect event arriving while `connectToRoom()` is mid-execution can leave `socket` in an inconsistent state. The old socket's `off()` may run after the new socket is already assigned.

### `Room.players` array mutated from multiple threads without synchronization (https://github.com/osudroid/osu-droid/pull/624/commits/84b37731c4d0802cc10e108ce109eafd36ccb55a)

`addPlayer()`, `removePlayer()`, and `sortPlayers()` all write to `players`, but these are called from socket event callbacks (EventThread). `updatePlayerList()` in `RoomScene` reads `room.activePlayers` (which iterates the same array) from the update thread. There is no `synchronized` block or other guard anywhere. A sorted array write racing alongside a list read will corrupt the player card layout silently.

### Reconnection coroutine is a CPU-burning busy-wait (https://github.com/osudroid/osu-droid/pull/624/commits/d6bba7cbcbdc91b43f01d6eafd6b3fcfd048833a)

In `Multiplayer.onReconnect`, there is no `delay()` or `Thread.sleep()` in the loop body. When the 5-second timer hasn't elapsed or `isWaitingAttemptResponse` is true, the loop continues immediately, spinning at 100% CPU on a `Dispatchers.Default` thread pool thread for up to 30 seconds.

### `Room.playersMap` allocates a new `HashMap` on every access (https://github.com/osudroid/osu-droid/pull/624/commits/eef1f6ebe464f6c4ca051aba8f7bfc983aa5d45c)

Called in `onPlayerStatusChange()`, `onRoomChatMessage()`, `onPlayerModsChange()`, `onPlayerTeamChange()`, `onPlayerKick()`, etc. Each call allocates a new `HashMap`. On fast paths like live-score events or frequent status changes this is wasteful, and it accumulates GC pressure during gameplay.

## Null Pointer / Unsafe Force-Unwrap

### `Multiplayer.player!!` used in event handlers without disconnect guard (https://github.com/osudroid/osu-droid/pull/624/commits/a94616e1a1ff6511f5dfc2a31acd8d536f70e24a)

Every event handler that references `Multiplayer.player!!` will throw `NullPointerException` if called after `back()` sets `Multiplayer.player = null` while a queued socket event is still in flight. Because socket.io delivers events asynchronously, a `playerStatusChanged` event can arrive a few milliseconds after the scene has begun tearing down.

### `socket!!.emit()` force-unwrap in three emitter methods (https://github.com/osudroid/osu-droid/commit/5ce997f08d1b93c9eee209adf4bdf2562c908d6f)

All other emitters use `socket?.emit(...) ?: run { log(...); return }`. These three are inconsistently force-unwrapped. If called after an unexpected disconnect (e.g., the socket drops exactly while the beatmap is loading), the app crashes. `notifyBeatmapLoaded()` is particularly risky since it is called mid-game from a loading callback where a disconnect is plausible.

### Local player identity assumed present in `initialConnection` (https://github.com/osudroid/osu-droid/pull/624/changes/1727939237bd8d9468f142d090be2277cf2b62ef)

https://github.com/osudroid/osu-droid/blob/f7070960326169a2a37121619424d5414f8f4370/src/com/osudroid/multiplayer/api/RoomAPI.kt#L216

If the server's player list is malformed or does not include the connecting client's UID, this throws `NullPointerException` and the entire `initialConnection` handler aborts. The socket listeners registered just above remain attached to a `socket` whose owning objects are now in an undefined state. There is no `catch` block.

### Force-cast of raw socket event data without type guard (https://github.com/osudroid/osu-droid/pull/624/changes/1727939237bd8d9468f142d090be2277cf2b62ef)

Throughout all `Listener` uses, there are inconsistent use of safe (`as?`) vs. hard (`as`) casts. If the server sends an unexpected type or the API version drifts, `ClassCastException` will be uncaught and silently propagate up the stack without disconnecting the user.

### `room.playersMap[uid]!!` in player event handlers (https://github.com/osudroid/osu-droid/pull/624/changes/6ca8fea638be394fd2c03184d9f478f963192c8d)

If `playerLeft` and `onPlayerModsChange`, `onPlayerStatusChange`, or `onPlayerTeamChange` arrive for the same UID in rapid succession (possible due to queuing on the EventThread), the player may no longer be in the room when the second event is processed, causing a crash.

## UI Thread Safety

### Most `onRoom*` and `onPlayer*` handlers run on the socket EventThread (https://github.com/osudroid/osu-droid/pull/624/commits/94a843e32cb11b402fadec28b1d8ae031a1c19aa)

Socket.io delivers all events on its own `EventThread`. The `RoomAPI` listeners forward directly to `RoomScene`. Inside `RoomScene`, only `updatePlayerList()` dispatches to the update thread. All other UI mutations run on the EventThread:

| Handler | Unsafe UI mutations |
|---------|---------------------|
| `onRoomBeatmapChange()` | `updateBeatmap()`, `updateBackground()`, beatmap info view visibility changes |
| `onRoomHostChange()` | `updateButtons()`, `ModMenu.back()`, `ModMenu.updateModButtonVisibility()` |
| `onRoomNameChange()` | `nameText.text = name` inside `updateInformation()` |
| `onRoomModsChange()` | `ModMenu.setMods()`, `modsIndicator.mods = ...` |
| `onRoomMatchPlay()` | `global.gameScene.startGame(...)` |
| `onServerError()` | `ToastLogger.showText()` |
| `onPlayerJoin/Left/Kick()` | `chat.onSystemChatMessage(...)` — only chat uses `mainThread {}` |

AndEngine's scene graph is not thread-safe; modifying it outside the update thread can cause rendering corruption or crashes.

### `onRoomBeatmapChange()` calls `songService.preLoad()` / `.play()` on EventThread

https://github.com/osudroid/osu-droid/blob/f7070960326169a2a37121619424d5414f8f4370/src/com/osudroid/ui/v2/multi/RoomScene.kt#L846-L847

Android's `MediaPlayer` API requires calls from a consistent thread (typically the thread that created it or the main thread). Calling these from the socket EventThread risks `IllegalStateException` inside the media player.

### `LobbyScene.fetchRooms()` mutates UI components from a background coroutine (https://github.com/osudroid/osu-droid/pull/624/commits/5fb6d8d49b6023281c0949a820730b1c68a0d963)

https://github.com/osudroid/osu-droid/blob/f7070960326169a2a37121619424d5414f8f4370/src/com/osudroid/ui/v2/multi/LobbyScene.kt#L235-L246

The pre-fetch UI setup (loading spinner, container switch) does not run in the update thread unlike the post-fetch UI update.

## State Inconsistencies

### Reconnection creates a new `RoomScene` that is never shown but replaces `Multiplayer.roomScene` (https://github.com/osudroid/osu-droid/pull/624/commits/b87a75f558fb2fb0062d92bd3b3e03a41f1790e6)

Every `initialConnection` event unconditionally creates a new `RoomScene(room)`. During reconnection, this new scene's constructor immediately registers itself as `RoomAPI.roomEventListener` and `RoomAPI.playerEventListener`, replacing the old, displayed scene. The flow then:

1. Sets `Multiplayer.roomScene = newScene` (the one **not** on screen).
2. Calls `newScene.onRoomConnect(newRoom)`.
3. Because `isReconnecting == true`, `show()` is **not** called on the new scene.
4. The old scene remains on screen with:
   - A stale `room` object reference (`val room: Room`).
   - No longer being the registered event listener.
   - The chat still attached to the overlay.

Subsequent events go to the new (off-screen) scene. The displayed scene becomes a dead UI shell that can never receive further updates. The reconnection toast "Connection was successfully restored" goes to the new scene's `chat`, which is not in the overlay.

### `RoomScene.onRoomMaxPlayersChange()` silently drops players when max size decreases (https://github.com/osudroid/osu-droid/pull/624/changes/b3301b3edb4a33af081466a3b4ef1cce3332647c)

https://github.com/osudroid/osu-droid/blob/f7070960326169a2a37121619424d5414f8f4370/src/com/osudroid/ui/v2/multi/RoomScene.kt#L809-L815

`copyOf(maxPlayers)` truncates the array if `maxPlayers < room.players.size`. Players in the discarded slots are silently removed from local state without firing `playerLeft` events, leaving no audit trail in the chat, and potentially leaving server-side data inconsistent if those players later submit scores.

### `Room.playersMap` keys and `Room.players` array indices diverge after `sortPlayers()` (https://github.com/osudroid/osu-droid/pull/624/commits/452715e774a917b3d705e6ddf4950258a5f2793c)

https://github.com/osudroid/osu-droid/blob/f7070960326169a2a37121619424d5414f8f4370/src/com/osudroid/multiplayer/api/data/Room.kt#L181-L183

`sortPlayers()` is called on every `addPlayer()`, `removePlayer()`, and `host` assignment. The server protocol may use fixed slot indices (implied by `parsePlayers(array, size)` which assigns by index). After sorting, local slot indices no longer match the server's, potentially causing wrong player slots to be displayed or future index-based operations to fail.

### `RoomScene.onRoomConnect()` during reconnection causes `invalidateStatus()` to emit twice (https://github.com/osudroid/osu-droid/pull/624/commits/1a0071d556dafea57ae0c30b02db72689a5a69d3)

During reconnection, `onRoomBeatmapChange()` → `invalidateStatus()` → `RoomAPI.setPlayerStatus(newStatus)` emits to the server. But `invalidateStatus()` is also called from `show()` (line 704), so when `show()` is eventually called on the same reconnection path, `setPlayerStatus` may be emitted twice for the same status transition.

## Missing Error Handling / Unhandled Edge Cases

### Enum ordinal accessors throw `ArrayIndexOutOfBoundsException` on unknown server values (https://github.com/osudroid/osu-droid/pull/624/changes/58d5773103f903054329e06da7a74af900e71145)

If the server adds a new status value or sends a malformed integer, this throws `ArrayIndexOutOfBoundsException` inside a `Listener` lambda. Socket.io swallows uncaught exceptions in callbacks, silently breaking state.

### No timeout for `allPlayersBeatmapLoadComplete` (https://github.com/osudroid/osu-droid/pull/624/changes/02c53026e4c6622b75aa1f55522706a3fb89781b)

After `playBeatmap` is received, every client calls `notifyBeatmapLoaded()`. The server waits for all clients before sending `allPlayersBeatmapLoadComplete`. If one client crashes, goes offline, or has a very slow load **without** triggering a clean disconnect, the match hangs for all other players indefinitely. There is no client-side timeout to give up waiting and force-start.

### Chat message from unknown UID is silently dropped (https://github.com/osudroid/osu-droid/pull/624/changes/c20de87e78f105226fd85c37333276aa124570fe)

https://github.com/osudroid/osu-droid/blob/f7070960326169a2a37121619424d5414f8f4370/src/com/osudroid/ui/v2/multi/RoomScene.kt#L719-L723

If `chatMessage` arrives slightly before `playerJoined` (e.g., both queued back-to-back on the EventThread but the chat message is first), the message is silently discarded with no retry or buffering.

### `parsePlayers()` silently ignores players beyond declared `size` (https://github.com/osudroid/osu-droid/pull/624/changes/5a2bb9eb29fbbd7f375c987d91c14d8c2f8c95fb)

https://github.com/osudroid/osu-droid/blob/f7070960326169a2a37121619424d5414f8f4370/src/com/osudroid/multiplayer/api/data/Parsing.kt#L21-L23

If `array.length() > size` (server bug or API mismatch), excess players are silently discarded. If `array.length() < size`, `optJSONObject(i)` returns `null` for missing indices, silently creating empty slots and masking a potential server-side bug.

### `MissingBeatmap` player status can block an entire match (https://github.com/osudroid/osu-droid/pull/624/changes/9b04b311eedd292a9befdc1099a3d4dc370a700d)

A player with `MissingBeatmap` status skips `startGame()` and never calls `notifyBeatmapLoaded()`. However, the server still waits for all players before sending `allPlayersBeatmapLoadComplete`. If such a player passes the "start game" guard (which only checks that 2+ players have the beatmap), one missing-beatmap client blocks the match for everyone.

### Kicked-during-game player leaves an orphaned game session (https://github.com/osudroid/osu-droid/pull/624/changes/57573093fe90986e9f775db5a34afe1369e133b6)

When the local player is kicked during gameplay, only a toast is shown and the game continues. No cleanup is done: `Multiplayer.isMultiplayer` remains `true`, live-score events continue to fire, and `submitFinalScore()` will still be called at the end. The kicked player's score will likely be rejected by the server since their session is invalid, but the client does not handle this gracefully.

## Memory Leaks / Stale Listeners

### `RoomAPI` event listeners never explicitly cleared in `back()` (https://github.com/osudroid/osu-droid/pull/624/changes/709de4e76cffde8a32c316b915d348bb5d9cf7fd)

`back()` does not null out `RoomAPI.roomEventListener` or `RoomAPI.playerEventListener`. After `back()`:
1. `RoomAPI.disconnect()` is called, which calls `socket?.off()` and nulls the socket.
2. But if `disconnect()` is still in-flight or a queued event fires after `Multiplayer.player` is set to `null`, the listener (the old `RoomScene`) is called with methods that dereference `Multiplayer.player!!`.

### `reconnectionScope` CoroutineScope is never cancelled (https://github.com/osudroid/osu-droid/pull/624/changes/3248a4bd0a1d546395a7d99c9de017c6c78cc143)

https://github.com/osudroid/osu-droid/blob/f7070960326169a2a37121619424d5414f8f4370/src/com/osudroid/multiplayer/Multiplayer.kt#L80

This scope lives on the `Multiplayer` singleton (`object`, effectively static) and is never cancelled. If `onReconnect()` is called while a previous coroutine is still running (the `isReconnecting` check guards against double-call, but only if the first coroutine has advanced past the `isReconnecting = true` assignment), a second coroutine could launch. On process reuse across multiple play sessions, stale coroutines could accumulate.

### `RoomChat` cleanup relies on a fragile `init` block workaround (https://github.com/osudroid/osu-droid/pull/624/changes/a8ce5a05644635dd3e3ad9c6c8bb433d083e6285)

https://github.com/osudroid/osu-droid/blob/f7070960326169a2a37121619424d5414f8f4370/src/com/osudroid/ui/v2/multi/RoomChat.kt#L77-79

This is a workaround for the stale-scene reconnection bug. The correct fix is to not create a new `RoomScene` on reconnection. If the overlay reference changes or the chat object is created before the overlay is initialized, the cleanup silently fails and multiple `RoomChat` instances will remain attached.

## Design Concerns

### `RoomMods.equals()` reads global mutable state (https://github.com/osudroid/osu-droid/pull/624/commits/fec3a3714e4692edc500eab9f33c07a54f23bb0c)

https://github.com/osudroid/osu-droid/blob/f7070960326169a2a37121619424d5414f8f4370/src/com/osudroid/multiplayer/api/data/RoomMods.kt#L22-L29

`equals()` is a pure function by contract. Accessing global mutable state inside it makes it non-deterministic and context-dependent. If `Multiplayer.room` is null or is being updated concurrently, `equals()` returns a different result for the same pair of objects depending on when it is called. This is used in `onRoomModsChange()`'s `if (mods != room.mods)` to decide whether to call `invalidateStatus()`.

### Two competing exit paths in reconnection both call `back()` (https://github.com/osudroid/osu-droid/pull/624/changes/9d8f8696e94ce0ba599daa32ae820209e4754934)

- Path A: `reconnectionStartTimeMS >= 30000` → toast + `roomScene?.back()`
- Path B: `onReconnectAttempt(false)` when `attemptCount >= 5` → toast + `roomScene?.back()`

If Path B fires at attempt 5 (≈ 25 s) it sets `isReconnecting = false` and the coroutine exits. But if Path A fires at 30 s **and** Path B already fired, `back()` is called a second time, potentially navigating away from an already-clean state.

### Status button has no atomic guard against double-tap (https://github.com/osudroid/osu-droid/pull/624/changes/e1a6657a138c2614c5e122c4830b9d9708f230ba)

https://github.com/osudroid/osu-droid/blob/f7070960326169a2a37121619424d5414f8f4370/src/com/osudroid/ui/v2/multi/RoomScene.kt#L433

`isWaitingForStatusChange` is set to `true` after `setPlayerStatus()` emits. But there is no atomic compare-and-set. If the user taps the button twice very quickly before the first tap sets the flag (two UI touch events arriving in the same frame), two `playerStatusChanged` emissions are sent to the server.

### Host change with unknown UID shows literal `"null"` in chat (https://github.com/osudroid/osu-droid/pull/624/changes/9b80d8310e31b23be2ad72fe0896f44bf2c5a887)

https://github.com/osudroid/osu-droid/blob/f7070960326169a2a37121619424d5414f8f4370/src/com/osudroid/ui/v2/multi/RoomScene.kt#L850-L854

`room.playersMap[uid]?.name.toString()` — if `uid` is not in `playersMap`, this produces the string `"null"` in the chat message. Additionally, `room.host = uid` calls `sortPlayers()` which may reorder the array at a moment when another thread is iterating it.