### PR TITLE
Add profile banner to player card in multiplayer

### DIFF
--- a/src/com/osudroid/ui/v2/multi/RoomPlayerCard.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomPlayerCard.kt
@@ -116,8 +116,6 @@ class RoomPlayerCard : UILinearContainer() {
             spacing = 6f
 
             bannerSprite = UIShapedSprite().apply {
-                isVisible = false
-
                 shape = object : UIBox() {
                     init {
                         cornerRadius = 12f
@@ -179,7 +177,6 @@ class RoomPlayerCard : UILinearContainer() {
 
             bannerJob?.cancel()
             bannerSprite.textureRegion = null
-            bannerSprite.isVisible = false
 
             val resourceManager = ResourceManager.getInstance()
             val bannerUrl = OnlineManager.getProfileBannerURL(player.id)
@@ -187,7 +184,6 @@ class RoomPlayerCard : UILinearContainer() {
 
             if (loadedTexture != null) {
                 bannerSprite.textureRegion = loadedTexture
-                bannerSprite.isVisible = true
                 background = bannerSprite
             } else {
                 bannerJob = async {
@@ -197,7 +193,6 @@ class RoomPlayerCard : UILinearContainer() {
 
                         updateThread {
                             bannerSprite.textureRegion = texture
-                            bannerSprite.isVisible = texture != null
                             background = if (texture != null) bannerSprite else defaultBackground
                         }
                     }

--- a/src/com/osudroid/ui/v2/multi/RoomPlayerCard.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomPlayerCard.kt
@@ -9,11 +9,15 @@ import com.osudroid.multiplayer.api.data.RoomTeam.Blue
 import com.osudroid.multiplayer.api.data.RoomTeam.Red
 import com.osudroid.ui.OsuColors
 import com.osudroid.ui.v2.*
+import com.osudroid.utils.async
+import com.osudroid.utils.updateThread
 import com.reco1l.andengine.*
 import com.reco1l.andengine.component.*
 import com.reco1l.andengine.container.*
 import com.reco1l.andengine.shape.*
 import com.reco1l.andengine.sprite.UISprite
+import com.reco1l.andengine.sprite.ScaleType
+import com.reco1l.andengine.sprite.UIShapedSprite
 import com.reco1l.andengine.text.CompoundText
 import com.reco1l.andengine.text.FontAwesomeIcon
 import com.reco1l.andengine.text.UIText
@@ -21,9 +25,13 @@ import com.reco1l.andengine.theme.Icon
 import com.reco1l.andengine.ui.*
 import com.reco1l.framework.*
 import com.reco1l.framework.math.*
+import javax.microedition.khronos.opengles.GL10
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.ensureActive
 import ru.nsu.ccfit.zuev.osu.Config
 import ru.nsu.ccfit.zuev.osu.ResourceManager
 import ru.nsu.ccfit.zuev.osu.helper.StringTable
+import ru.nsu.ccfit.zuev.osu.online.OnlineManager
 import ru.nsu.ccfit.zuev.osuplus.R
 
 class RoomPlayerCard : UILinearContainer() {
@@ -73,6 +81,15 @@ class RoomPlayerCard : UILinearContainer() {
         private val innerContainer: UILinearContainer
         private var modDisplay: UIComponent? = null
 
+        private val bannerSprite: UIShapedSprite
+        private var bannerJob: Job? = null
+
+        private val defaultBackground = UIBox().apply {
+            cornerRadius = 12f
+            color = Theme.current.accentColor * 0.15f
+            alpha = 0.5f
+        }
+
         private val hostIcon = FontAwesomeIcon(Icon.Crown).apply {
             applyTheme = { color = it.accentColor }
         }
@@ -92,11 +109,26 @@ class RoomPlayerCard : UILinearContainer() {
             orientation = Orientation.Horizontal
             spacing = 6f
 
-            background = UIBox().apply {
-                cornerRadius = 12f
-                color = Theme.current.accentColor * 0.15f
-                alpha = 0.5f
+            bannerSprite = UIShapedSprite().apply {
+                isVisible = false
+
+                shape = object : UIBox() {
+                    init {
+                        cornerRadius = 12f
+                        color = Color4.Transparent
+                    }
+
+                    override fun beginDraw(gl: GL10) {
+                        gl.glDepthMask(true)
+                        super.beginDraw(gl)
+                    }
+                }
+
+                scaleType = ScaleType.Crop
+                setColor(0.25f, 0.25f, 0.25f)
             }
+
+            background = defaultBackground
 
             foreground = UIBox().apply {
                 cornerRadius = 12f
@@ -127,11 +159,43 @@ class RoomPlayerCard : UILinearContainer() {
         }
 
 
+        override fun onDetached() {
+            super.onDetached()
+            bannerJob?.cancel()
+        }
+
         fun updateState(room: Room, player: RoomPlayer) {
             foreground!!.color = when (player.status) {
                 Playing -> Theme.current.accentColor
                 Ready -> Color4("#A0FFA0")
                 NotReady, MissingBeatmap -> Color4("#FFA0A0")
+            }
+
+            bannerJob?.cancel()
+            bannerSprite.textureRegion = null
+            bannerSprite.isVisible = false
+
+            val resourceManager = ResourceManager.getInstance()
+            val bannerUrl = OnlineManager.getProfileBannerURL(player.id)
+            val loadedTexture = resourceManager.getProfileBannerTextureIfLoaded(bannerUrl)
+
+            if (loadedTexture != null) {
+                bannerSprite.textureRegion = loadedTexture
+                bannerSprite.isVisible = true
+                background = bannerSprite
+            } else {
+                bannerJob = async {
+                    if (OnlineManager.getInstance().loadProfileBannerToTextureManager(bannerUrl)) {
+                        ensureActive()
+                        val texture = resourceManager.getProfileBannerTextureIfLoaded(bannerUrl)
+
+                        updateThread {
+                            bannerSprite.textureRegion = texture
+                            bannerSprite.isVisible = texture != null
+                            background = if (texture != null) bannerSprite else defaultBackground
+                        }
+                    }
+                }
             }
 
             nameText.text = player.name

--- a/src/com/osudroid/ui/v2/multi/RoomPlayerCard.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomPlayerCard.kt
@@ -73,6 +73,10 @@ class RoomPlayerCard : UILinearContainer() {
         }
     }
 
+    fun cancelBannerJob() {
+        playerButton.bannerJob?.cancel()
+    }
+
     private class RoomPlayerButton : UIButton() {
 
         private lateinit var nameText: CompoundText
@@ -82,7 +86,9 @@ class RoomPlayerCard : UILinearContainer() {
         private var modDisplay: UIComponent? = null
 
         private val bannerSprite: UIShapedSprite
-        private var bannerJob: Job? = null
+
+        var bannerJob: Job? = null
+            private set
 
         private val defaultBackground = UIBox().apply {
             cornerRadius = 12f

--- a/src/com/osudroid/ui/v2/multi/RoomPlayerCard.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomPlayerCard.kt
@@ -96,6 +96,8 @@ class RoomPlayerCard : UILinearContainer() {
             alpha = 0.5f
         }
 
+        private var lastPlayerId = -1L
+
         private val hostIcon = FontAwesomeIcon(Icon.Crown).apply {
             applyTheme = { color = it.accentColor }
         }
@@ -175,25 +177,46 @@ class RoomPlayerCard : UILinearContainer() {
                 NotReady, MissingBeatmap -> Color4("#FFA0A0")
             }
 
-            bannerJob?.cancel()
-            bannerSprite.textureRegion = null
+            if (lastPlayerId != player.id) {
+                lastPlayerId = player.id
+                val bannerUrl = OnlineManager.getProfileBannerURL(player.id)
 
-            val resourceManager = ResourceManager.getInstance()
-            val bannerUrl = OnlineManager.getProfileBannerURL(player.id)
-            val loadedTexture = resourceManager.getProfileBannerTextureIfLoaded(bannerUrl)
+                bannerJob?.cancel()
+                bannerJob = null
 
-            if (loadedTexture != null) {
-                bannerSprite.textureRegion = loadedTexture
-                background = bannerSprite
-            } else {
-                bannerJob = async {
-                    if (OnlineManager.getInstance().loadProfileBannerToTextureManager(bannerUrl)) {
+                val resourceManager = ResourceManager.getInstance()
+                val loadedTexture = resourceManager.getProfileBannerTextureIfLoaded(bannerUrl)
+
+                if (loadedTexture != null) {
+                    bannerSprite.textureRegion = loadedTexture
+                    background = bannerSprite
+                } else {
+                    bannerSprite.textureRegion = null
+                    background = defaultBackground
+
+                    bannerJob = async {
                         ensureActive()
-                        val texture = resourceManager.getProfileBannerTextureIfLoaded(bannerUrl)
 
-                        updateThread {
-                            bannerSprite.textureRegion = texture
-                            background = if (texture != null) bannerSprite else defaultBackground
+                        if (OnlineManager.getInstance().loadProfileBannerToTextureManager(bannerUrl)) {
+                            ensureActive()
+
+                            val texture = resourceManager.getProfileBannerTextureIfLoaded(bannerUrl)
+
+                            updateThread {
+                                if (lastPlayerId == player.id) {
+                                    bannerSprite.textureRegion = texture
+
+                                    if (texture != null) {
+                                        background = bannerSprite
+                                    }
+                                }
+                            }
+                        } else {
+                            updateThread {
+                                if (lastPlayerId == player.id) {
+                                    background = defaultBackground
+                                }
+                            }
                         }
                     }
                 }

--- a/src/com/osudroid/ui/v2/multi/RoomScene.kt
+++ b/src/com/osudroid/ui/v2/multi/RoomScene.kt
@@ -31,6 +31,7 @@ import com.reco1l.andengine.UIEngine
 import com.reco1l.andengine.UIScene
 import com.reco1l.andengine.badge
 import com.reco1l.andengine.component.UIComponent.Companion.FillParent
+import com.reco1l.andengine.component.forEach
 import com.reco1l.andengine.component.setText
 import com.reco1l.andengine.container
 import com.reco1l.andengine.container.JustifyContent
@@ -707,6 +708,7 @@ class RoomScene(
     private fun teardownSession() {
         Multiplayer.cancelReconnection()
         beatmapInfoLayout.cancelCalculation()
+        playersContainer.forEach { (it as RoomPlayerCard).cancelBannerJob() }
 
         // Null out event listeners before disconnect so any queued socket events that
         // arrive after teardown find no listener to call.


### PR DESCRIPTION
Straightforward. It adds profile banners to respective player cards. If they do not have a banner, the current background is shown.

## Preview
<img width="2800" height="1260" alt="image" src="https://github.com/user-attachments/assets/7029c83e-ceac-4fab-97f5-c873b086bdf6" />
