### PR TITLE
Add replay playback controls

### DIFF
--- a/src/com/osudroid/game/replay/ReplayPlaybackControl.kt
+++ b/src/com/osudroid/game/replay/ReplayPlaybackControl.kt
@@ -1,0 +1,84 @@
+package com.osudroid.game.replay
+
+import com.reco1l.andengine.Anchor
+import com.reco1l.andengine.iconButton
+import com.reco1l.andengine.linearContainer
+import com.reco1l.andengine.textButton
+import com.reco1l.andengine.ui.UICard
+import com.reco1l.andengine.ui.form.FormSlider
+import com.reco1l.framework.math.Vec4
+import java.text.DecimalFormat
+import ru.nsu.ccfit.zuev.osu.ResourceManager
+
+/**
+ * Controls playback of gameplay when replaying.
+ */
+class ReplayPlaybackControl : UICard() {
+    /**
+     * The rate at which gameplay should progress.
+     */
+    var rate = 1f
+        private set
+
+    /**
+     * Called when the user presses the play/pause button. The argument is `true` when pausing, `false` when resuming.
+     */
+    var onPauseToggle: ((Boolean) -> Unit)? = null
+
+    private val rateFormatter = DecimalFormat("0.00x")
+
+    init {
+        val resourceManager = ResourceManager.getInstance()
+
+        width = FillParent
+        title = "Playback"
+
+        content.apply {
+            val slider = FormSlider().apply {
+                label = "Playback speed"
+                control.min = 0.05f
+                control.max = 2f
+                value = rate
+                defaultValue = rate
+                valueFormatter = { rateFormatter.format(it) }
+                onValueChanged = { rate = it }
+            }
+
+            +slider
+
+            linearContainer {
+                spacing = 10f
+                padding = Vec4(0f, 16f)
+                anchor = Anchor.TopCenter
+                origin = Anchor.TopCenter
+
+                fun addStepButton(step: Float) = textButton {
+                    text = "%+.2f".format(step)
+                    height = 42f
+                    padding = Vec4(12f, 0f)
+                    onActionUp = { slider.value += step }
+                }
+
+                addStepButton(-0.05f)
+                addStepButton(-0.01f)
+
+                iconButton {
+                    height = 42f
+                    padding = Vec4(12f, 0f)
+                    icon = resourceManager.getTexture("music_pause")
+
+                    var isPlaybackPaused = false
+
+                    onActionUp = {
+                        isPlaybackPaused = !isPlaybackPaused
+                        icon = resourceManager.getTexture(if (isPlaybackPaused) "music_play" else "music_pause")
+                        onPauseToggle?.invoke(isPlaybackPaused)
+                    }
+                }
+
+                addStepButton(0.01f)
+                addStepButton(0.05f)
+            }
+        }
+    }
+}

