### PR TITLE
Always show FPS counter across all scenes

### DIFF
--- a/res/layout/loading_badge_fragment.xml
+++ b/res/layout/loading_badge_fragment.xml
@@ -8,6 +8,7 @@
     tools:background="#FFF">
 
     <LinearLayout
+        android:id="@+id/container"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="16dp"

--- a/res/xml/settings_gameplay.xml
+++ b/res/xml/settings_gameplay.xml
@@ -100,13 +100,6 @@
 
         <CheckBoxPreference
             android:defaultValue="true"
-            android:key="fps"
-            android:summary="@string/opt_fps_summary"
-            android:title="@string/opt_fps_title"
-            app:layout="@layout/settings_preference_checkbox" />
-
-        <CheckBoxPreference
-            android:defaultValue="true"
             android:key="displayScoreStatistics"
             android:summary="@string/opt_display_score_statistics_summary"
             android:title="@string/opt_display_score_statistics_title"

--- a/res/xml/settings_graphics.xml
+++ b/res/xml/settings_graphics.xml
@@ -34,6 +34,17 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="@string/opt_category_hud">
+
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="fps"
+            android:summary="@string/opt_fps_summary"
+            android:title="@string/opt_fps_title"
+            app:layout="@layout/settings_preference_checkbox_bottom" />
+
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="@string/opt_category_cursor">
 
         <CheckBoxPreference

