### PR TITLE
Update FPS counter to use draw thread clock

### DIFF
--- a/src/com/osudroid/ui/FPSCounter.kt
+++ b/src/com/osudroid/ui/FPSCounter.kt
@@ -119,20 +119,29 @@ class FPSCounter(font: Font) : ChangeableText(
         }
 
         timeSinceLastUpdate = 0f
-        val displayedFps = displayedFpsCount.roundToInt()
 
-        if (!hasSignificantChanges && displayedFps == lastDisplayedFps && displayedFrameTime == lastDisplayedFrameTime) {
+        val displayedFps = displayedFpsCount.roundToInt()
+        val isHighPrecision = displayedFrameTime < 0.01f
+        val displayedMs = displayedFrameTime * 1000
+
+        val roundedFrameTime = if (isHighPrecision) {
+            (displayedMs * 10).roundToInt() / 10f
+        } else {
+            displayedMs.roundToInt().toFloat()
+        }
+
+        if (!hasSignificantChanges && displayedFps == lastDisplayedFps && roundedFrameTime == lastDisplayedFrameTime) {
             return
         }
 
         lastDisplayedFps = displayedFps
-        lastDisplayedFrameTime = displayedFrameTime
+        lastDisplayedFrameTime = roundedFrameTime
 
         stringBuilder.setLength(0)
 
         formatter.format(
-            "%.${if (displayedFrameTime < 0.01f) "1" else "0"}f ms | %d FPS",
-            displayedFrameTime * 1000,
+            "%.${if (isHighPrecision) "1" else "0"}f ms | %d FPS",
+            displayedMs,
             displayedFps
         )
 

--- a/src/com/osudroid/ui/FPSCounter.kt
+++ b/src/com/osudroid/ui/FPSCounter.kt
@@ -5,6 +5,7 @@ import com.osudroid.math.Interpolation
 import com.reco1l.andengine.UIEngine
 import java.util.Formatter
 import java.util.Locale
+import kotlin.math.min
 import kotlin.math.roundToInt
 import org.anddev.andengine.entity.text.ChangeableText
 import org.anddev.andengine.opengl.font.Font
@@ -143,7 +144,12 @@ class FPSCounter(font: Font) : ChangeableText(
 
     private fun updateAimFPS(): Boolean {
         val newAimDrawFPS = getGlobal().mainActivity.refreshRate
-        val newAimUpdateFPS = if (updateClock.throttling) updateClock.maximumUpdateHz else newAimDrawFPS
+
+        val newAimUpdateFPS = if (updateClock.throttling && updateClock.maximumUpdateHz > 0) {
+            min(updateClock.maximumUpdateHz, newAimDrawFPS)
+        } else {
+            newAimDrawFPS
+        }
 
         if (aimDrawFPS != newAimDrawFPS || aimUpdateFPS != newAimUpdateFPS) {
             aimDrawFPS = newAimDrawFPS

--- a/src/com/osudroid/ui/FPSCounter.kt
+++ b/src/com/osudroid/ui/FPSCounter.kt
@@ -83,7 +83,7 @@ class FPSCounter(font: Font) : ChangeableText(
 
         val hasUpdateSpike = displayedFrameTime < spikeTime && elapsedUpdateFrameTime > spikeTime
         // Use elapsed frame time rather than framesPerSecond to better catch stutter frames.
-        val hasDrawSpike = displayedFpsCount > (1f / spikeTime) && elapsedDrawFrameTime > spikeTime
+        val hasDrawSpike = displayedFpsCount > 1f / spikeTime && elapsedDrawFrameTime > spikeTime
 
         displayedFrameTime = Interpolation.dampContinuously(
             displayedFrameTime,

--- a/src/com/osudroid/ui/FPSCounter.kt
+++ b/src/com/osudroid/ui/FPSCounter.kt
@@ -1,11 +1,14 @@
 package com.osudroid.ui
 
 import com.reco1l.framework.Color4
-import com.osudroid.math.Interpolation.dampContinuously
-import kotlin.math.min
+import com.osudroid.math.Interpolation
+import com.reco1l.andengine.UIEngine
+import java.util.Formatter
+import java.util.Locale
 import kotlin.math.roundToInt
 import org.anddev.andengine.entity.text.ChangeableText
 import org.anddev.andengine.opengl.font.Font
+import ru.nsu.ccfit.zuev.osu.Config
 import ru.nsu.ccfit.zuev.osu.GlobalManager.getInstance as getGlobal
 
 /**
@@ -19,87 +22,41 @@ class FPSCounter(font: Font) : ChangeableText(
     0f,
     0f,
     font,
-    "${getGlobal().mainActivity.refreshRate.roundToInt()}/${getGlobal().mainActivity.refreshRate.roundToInt()} FPS"
+    "",
+    24
 ) {
+    private val drawClock = UIEngine.current.drawClock
+    private val updateClock = UIEngine.current.updateClock
+
     //region Counting logic
 
     /**
      * The current frame rate.
      */
-    @get:JvmName("getFPS")
-    var fps = 0f
+    var displayedFpsCount = 0f
         private set
 
     /**
-     * The maximum frame rate that can be displayed.
+     * The average frame time in seconds.
      */
-    @get:JvmName("getMaximumFPS")
-    var maximumFps = 0f
-        private set(value) {
-            if (field == value) {
-                return
-            }
-
-            field = value
-
-            // Force update so that the new maximum frame rate is displayed.
-            forceUpdate = true
-        }
-
-    /**
-     * The average frame rate.
-     */
-    @get:JvmName("getAverageFPS")
-    var averageFps = 0f
+    var displayedFrameTime = 0f
         private set
+
+    private var aimDrawFPS = 0f
+    private var aimUpdateFPS = 0f
 
     private val spikeTime = 0.02f
     private val dampTime = 0.1f
 
-    // Average FPS calculation
-    private var timeUntilNextAverageFpsCalculation = 0f
-    private var timeSinceLastAverageFpsCalculation = 0f
-    private var framesSinceLastAverageFpsCalculation = 0
-    private val averageFpsCalculationInterval = 0.25f
-
-    /**
-     * Updates the FPS of this [FPSCounter].
-     *
-     * @param deltaTime The time in seconds since the last update.
-     */
-    fun updateFps(deltaTime: Float) {
-        // Update average FPS
-        if (timeUntilNextAverageFpsCalculation <= 0) {
-            timeUntilNextAverageFpsCalculation += averageFpsCalculationInterval
-
-            averageFps =
-                if (framesSinceLastAverageFpsCalculation == 0) 0f
-                else framesSinceLastAverageFpsCalculation / timeSinceLastAverageFpsCalculation
-
-            timeSinceLastAverageFpsCalculation = 0f
-            framesSinceLastAverageFpsCalculation = 0
-
-            maximumFps = getGlobal().mainActivity.refreshRate
-        }
-
-        framesSinceLastAverageFpsCalculation++
-        timeUntilNextAverageFpsCalculation -= deltaTime
-        timeSinceLastAverageFpsCalculation += deltaTime
-
-        // Use elapsed frame time rather than FPS to better catch stutter frames.
-        val hasSpike = fps > 1 / spikeTime && deltaTime > spikeTime
-
-        // Show spike time using raw elapsed value to account for average FPS being so averaged spike frames don't show.
-        fps = min(maximumFps, if (hasSpike) 1 / deltaTime else dampContinuously(fps, averageFps, dampTime, deltaTime))
-    }
+    private val stringBuilder = StringBuilder(24)
+    private val formatter = Formatter(stringBuilder, Locale.US)
 
     //endregion
 
     //region Display logic
 
     private var lastDisplayedFps = 0
-
-    private var forceUpdate = false
+    private var lastDisplayedFrameTime = 0f
 
     private var timeSinceLastUpdate = 0f
     private val updateInterval = 0.1f
@@ -111,52 +68,110 @@ class FPSCounter(font: Font) : ChangeableText(
     override fun onManagedUpdate(pSecondsElapsed: Float) {
         super.onManagedUpdate(pSecondsElapsed)
 
+        val elapsedDrawFrameTime = drawClock.elapsedFrameTime
+        val elapsedUpdateFrameTime = updateClock.elapsedFrameTime
+
         // If the game goes into a suspended state (i.e., debugger attached), we want to ignore really long periods of
         // no processing.
-        if (pSecondsElapsed > 10) {
+        if (elapsedUpdateFrameTime > 10) {
             return
         }
 
-        timeSinceLastUpdate += pSecondsElapsed
+        // Handle the case where the window has become inactive (we want to show the FPS as it is changing, even if it
+        // is not an outlier).
+        val aimRatesChanged = updateAimFPS()
 
-        if (!forceUpdate && timeSinceLastUpdate < updateInterval) {
+        val hasUpdateSpike = displayedFrameTime < spikeTime && elapsedUpdateFrameTime > spikeTime
+        // Use elapsed frame time rather than framesPerSecond to better catch stutter frames.
+        val hasDrawSpike = displayedFpsCount > (1f / spikeTime) && elapsedDrawFrameTime > spikeTime
+
+        displayedFrameTime = Interpolation.dampContinuously(
+            displayedFrameTime,
+            elapsedUpdateFrameTime,
+            if (hasUpdateSpike) 0f else dampTime,
+            elapsedUpdateFrameTime
+        )
+
+        displayedFpsCount = if (hasDrawSpike) {
+            // Show spike time using raw elapsed value, to account for `framesPerSecond` being so averaged spike frames
+            // do not show.
+            1f / elapsedDrawFrameTime
+        } else {
+            Interpolation.dampContinuously(
+                displayedFpsCount,
+                drawClock.framesPerSecond,
+                dampTime,
+                updateClock.timeInfo.elapsed
+            )
+        }
+
+        val hasSignificantChanges = aimRatesChanged ||
+                hasDrawSpike ||
+                hasUpdateSpike ||
+                displayedFpsCount < aimDrawFPS * 0.8f ||
+                1 / displayedFrameTime < aimUpdateFPS * 0.8f
+
+        timeSinceLastUpdate += updateClock.timeInfo.elapsed
+
+        if (!hasSignificantChanges && timeSinceLastUpdate < updateInterval) {
             return
         }
 
-        forceUpdate = false
         timeSinceLastUpdate = 0f
+        val displayedFps = displayedFpsCount.roundToInt()
 
-        val displayedFps = fps.roundToInt()
-
-        if (!forceUpdate && displayedFps == lastDisplayedFps) {
+        if (!hasSignificantChanges && displayedFps == lastDisplayedFps && displayedFrameTime == lastDisplayedFrameTime) {
             return
         }
 
         lastDisplayedFps = displayedFps
+        lastDisplayedFrameTime = displayedFrameTime
 
-        text = "$displayedFps/${maximumFps.roundToInt()} FPS"
+        stringBuilder.setLength(0)
+
+        formatter.format(
+            "%.${if (displayedFrameTime < 0.005f) "1" else "0"}f ms | %d FPS",
+            displayedFrameTime * 1000,
+            displayedFps
+        )
+
+        text = stringBuilder.toString()
 
         updateColor()
+        setPosition(Config.getRES_WIDTH() - widthScaled - 5, Config.getRES_HEIGHT() - heightScaled - 10)
+    }
+
+    private fun updateAimFPS(): Boolean {
+        val newAimDrawFPS = getGlobal().mainActivity.refreshRate
+        val newAimUpdateFPS = if (updateClock.throttling) updateClock.maximumUpdateHz else newAimDrawFPS
+
+        if (aimDrawFPS != newAimDrawFPS || aimUpdateFPS != newAimUpdateFPS) {
+            aimDrawFPS = newAimDrawFPS
+            aimUpdateFPS = newAimUpdateFPS
+            return true
+        }
+
+        return false
     }
 
     private fun updateColor() {
-        val performanceRatio = fps / maximumFps
+        val performanceRatio = displayedFpsCount / aimDrawFPS
         val red: Float
         val green: Float
         val blue: Float
 
         if (performanceRatio < 0.5f) {
-            val t = performanceRatio / 0.5f
+            val t = (performanceRatio / 0.5f).coerceIn(0f, 1f)
 
-            red = minimumTextColor.red + t * (middleTextColor.red - minimumTextColor.red)
-            green = minimumTextColor.green + t * (middleTextColor.green - minimumTextColor.green)
-            blue = minimumTextColor.blue + t * (middleTextColor.blue - minimumTextColor.blue)
+            red = Interpolation.linear(minimumTextColor.red, middleTextColor.red, t)
+            green = Interpolation.linear(minimumTextColor.green, middleTextColor.green, t)
+            blue = Interpolation.linear(minimumTextColor.blue, middleTextColor.blue, t)
         } else {
             val t = ((performanceRatio - 0.5f) / 0.4f).coerceIn(0f, 1f)
 
-            red = middleTextColor.red + t * (maximumTextColor.red - middleTextColor.red)
-            green = middleTextColor.green + t * (maximumTextColor.green - middleTextColor.green)
-            blue = middleTextColor.blue + t * (maximumTextColor.blue - middleTextColor.blue)
+            red = Interpolation.linear(middleTextColor.red, maximumTextColor.red, t)
+            green = Interpolation.linear(middleTextColor.green, maximumTextColor.green, t)
+            blue = Interpolation.linear(middleTextColor.blue, maximumTextColor.blue, t)
         }
 
         setColor(red, green, blue)
@@ -169,15 +184,10 @@ class FPSCounter(font: Font) : ChangeableText(
     override fun reset() {
         super.reset()
 
-        timeUntilNextAverageFpsCalculation = 0f
-        timeSinceLastAverageFpsCalculation = 0f
-        framesSinceLastAverageFpsCalculation = 0
-
-        fps = 0f
-        averageFps = 0f
-        maximumFps = 0f
+        displayedFpsCount = 0f
+        displayedFrameTime = 0f
         lastDisplayedFps = 0
-        forceUpdate = false
+        lastDisplayedFrameTime = 0f
         timeSinceLastUpdate = 0f
     }
 

--- a/src/com/osudroid/ui/FPSCounter.kt
+++ b/src/com/osudroid/ui/FPSCounter.kt
@@ -130,7 +130,7 @@ class FPSCounter(font: Font) : ChangeableText(
         stringBuilder.setLength(0)
 
         formatter.format(
-            "%.${if (displayedFrameTime < 0.005f) "1" else "0"}f ms | %d FPS",
+            "%.${if (displayedFrameTime < 0.01f) "1" else "0"}f ms | %d FPS",
             displayedFrameTime * 1000,
             displayedFps
         )

--- a/src/com/osudroid/ui/FPSCounter.kt
+++ b/src/com/osudroid/ui/FPSCounter.kt
@@ -109,8 +109,9 @@ class FPSCounter(font: Font) : ChangeableText(
         val hasSignificantChanges = aimRatesChanged ||
                 hasDrawSpike ||
                 hasUpdateSpike ||
-                displayedFpsCount < aimDrawFPS * 0.8f ||
-                1 / displayedFrameTime < aimUpdateFPS * 0.8f
+                // Force update if we are below the target by a certain threshold.
+                displayedFpsCount < aimDrawFPS * 0.6f ||
+                1 / displayedFrameTime < aimUpdateFPS * 0.6f
 
         timeSinceLastUpdate += updateClock.timeInfo.elapsed
 

--- a/src/com/osudroid/ui/FPSCounter.kt
+++ b/src/com/osudroid/ui/FPSCounter.kt
@@ -118,8 +118,6 @@ class FPSCounter(font: Font) : ChangeableText(
             return
         }
 
-        timeSinceLastUpdate = 0f
-
         val displayedFps = displayedFpsCount.roundToInt()
         val isHighPrecision = displayedFrameTime < 0.01f
         val displayedMs = displayedFrameTime * 1000
@@ -134,6 +132,7 @@ class FPSCounter(font: Font) : ChangeableText(
             return
         }
 
+        timeSinceLastUpdate = 0f
         lastDisplayedFps = displayedFps
         lastDisplayedFrameTime = roundedFrameTime
 

--- a/src/com/reco1l/andengine/UIEngine.kt
+++ b/src/com/reco1l/andengine/UIEngine.kt
@@ -20,8 +20,17 @@ import org.anddev.andengine.engine.camera.Camera
 
 class UIEngine(val context: Activity, options: EngineOptions) : Engine(options),
     IClockProvider<ThrottledFrameClock> {
+    /**
+     * The clock used for the update thread.
+     */
+    val updateClock = ThrottledFrameClock()
 
-    override val clock = ThrottledFrameClock()
+    /**
+     * The clock used for the draw (GL) thread.
+     */
+    val drawClock = ThrottledFrameClock()
+
+    override val clock = updateClock
 
     /**
      * The global HUD used for overlays (menus, dialogs, etc).
@@ -68,6 +77,7 @@ class UIEngine(val context: Activity, options: EngineOptions) : Engine(options),
 
 
     override fun onDrawScene(pGL: GL10) {
+        drawClock.processFrame()
 
         val focusedEntity = focusedEntity
 
@@ -195,9 +205,9 @@ class UIEngine(val context: Activity, options: EngineOptions) : Engine(options),
     }
 
     override fun onUpdate(pNanosecondsElapsed: Long) {
-        clock.processFrame()
+        updateClock.processFrame()
 
-        super.onUpdate((clock.elapsedFrameTime * 1e9).toLong())
+        super.onUpdate((updateClock.elapsedFrameTime * 1e9).toLong())
     }
 
     override fun setScene(scene: Scene?) {

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -1284,37 +1284,7 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
         var counterTextFont = ResourceManager.getInstance().getFont("smallFont");
 
         if (Config.isShowFPS()) {
-            var fpsCounter = new FPSCounter(counterTextFont);
-
-            // Attach a dummy entity for computing FPS, as its frame rate is tied to the draw thread and not
-            // the update thread.
-            hud.attachChild(new Entity() {
-                private long previousDrawTime;
-
-                @Override
-                protected void onManagedUpdate(float pSecondsElapsed) {
-                    fpsCounter.setPosition(
-                        Config.getRES_WIDTH() - fpsCounter.getWidthScaled() - 5,
-                        Config.getRES_HEIGHT() - fpsCounter.getHeightScaled() - 10
-                    );
-                }
-
-                @Override
-                protected void onManagedDraw(GL10 pGL, Camera pCamera) {
-                    long currentDrawTime = SystemClock.uptimeMillis();
-
-                    fpsCounter.updateFps((currentDrawTime - previousDrawTime) / 1000f);
-
-                    previousDrawTime = currentDrawTime;
-                }
-            });
-
-            fpsCounter.setPosition(
-                Config.getRES_WIDTH() - fpsCounter.getWidthScaled() - 5,
-                Config.getRES_HEIGHT() - fpsCounter.getHeightScaled() - 10
-            );
-
-            hud.attachChild(fpsCounter);
+            hud.attachChild(new FPSCounter(counterTextFont));
         }
 
         breakAnimator = new BreakAnimator(fgScene, stat, hud);


### PR DESCRIPTION
- [x] Requires #629 

With the new clock system, it is now possible to have a separate clock for the draw (GL) thread. This PR updates `FPSCounter` to use that clock for consideration in frame time calculation and removes the local average FPS calculation (since it is already done in `FramedClock`).

<img width="2800" height="1260" alt="Screenshot_20260512_005754" src="https://github.com/user-attachments/assets/05cad552-0b52-4d87-b54c-dcd8ab6d3925" />