--- a/src/com/osudroid/game/replay/ReplayPlaybackControl.kt
+++ b/src/com/osudroid/game/replay/ReplayPlaybackControl.kt
@@ -21,6 +21,12 @@ class ReplayPlaybackControl : UICard() {
         private set
 
     /**
+     * Whether the user has paused playback via the play/pause button.
+     */
+    var isPlaybackPaused = false
+        private set
+
+    /**
      * Called when the user presses the play/pause button. The argument is `true` when pausing, `false` when resuming.
      */
     var onPauseToggle: ((Boolean) -> Unit)? = null
@@ -66,8 +72,6 @@ class ReplayPlaybackControl : UICard() {
                     height = 42f
                     padding = Vec4(12f, 0f)
                     icon = resourceManager.getTexture("music_pause")
-
-                    var isPlaybackPaused = false
 
                     onActionUp = {
                         isPlaybackPaused = !isPlaybackPaused

--- a/src/com/osudroid/game/replay/ReplaySettingsPanel.kt
+++ b/src/com/osudroid/game/replay/ReplaySettingsPanel.kt
@@ -1,0 +1,132 @@
+package com.osudroid.game.replay
+
+import com.osudroid.math.Precision
+import com.reco1l.andengine.Anchor
+import com.reco1l.andengine.Axes
+import com.reco1l.andengine.UIEngine
+import com.reco1l.andengine.container.Orientation
+import com.reco1l.andengine.container.UIContainer
+import com.reco1l.andengine.container.UILinearContainer
+import com.reco1l.andengine.container.UIScrollableContainer
+import com.reco1l.andengine.linearContainer
+import com.reco1l.andengine.shape.UIBox
+import com.reco1l.andengine.text
+import com.reco1l.framework.Color4
+import com.reco1l.framework.math.Vec4
+import org.anddev.andengine.input.touch.TouchEvent
+import ru.nsu.ccfit.zuev.osu.ResourceManager
+
+/**
+ * A panel that contains settings for replay playback. Can be expanded and collapsed by tapping the button on the left.
+ */
+class ReplaySettingsPanel : UIContainer() {
+    lateinit var playbackControl: ReplayPlaybackControl
+        private set
+
+    private val isExpanded
+        get() = Precision.almostEquals(x, 0f)
+
+    private val elementContainer = UIScrollableContainer().apply {
+        x = BUTTON_WIDTH
+
+        scrollAxes = Axes.Y
+        width = PANEL_WIDTH
+        height = FillParent
+        showVerticalIndicator = false
+
+        linearContainer {
+            width = FillParent
+            spacing = 20f
+            padding = Vec4(0f, 20f)
+            orientation = Orientation.Vertical
+
+            addControls()
+        }
+    }
+
+    init {
+        x = PANEL_WIDTH
+        height = FillParent
+        anchor = Anchor.TopRight
+        origin = Anchor.TopRight
+        alpha = 0.5f
+
+        clock = UIEngine.current.clock
+        processCustomClock = false
+
+        +ReplaySettingsPanelButton()
+        +elementContainer
+    }
+
+    fun expand() {
+        if (isExpanded) {
+            return
+        }
+
+        elementContainer.isVisible = true
+
+        clearEntityModifiers()
+        moveToX(0f, 0.2f)
+        fadeIn(0.2f)
+    }
+
+    fun collapse() {
+        if (!isExpanded) {
+            return
+        }
+
+        clearEntityModifiers()
+        moveToX(PANEL_WIDTH, 0.2f)
+        fadeTo(0.5f, 0.2f).after { elementContainer.isVisible = false }
+    }
+
+    private fun UILinearContainer.addControls() {
+        playbackControl = ReplayPlaybackControl()
+        +playbackControl
+    }
+
+    private inner class ReplaySettingsPanelButton : UIContainer() {
+        init {
+            background = UIBox().apply {
+                cornerRadius = BUTTON_RADIUS
+                color = Color4(0xFF181825)
+            }
+
+            setSize(BUTTON_WIDTH, 150f)
+            y = -100f
+
+            anchor = Anchor.CenterLeft
+            origin = Anchor.CenterLeft
+
+            text {
+                rotation = -90f
+                anchor = Anchor.Center
+                origin = Anchor.Center
+                font = ResourceManager.getInstance().getFont("smallFont")
+                text = "Settings"
+            }
+        }
+
+        override fun onAreaTouched(event: TouchEvent, localX: Float, localY: Float) = when {
+            event.isActionDown || event.isActionMove -> true
+
+            event.isActionUp -> {
+                if (isExpanded) {
+                    collapse()
+                } else {
+                    expand()
+                }
+
+                false
+            }
+
+            else -> false
+        }
+    }
+
+    companion object {
+        private const val PANEL_WIDTH = 460f
+        private const val BUTTON_WIDTH = 48f
+        private const val BUTTON_RADIUS = 12f
+    }
+}

--- a/src/com/osudroid/game/replay/ReplaySettingsPanel.kt
+++ b/src/com/osudroid/game/replay/ReplaySettingsPanel.kt
@@ -93,7 +93,7 @@ class ReplaySettingsPanel : UIContainer() {
             }
 
             setSize(BUTTON_WIDTH, 150f)
-            y = -100f
+            y = -125f
 
             anchor = Anchor.CenterLeft
             origin = Anchor.CenterLeft

--- a/src/com/osudroid/ui/v2/hud/elements/HUDBackButton.kt
+++ b/src/com/osudroid/ui/v2/hud/elements/HUDBackButton.kt
@@ -74,6 +74,13 @@ class HUDBackButton : HUDElement() {
         setSize(SIZE, SIZE)
         alpha = 0.25f
 
+        // The HUD layer may be attached to the beatmap's clock, which can be paused at any time. When that happens,
+        // this back button will never be pressable. For this reason, we use the engine's update clock.
+        // We will not inherit the beatmap clock's rate, but this is fine since the press duration is based on real
+        // time, not game time.
+        clock = UIEngine.current.clock
+        processCustomClock = false
+
         attachChild(frontCircle)
         attachChild(backCircle)
         attachChild(arrow)

--- a/src/com/reco1l/andengine/container/UIScrollableContainer.kt
+++ b/src/com/reco1l/andengine/container/UIScrollableContainer.kt
@@ -139,6 +139,16 @@ open class UIScrollableContainer : UIContainer() {
     //region Indicators
 
     /**
+     * Whether to show the horizontal scroll indicator.
+     */
+    var showHorizontalIndicator = true
+
+    /**
+     * Whether to show the vertical scroll indicator.
+     */
+    var showVerticalIndicator = true
+
+    /**
      * The scroll indicator for the x-axis that shows the current scroll position.
      */
     var horizontalIndicator: UIComponent? = UIBox().apply {
@@ -336,7 +346,7 @@ open class UIScrollableContainer : UIContainer() {
         val verticalIndicator = verticalIndicator
 
         if (verticalIndicator != null) {
-            verticalIndicator.isVisible = scrollAxes == Axes.Both || scrollAxes == Axes.Y
+            verticalIndicator.isVisible = showVerticalIndicator && (scrollAxes == Axes.Both || scrollAxes == Axes.Y)
 
             if (verticalIndicator.alpha > 0f && velocityY == 0f) {
                 verticalIndicator.alpha = (verticalIndicator.alpha - deltaTimeSec * 0.75f).coerceAtLeast(0f)
@@ -353,7 +363,7 @@ open class UIScrollableContainer : UIContainer() {
         val horizontalIndicator = horizontalIndicator
 
         if (horizontalIndicator != null) {
-            horizontalIndicator.isVisible = scrollAxes == Axes.Both || scrollAxes == Axes.X
+            horizontalIndicator.isVisible = showHorizontalIndicator && (scrollAxes == Axes.Both || scrollAxes == Axes.X)
 
             if (horizontalIndicator.alpha > 0f && velocityX == 0f) {
                 horizontalIndicator.alpha = (horizontalIndicator.alpha - deltaTimeSec * 0.75f).coerceAtLeast(0f)

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -26,6 +26,7 @@ import com.edlplan.framework.utils.functionality.SmartIterator;
 import com.osudroid.beatmaps.BeatmapCache;
 import com.osudroid.game.Cursor;
 import com.osudroid.game.CursorEvent;
+import com.osudroid.game.replay.ReplaySettingsPanel;
 import com.osudroid.multiplayer.api.RoomAPI;
 import com.osudroid.beatmaps.DifficultyCalculationManager;
 import com.osudroid.data.BeatmapInfo;
@@ -213,6 +214,8 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
     private PerformanceCalculationParameters performanceCalculationParameters;
     private TimedDifficultyAttributes<DroidDifficultyAttributes>[] droidTimedDifficultyAttributes;
     private TimedDifficultyAttributes<StandardDifficultyAttributes>[] standardTimedDifficultyAttributes;
+
+    private ReplaySettingsPanel replaySettingsPanel;
 
     // Game
 
@@ -1270,6 +1273,33 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
 
         breakAnimator = new BreakAnimator(fgScene, stat, hud);
 
+        if (!startedFromHUDEditor && (GameHelper.isAutoplay() || replaying)) {
+            hud.attachChild(replaySettingsPanel = new ReplaySettingsPanel());
+
+            replaySettingsPanel.getPlaybackControl().setOnPauseToggle(isPaused -> {
+                if (isPaused) {
+                    beatmapClock.stop();
+                    stopLoopingSamples();
+
+                    if (video != null && videoStarted) {
+                        video.pause();
+                    }
+                } else {
+                    if (!beatmapClock.isRunning()) {
+                        beatmapClock.start();
+                    }
+
+                    playLoopingSamples();
+
+                    if (video != null && videoStarted) {
+                        video.play();
+                    }
+                }
+
+                return Unit.INSTANCE;
+            });
+        }
+
         if (Multiplayer.isMultiplayer) {
             RoomAPI.INSTANCE.notifyBeatmapLoaded();
         } else {
@@ -1395,6 +1425,10 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
 
         if (!isGameOver) {
             float currentSpeedMultiplier = ModUtils.calculateRateWithTrackRateMods(rateAdjustingMods, mSecPassed);
+
+            if (replaySettingsPanel != null) {
+                currentSpeedMultiplier *= replaySettingsPanel.getPlaybackControl().getRate();
+            }
 
             if (currentSpeedMultiplier != GameHelper.getSpeedMultiplier()) {
                 GameHelper.setSpeedMultiplier(currentSpeedMultiplier);
@@ -1834,6 +1868,7 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
             objects = null;
             activeObjects.clear();
             expiredObjects.clear();
+            replaySettingsPanel = null;
             breakPeriods = null;
             cursorSprites = null;
             this.playableBeatmap = null;
@@ -2031,6 +2066,7 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
                 expiredObjects.clear();
             }
             breakPeriods = null;
+            replaySettingsPanel = null;
             objects = null;
             timingControlPoints = null;
             effectControlPoints = null;

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -2861,15 +2861,16 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
             return;
         }
 
-        if (video != null && videoStarted) {
-            video.play();
-        }
-
-        if (!beatmapClock.isRunning()) {
+        if (!beatmapClock.isRunning()
+                && (replaySettingsPanel == null || !replaySettingsPanel.getPlaybackControl().isPlaybackPaused())) {
             beatmapClock.start();
-        }
 
-        playLoopingSamples();
+            if (video != null && videoStarted) {
+                video.play();
+            }
+
+            playLoopingSamples();
+        }
     }
 
     public boolean isPaused() {


### PR DESCRIPTION
This adds the ability to alter replay playback speed between 0.05x and 2x of the beatmap's playback rate (multiplicative) as well as pausing the playback.

The settings panel is designed to be able to handle more controls in the future.

<img width="2800" height="1260" alt="image" src="https://github.com/user-attachments/assets/ca00a5be-da5f-4fed-836a-1573ec6a3593" />
<img width="2800" height="1260" alt="image" src="https://github.com/user-attachments/assets/222b83a2-bc24-4875-b5df-4e51d165fdc6" />