--- a/src/com/osudroid/ui/FPSCounter.kt
+++ b/src/com/osudroid/ui/FPSCounter.kt
@@ -75,87 +75,89 @@ class FPSCounter : UIText() {
     }
 
     override fun onManagedUpdate(deltaTimeSec: Float) {
-        isVisible = Config.isShowFPS()
-
         try {
-            if (!isVisible) {
-                return
+            isVisible = Config.isShowFPS()
+
+            if (isVisible) {
+                updateFPS()
             }
-
-            val elapsedUpdateFrameTime = updateClock.elapsedFrameTime
-
-            // If the game goes into a suspended state (i.e., debugger attached), we want to ignore really long periods of
-            // no processing.
-            if (elapsedUpdateFrameTime > 10) {
-                return
-            }
-
-            // Handle the case where the window has become inactive (we want to show the FPS as it is changing, even if it
-            // is not an outlier).
-            val aimRatesChanged = updateAimFPS()
-            val hasUpdateSpike = displayedFrameTime < spikeTime && elapsedUpdateFrameTime > spikeTime
-
-            displayedFrameTime = Interpolation.dampContinuously(
-                displayedFrameTime,
-                elapsedUpdateFrameTime,
-                if (hasUpdateSpike) 0f else dampTime,
-                elapsedUpdateFrameTime
-            )
-
-            displayedFpsCount = if (hasUpdateSpike) {
-                // Show spike time using raw elapsed value, to account for `framesPerSecond` being so averaged spike frames
-                // do not show.
-                1f / elapsedUpdateFrameTime
-            } else {
-                Interpolation.dampContinuously(
-                    displayedFpsCount,
-                    updateClock.framesPerSecond,
-                    dampTime,
-                    updateClock.timeInfo.elapsed
-                )
-            }
-
-            // Force update if we are below the target by a certain threshold.
-            val hasSignificantChanges = aimRatesChanged || hasUpdateSpike || displayedFpsCount < aimFPS * 0.6f
-
-            timeSinceLastUpdate += updateClock.timeInfo.elapsed
-
-            if (!hasSignificantChanges && timeSinceLastUpdate < updateInterval) {
-                return
-            }
-
-            val displayedFps = displayedFpsCount.roundToInt()
-            val isHighPrecision = displayedFrameTime < 0.01f
-            val displayedMs = displayedFrameTime * 1000
-
-            val roundedFrameTime = if (isHighPrecision) {
-                (displayedMs * 10).roundToInt() / 10f
-            } else {
-                displayedMs.roundToInt().toFloat()
-            }
-
-            if (!hasSignificantChanges && displayedFps == lastDisplayedFps && roundedFrameTime == lastDisplayedFrameTime) {
-                return
-            }
-
-            timeSinceLastUpdate = 0f
-            lastDisplayedFps = displayedFps
-            lastDisplayedFrameTime = roundedFrameTime
-
-            stringBuilder.setLength(0)
-
-            formatter.format(
-                "%.${if (isHighPrecision) "1" else "0"}f ms | %d FPS",
-                displayedMs,
-                displayedFps
-            )
-
-            text = stringBuilder.toString()
-
-            updateColor()
         } finally {
             super.onManagedUpdate(deltaTimeSec)
         }
+    }
+
+    private fun updateFPS() {
+        val elapsedUpdateFrameTime = updateClock.elapsedFrameTime
+
+        // If the game goes into a suspended state (i.e., debugger attached), we want to ignore really long periods of
+        // no processing.
+        if (elapsedUpdateFrameTime > 10) {
+            return
+        }
+
+        // Handle the case where the window has become inactive (we want to show the FPS as it is changing, even if it
+        // is not an outlier).
+        val aimRatesChanged = updateAimFPS()
+        val hasUpdateSpike = displayedFrameTime < spikeTime && elapsedUpdateFrameTime > spikeTime
+
+        displayedFrameTime = Interpolation.dampContinuously(
+            displayedFrameTime,
+            elapsedUpdateFrameTime,
+            if (hasUpdateSpike) 0f else dampTime,
+            elapsedUpdateFrameTime
+        )
+
+        displayedFpsCount = if (hasUpdateSpike) {
+            // Show spike time using raw elapsed value, to account for `framesPerSecond` being so averaged spike frames
+            // do not show.
+            1f / elapsedUpdateFrameTime
+        } else {
+            Interpolation.dampContinuously(
+                displayedFpsCount,
+                updateClock.framesPerSecond,
+                dampTime,
+                updateClock.timeInfo.elapsed
+            )
+        }
+
+        // Force update if we are below the target by a certain threshold.
+        val hasSignificantChanges = aimRatesChanged || hasUpdateSpike || displayedFpsCount < aimFPS * 0.6f
+
+        timeSinceLastUpdate += updateClock.timeInfo.elapsed
+
+        if (!hasSignificantChanges && timeSinceLastUpdate < updateInterval) {
+            return
+        }
+
+        val displayedFps = displayedFpsCount.roundToInt()
+        val isHighPrecision = displayedFrameTime < 0.01f
+        val displayedMs = displayedFrameTime * 1000
+
+        val roundedFrameTime = if (isHighPrecision) {
+            (displayedMs * 10).roundToInt() / 10f
+        } else {
+            displayedMs.roundToInt().toFloat()
+        }
+
+        if (!hasSignificantChanges && displayedFps == lastDisplayedFps && roundedFrameTime == lastDisplayedFrameTime) {
+            return
+        }
+
+        timeSinceLastUpdate = 0f
+        lastDisplayedFps = displayedFps
+        lastDisplayedFrameTime = roundedFrameTime
+
+        stringBuilder.setLength(0)
+
+        formatter.format(
+            "%.${if (isHighPrecision) "1" else "0"}f ms | %d FPS",
+            displayedMs,
+            displayedFps
+        )
+
+        text = stringBuilder.toString()
+
+        updateColor()
     }
 
     private fun updateAimFPS(): Boolean {

--- a/src/com/osudroid/ui/FPSCounter.kt
+++ b/src/com/osudroid/ui/FPSCounter.kt
@@ -63,12 +63,12 @@ class FPSCounter : UIText() {
         padding = Vec4(4f)
         anchor = Anchor.BottomRight
         origin = Anchor.BottomRight
-        alignment = Anchor.BottomRight
+        alignment = Anchor.Center
 
         background = UIBox().apply {
             cornerRadius = 8f
             applyTheme = {
-                color = it.accentColor * 0.7f
+                color = it.accentColor * 0.1f
                 alpha = 0.8f
             }
         }

--- a/src/com/osudroid/ui/FPSCounter.kt
+++ b/src/com/osudroid/ui/FPSCounter.kt
@@ -60,7 +60,7 @@ class FPSCounter : UIText() {
 
     init {
         font = ResourceManager.getInstance().getFont("smallFont")
-        padding = Vec4(4f)
+        padding = Vec4(6f, 4f)
         anchor = Anchor.BottomRight
         origin = Anchor.BottomRight
         alignment = Anchor.Center

--- a/src/com/osudroid/ui/FPSCounter.kt
+++ b/src/com/osudroid/ui/FPSCounter.kt
@@ -72,8 +72,6 @@ class FPSCounter : UIText() {
                 alpha = 0.8f
             }
         }
-
-        instance = this
     }
 
     override fun onManagedUpdate(deltaTimeSec: Float) {
@@ -217,10 +215,4 @@ class FPSCounter : UIText() {
     }
 
     //endregion
-
-    companion object {
-        @JvmStatic
-        var instance: FPSCounter? = null
-            private set
-    }
 }

--- a/src/com/osudroid/ui/FPSCounter.kt
+++ b/src/com/osudroid/ui/FPSCounter.kt
@@ -16,8 +16,6 @@ import ru.nsu.ccfit.zuev.osu.GlobalManager.getInstance as getGlobal
  * Represents an FPS counter.
  *
  * All time units are in seconds.
- *
- * @param font The [Font] that will be used to display the current frame rate.
  */
 class FPSCounter(font: Font) : ChangeableText(
     0f,
@@ -26,8 +24,8 @@ class FPSCounter(font: Font) : ChangeableText(
     "",
     24
 ) {
-    private val drawClock = UIEngine.current.drawClock
-    private val updateClock = UIEngine.current.updateClock
+    private val clock
+        get() = UIEngine.current.clock
 
     //region Counting logic
 
@@ -43,8 +41,7 @@ class FPSCounter(font: Font) : ChangeableText(
     var displayedFrameTime = 0f
         private set
 
-    private var aimDrawFPS = 0f
-    private var aimUpdateFPS = 0f
+    private var aimFPS = 0f
 
     private val spikeTime = 0.02f
     private val dampTime = 0.1f
@@ -69,8 +66,7 @@ class FPSCounter(font: Font) : ChangeableText(
     override fun onManagedUpdate(pSecondsElapsed: Float) {
         super.onManagedUpdate(pSecondsElapsed)
 
-        val elapsedDrawFrameTime = drawClock.elapsedFrameTime
-        val elapsedUpdateFrameTime = updateClock.elapsedFrameTime
+        val elapsedUpdateFrameTime = clock.elapsedFrameTime
 
         // If the game goes into a suspended state (i.e., debugger attached), we want to ignore really long periods of
         // no processing.
@@ -81,10 +77,7 @@ class FPSCounter(font: Font) : ChangeableText(
         // Handle the case where the window has become inactive (we want to show the FPS as it is changing, even if it
         // is not an outlier).
         val aimRatesChanged = updateAimFPS()
-
         val hasUpdateSpike = displayedFrameTime < spikeTime && elapsedUpdateFrameTime > spikeTime
-        // Use elapsed frame time rather than framesPerSecond to better catch stutter frames.
-        val hasDrawSpike = displayedFpsCount > 1f / spikeTime && elapsedDrawFrameTime > spikeTime
 
         displayedFrameTime = Interpolation.dampContinuously(
             displayedFrameTime,
@@ -93,27 +86,23 @@ class FPSCounter(font: Font) : ChangeableText(
             elapsedUpdateFrameTime
         )
 
-        displayedFpsCount = if (hasDrawSpike) {
+        displayedFpsCount = if (hasUpdateSpike) {
             // Show spike time using raw elapsed value, to account for `framesPerSecond` being so averaged spike frames
             // do not show.
-            1f / elapsedDrawFrameTime
+            1f / elapsedUpdateFrameTime
         } else {
             Interpolation.dampContinuously(
                 displayedFpsCount,
-                drawClock.framesPerSecond,
+                clock.framesPerSecond,
                 dampTime,
-                updateClock.timeInfo.elapsed
+                clock.timeInfo.elapsed
             )
         }
 
-        val hasSignificantChanges = aimRatesChanged ||
-                hasDrawSpike ||
-                hasUpdateSpike ||
-                // Force update if we are below the target by a certain threshold.
-                displayedFpsCount < aimDrawFPS * 0.6f ||
-                1 / displayedFrameTime < aimUpdateFPS * 0.6f
+        // Force update if we are below the target by a certain threshold.
+        val hasSignificantChanges = aimRatesChanged || hasUpdateSpike || displayedFpsCount < aimFPS * 0.6f
 
-        timeSinceLastUpdate += updateClock.timeInfo.elapsed
+        timeSinceLastUpdate += clock.timeInfo.elapsed
 
         if (!hasSignificantChanges && timeSinceLastUpdate < updateInterval) {
             return
@@ -152,17 +141,16 @@ class FPSCounter(font: Font) : ChangeableText(
     }
 
     private fun updateAimFPS(): Boolean {
-        val newAimDrawFPS = getGlobal().mainActivity.refreshRate
+        val refreshRate = getGlobal().mainActivity.refreshRate
 
-        val newAimUpdateFPS = if (updateClock.throttling && updateClock.maximumUpdateHz > 0) {
-            min(updateClock.maximumUpdateHz, newAimDrawFPS)
+        val newAimFPS = if (clock.throttling && clock.maximumUpdateHz > 0) {
+            min(clock.maximumUpdateHz, refreshRate)
         } else {
-            newAimDrawFPS
+            refreshRate
         }
 
-        if (aimDrawFPS != newAimDrawFPS || aimUpdateFPS != newAimUpdateFPS) {
-            aimDrawFPS = newAimDrawFPS
-            aimUpdateFPS = newAimUpdateFPS
+        if (aimFPS != newAimFPS) {
+            aimFPS = newAimFPS
             return true
         }
 
@@ -170,7 +158,7 @@ class FPSCounter(font: Font) : ChangeableText(
     }
 
     private fun updateColor() {
-        val performanceRatio = displayedFpsCount / aimDrawFPS
+        val performanceRatio = displayedFpsCount / aimFPS
         val red: Float
         val green: Float
         val blue: Float

--- a/src/com/osudroid/ui/FPSCounter.kt
+++ b/src/com/osudroid/ui/FPSCounter.kt
@@ -72,6 +72,8 @@ class FPSCounter : UIText() {
                 alpha = 0.8f
             }
         }
+
+        instance = this
     }
 
     override fun onManagedUpdate(deltaTimeSec: Float) {
@@ -215,4 +217,10 @@ class FPSCounter : UIText() {
     }
 
     //endregion
+
+    companion object {
+        @JvmStatic
+        var instance: FPSCounter? = null
+            private set
+    }
 }

--- a/src/com/osudroid/ui/FPSCounter.kt
+++ b/src/com/osudroid/ui/FPSCounter.kt
@@ -2,29 +2,24 @@ package com.osudroid.ui
 
 import com.reco1l.framework.Color4
 import com.osudroid.math.Interpolation
+import com.reco1l.andengine.Anchor
 import com.reco1l.andengine.UIEngine
+import com.reco1l.andengine.shape.UIBox
+import com.reco1l.andengine.text.UIText
+import com.reco1l.framework.math.Vec4
 import java.util.Formatter
 import java.util.Locale
 import kotlin.math.min
 import kotlin.math.roundToInt
-import org.anddev.andengine.entity.text.ChangeableText
-import org.anddev.andengine.opengl.font.Font
 import ru.nsu.ccfit.zuev.osu.Config
+import ru.nsu.ccfit.zuev.osu.ResourceManager
 import ru.nsu.ccfit.zuev.osu.GlobalManager.getInstance as getGlobal
 
 /**
  * Represents an FPS counter.
- *
- * All time units are in seconds.
  */
-class FPSCounter(font: Font) : ChangeableText(
-    0f,
-    0f,
-    font,
-    "",
-    24
-) {
-    private val clock
+class FPSCounter : UIText() {
+    private val updateClock
         get() = UIEngine.current.clock
 
     //region Counting logic
@@ -63,88 +58,111 @@ class FPSCounter(font: Font) : ChangeableText(
     private val middleTextColor = Color4(0xebc247)
     private val maximumTextColor = Color4(0xccff99)
 
-    override fun onManagedUpdate(pSecondsElapsed: Float) {
-        super.onManagedUpdate(pSecondsElapsed)
+    init {
+        font = ResourceManager.getInstance().getFont("smallFont")
+        padding = Vec4(4f)
+        anchor = Anchor.BottomRight
+        origin = Anchor.BottomRight
+        alignment = Anchor.BottomRight
 
-        val elapsedUpdateFrameTime = clock.elapsedFrameTime
-
-        // If the game goes into a suspended state (i.e., debugger attached), we want to ignore really long periods of
-        // no processing.
-        if (elapsedUpdateFrameTime > 10) {
-            return
+        background = UIBox().apply {
+            cornerRadius = 8f
+            applyTheme = {
+                color = it.accentColor * 0.7f
+                alpha = 0.8f
+            }
         }
+    }
 
-        // Handle the case where the window has become inactive (we want to show the FPS as it is changing, even if it
-        // is not an outlier).
-        val aimRatesChanged = updateAimFPS()
-        val hasUpdateSpike = displayedFrameTime < spikeTime && elapsedUpdateFrameTime > spikeTime
+    override fun onManagedUpdate(deltaTimeSec: Float) {
+        isVisible = Config.isShowFPS()
 
-        displayedFrameTime = Interpolation.dampContinuously(
-            displayedFrameTime,
-            elapsedUpdateFrameTime,
-            if (hasUpdateSpike) 0f else dampTime,
-            elapsedUpdateFrameTime
-        )
+        try {
+            if (!isVisible) {
+                return
+            }
 
-        displayedFpsCount = if (hasUpdateSpike) {
-            // Show spike time using raw elapsed value, to account for `framesPerSecond` being so averaged spike frames
-            // do not show.
-            1f / elapsedUpdateFrameTime
-        } else {
-            Interpolation.dampContinuously(
-                displayedFpsCount,
-                clock.framesPerSecond,
-                dampTime,
-                clock.timeInfo.elapsed
+            val elapsedUpdateFrameTime = updateClock.elapsedFrameTime
+
+            // If the game goes into a suspended state (i.e., debugger attached), we want to ignore really long periods of
+            // no processing.
+            if (elapsedUpdateFrameTime > 10) {
+                return
+            }
+
+            // Handle the case where the window has become inactive (we want to show the FPS as it is changing, even if it
+            // is not an outlier).
+            val aimRatesChanged = updateAimFPS()
+            val hasUpdateSpike = displayedFrameTime < spikeTime && elapsedUpdateFrameTime > spikeTime
+
+            displayedFrameTime = Interpolation.dampContinuously(
+                displayedFrameTime,
+                elapsedUpdateFrameTime,
+                if (hasUpdateSpike) 0f else dampTime,
+                elapsedUpdateFrameTime
             )
+
+            displayedFpsCount = if (hasUpdateSpike) {
+                // Show spike time using raw elapsed value, to account for `framesPerSecond` being so averaged spike frames
+                // do not show.
+                1f / elapsedUpdateFrameTime
+            } else {
+                Interpolation.dampContinuously(
+                    displayedFpsCount,
+                    updateClock.framesPerSecond,
+                    dampTime,
+                    updateClock.timeInfo.elapsed
+                )
+            }
+
+            // Force update if we are below the target by a certain threshold.
+            val hasSignificantChanges = aimRatesChanged || hasUpdateSpike || displayedFpsCount < aimFPS * 0.6f
+
+            timeSinceLastUpdate += updateClock.timeInfo.elapsed
+
+            if (!hasSignificantChanges && timeSinceLastUpdate < updateInterval) {
+                return
+            }
+
+            val displayedFps = displayedFpsCount.roundToInt()
+            val isHighPrecision = displayedFrameTime < 0.01f
+            val displayedMs = displayedFrameTime * 1000
+
+            val roundedFrameTime = if (isHighPrecision) {
+                (displayedMs * 10).roundToInt() / 10f
+            } else {
+                displayedMs.roundToInt().toFloat()
+            }
+
+            if (!hasSignificantChanges && displayedFps == lastDisplayedFps && roundedFrameTime == lastDisplayedFrameTime) {
+                return
+            }
+
+            timeSinceLastUpdate = 0f
+            lastDisplayedFps = displayedFps
+            lastDisplayedFrameTime = roundedFrameTime
+
+            stringBuilder.setLength(0)
+
+            formatter.format(
+                "%.${if (isHighPrecision) "1" else "0"}f ms | %d FPS",
+                displayedMs,
+                displayedFps
+            )
+
+            text = stringBuilder.toString()
+
+            updateColor()
+        } finally {
+            super.onManagedUpdate(deltaTimeSec)
         }
-
-        // Force update if we are below the target by a certain threshold.
-        val hasSignificantChanges = aimRatesChanged || hasUpdateSpike || displayedFpsCount < aimFPS * 0.6f
-
-        timeSinceLastUpdate += clock.timeInfo.elapsed
-
-        if (!hasSignificantChanges && timeSinceLastUpdate < updateInterval) {
-            return
-        }
-
-        val displayedFps = displayedFpsCount.roundToInt()
-        val isHighPrecision = displayedFrameTime < 0.01f
-        val displayedMs = displayedFrameTime * 1000
-
-        val roundedFrameTime = if (isHighPrecision) {
-            (displayedMs * 10).roundToInt() / 10f
-        } else {
-            displayedMs.roundToInt().toFloat()
-        }
-
-        if (!hasSignificantChanges && displayedFps == lastDisplayedFps && roundedFrameTime == lastDisplayedFrameTime) {
-            return
-        }
-
-        timeSinceLastUpdate = 0f
-        lastDisplayedFps = displayedFps
-        lastDisplayedFrameTime = roundedFrameTime
-
-        stringBuilder.setLength(0)
-
-        formatter.format(
-            "%.${if (isHighPrecision) "1" else "0"}f ms | %d FPS",
-            displayedMs,
-            displayedFps
-        )
-
-        text = stringBuilder.toString()
-
-        updateColor()
-        setPosition(Config.getRES_WIDTH() - widthScaled - 5, Config.getRES_HEIGHT() - heightScaled - 10)
     }
 
     private fun updateAimFPS(): Boolean {
         val refreshRate = getGlobal().mainActivity.refreshRate
 
-        val newAimFPS = if (clock.throttling && clock.maximumUpdateHz > 0) {
-            min(clock.maximumUpdateHz, refreshRate)
+        val newAimFPS = if (updateClock.throttling && updateClock.maximumUpdateHz > 0) {
+            min(updateClock.maximumUpdateHz, refreshRate)
         } else {
             refreshRate
         }

--- a/src/com/osudroid/ui/v1/LoadingBadgeFragment.kt
+++ b/src/com/osudroid/ui/v1/LoadingBadgeFragment.kt
@@ -1,9 +1,16 @@
 package com.osudroid.ui.v1
 
 import android.view.View
+import android.widget.LinearLayout
+import android.widget.RelativeLayout
 import android.widget.TextView
+import androidx.core.view.updateLayoutParams
 import com.edlplan.ui.fragment.BaseFragment
 import com.google.android.material.progressindicator.CircularProgressIndicator
+import com.osudroid.ui.FPSCounter
+import com.reco1l.toolkt.android.dp
+import kotlin.math.roundToInt
+import ru.nsu.ccfit.zuev.osu.Config
 import ru.nsu.ccfit.zuev.osuplus.R
 
 class LoadingBadgeFragment : BaseFragment() {
@@ -57,6 +64,12 @@ class LoadingBadgeFragment : BaseFragment() {
     }
 
     override fun onLoadView() {
+        findViewById<LinearLayout>(R.id.container)!!.updateLayoutParams<RelativeLayout.LayoutParams> {
+            val fpsHeight = if (Config.isShowFPS()) FPSCounter.instance?.height?.toInt() ?: 0 else 0
+
+            bottomMargin = 16f.dp.roundToInt() + fpsHeight
+        }
+
         progressView = findViewById(R.id.progress)!!
         messageView = findViewById(R.id.message)!!
         textView = findViewById(R.id.text)!!

--- a/src/com/osudroid/ui/v1/LoadingBadgeFragment.kt
+++ b/src/com/osudroid/ui/v1/LoadingBadgeFragment.kt
@@ -7,10 +7,10 @@ import android.widget.TextView
 import androidx.core.view.updateLayoutParams
 import com.edlplan.ui.fragment.BaseFragment
 import com.google.android.material.progressindicator.CircularProgressIndicator
-import com.osudroid.ui.FPSCounter
 import com.reco1l.toolkt.android.dp
 import kotlin.math.roundToInt
 import ru.nsu.ccfit.zuev.osu.Config
+import ru.nsu.ccfit.zuev.osu.ResourceManager
 import ru.nsu.ccfit.zuev.osuplus.R
 
 class LoadingBadgeFragment : BaseFragment() {
@@ -65,7 +65,17 @@ class LoadingBadgeFragment : BaseFragment() {
 
     override fun onLoadView() {
         findViewById<LinearLayout>(R.id.container)!!.updateLayoutParams<RelativeLayout.LayoutParams> {
-            val fpsHeight = if (Config.isShowFPS()) FPSCounter.instance?.height?.toInt() ?: 0 else 0
+            var fpsHeight = 0
+
+            if (Config.isShowFPS()) {
+                val font = ResourceManager.getInstance().getFont("smallFont")
+
+                if (font != null) {
+                    val scale = resources.displayMetrics.widthPixels.toFloat() / Config.getRES_WIDTH()
+
+                    fpsHeight = ((font.lineHeight + 4f) * scale).roundToInt()
+                }
+            }
 
             bottomMargin = 16f.dp.roundToInt() + fpsHeight
         }

--- a/src/com/reco1l/andengine/UIEngine.kt
+++ b/src/com/reco1l/andengine/UIEngine.kt
@@ -20,17 +20,7 @@ import org.anddev.andengine.engine.camera.Camera
 
 class UIEngine(val context: Activity, options: EngineOptions) : Engine(options),
     IClockProvider<ThrottledFrameClock> {
-    /**
-     * The clock used for the update thread.
-     */
-    val updateClock = ThrottledFrameClock()
-
-    /**
-     * The clock used for the draw (GL) thread.
-     */
-    val drawClock = ThrottledFrameClock()
-
-    override val clock = updateClock
+    override val clock = ThrottledFrameClock()
 
     /**
      * The global HUD used for overlays (menus, dialogs, etc).
@@ -77,8 +67,6 @@ class UIEngine(val context: Activity, options: EngineOptions) : Engine(options),
 
 
     override fun onDrawScene(pGL: GL10) {
-        drawClock.processFrame()
-
         val focusedEntity = focusedEntity
 
         if (focusedEntity != null) {
@@ -205,9 +193,9 @@ class UIEngine(val context: Activity, options: EngineOptions) : Engine(options),
     }
 
     override fun onUpdate(pNanosecondsElapsed: Long) {
-        updateClock.processFrame()
+        clock.processFrame()
 
-        super.onUpdate((updateClock.elapsedFrameTime * 1e9).toLong())
+        super.onUpdate((clock.elapsedFrameTime * 1e9).toLong())
     }
 
     override fun setScene(scene: Scene?) {

--- a/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
+++ b/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
@@ -42,6 +42,7 @@ import com.google.firebase.crashlytics.FirebaseCrashlytics;
 import com.osudroid.BuildSettings;
 import com.osudroid.beatmaps.BeatmapCache;
 import com.osudroid.debug.DebugPlaygroundScene;
+import com.osudroid.ui.FPSCounter;
 import com.osudroid.ui.v2.GameLoaderScene;
 import com.osudroid.utils.Execution;
 import com.reco1l.andengine.UIEngine;
@@ -306,9 +307,12 @@ public class MainActivity extends BaseGameActivity implements
 
     @Override
     public Scene onLoadScene() {
+        UIEngine.getCurrent().getOverlay().attachChild(new FPSCounter());
+
         if (BuildSettings.DEBUG_PLAYGROUND) {
             return DebugPlaygroundScene.INSTANCE;
         }
+
         return SplashScene.INSTANCE.getScene();
     }
 

--- a/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
+++ b/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
@@ -307,8 +307,6 @@ public class MainActivity extends BaseGameActivity implements
 
     @Override
     public Scene onLoadScene() {
-        UIEngine.getCurrent().getOverlay().attachChild(new FPSCounter());
-
         if (BuildSettings.DEBUG_PLAYGROUND) {
             return DebugPlaygroundScene.INSTANCE;
         }
@@ -320,6 +318,7 @@ public class MainActivity extends BaseGameActivity implements
     public void onLoadComplete() {
         Execution.async(() -> {
             GlobalManager.getInstance().init();
+            Execution.updateThread(() -> UIEngine.getCurrent().getOverlay().attachChild(new FPSCounter()));
             analytics.logEvent(FirebaseAnalytics.Event.APP_OPEN, null);
             GlobalManager.getInstance().setLoadingProgress(50);
             checkNewSkins();

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -77,7 +77,6 @@ import com.osudroid.difficulty.calculator.StandardPerformanceCalculationParamete
 import com.osudroid.game.GameplayHitSampleInfo;
 import com.osudroid.math.Interpolation;
 import com.osudroid.mods.*;
-import com.osudroid.ui.FPSCounter;
 import com.osudroid.utils.ModHashMap;
 import com.osudroid.utils.ModUtils;
 
@@ -1279,12 +1278,6 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
             playname = Multiplayer.player.getTeam().toString();
         }
         stat.setPlayerName(playname);
-
-        var counterTextFont = ResourceManager.getInstance().getFont("smallFont");
-
-        if (Config.isShowFPS()) {
-            hud.attachChild(new FPSCounter(counterTextFont));
-        }
 
         breakAnimator = new BreakAnimator(fgScene, stat, hud);
 


### PR DESCRIPTION
This PR reworks `FPSCounter` to use the modern `UIText`. In addition to that, it now always displays regardless of where you are (aside from settings, since it's a fragment).

Padding was chosen to not clash with the default gameplay HUD layout.

Partially reverts #631 due to lockstep model in threading but keeps frame time in the counter.