### PR TITLE
Add Autoplay/replay seeking

### DIFF
--- a/src/com/osudroid/game/replay/ReplayPlaybackControl.kt
+++ b/src/com/osudroid/game/replay/ReplayPlaybackControl.kt
@@ -11,11 +11,17 @@ class ReplayPlaybackControl : UICard() {
      */
     val rateControl = ReplayPlaybackRate()
 
+    /**
+     * Controls for seeking.
+     */
+    val seekControl = ReplayPlaybackSeek()
+
     init {
         width = FillParent
         title = "Playback"
 
         content.apply {
+            +seekControl
             +rateControl
         }
     }

--- a/src/com/osudroid/game/replay/ReplayPlaybackControl.kt
+++ b/src/com/osudroid/game/replay/ReplayPlaybackControl.kt
@@ -1,86 +1,22 @@
 package com.osudroid.game.replay
 
-import com.reco1l.andengine.Anchor
-import com.reco1l.andengine.iconButton
-import com.reco1l.andengine.linearContainer
-import com.reco1l.andengine.textButton
 import com.reco1l.andengine.ui.UICard
-import com.reco1l.andengine.ui.form.FormSlider
-import com.reco1l.framework.math.Vec4
-import java.text.DecimalFormat
-import ru.nsu.ccfit.zuev.osu.ResourceManager
 
 /**
  * Controls playback of gameplay when replaying.
  */
 class ReplayPlaybackControl : UICard() {
     /**
-     * The rate at which gameplay should progress.
+     * Controls for playback rate.
      */
-    var rate = 1f
-        private set
-
-    /**
-     * Whether the user has paused playback via the play/pause button.
-     */
-    var isPlaybackPaused = false
-        private set
-
-    /**
-     * Called when the user presses the play/pause button. The argument is `true` when pausing, `false` when resuming.
-     */
-    var onPauseToggle: ((Boolean) -> Unit)? = null
-
-    private val rateFormatter = DecimalFormat("0.00x")
+    val rateControl = ReplayPlaybackRate()
 
     init {
-        val resourceManager = ResourceManager.getInstance()
-
         width = FillParent
         title = "Playback"
 
         content.apply {
-            val slider = FormSlider(rate).apply {
-                label = "Playback speed"
-                control.min = 0.05f
-                control.max = 2f
-                valueFormatter = { rateFormatter.format(it) }
-                onValueChanged = { rate = it }
-            }
-
-            +slider
-
-            linearContainer {
-                spacing = 10f
-                padding = Vec4(0f, 16f)
-                anchor = Anchor.TopCenter
-                origin = Anchor.TopCenter
-
-                fun addStepButton(step: Float) = textButton {
-                    text = "%+.2f".format(step)
-                    height = 42f
-                    padding = Vec4(12f, 0f)
-                    onActionUp = { slider.value += step }
-                }
-
-                addStepButton(-0.05f)
-                addStepButton(-0.01f)
-
-                iconButton {
-                    height = 42f
-                    padding = Vec4(12f, 0f)
-                    icon = resourceManager.getTexture("music_pause")
-
-                    onActionUp = {
-                        isPlaybackPaused = !isPlaybackPaused
-                        icon = resourceManager.getTexture(if (isPlaybackPaused) "music_play" else "music_pause")
-                        onPauseToggle?.invoke(isPlaybackPaused)
-                    }
-                }
-
-                addStepButton(0.01f)
-                addStepButton(0.05f)
-            }
+            +rateControl
         }
     }
 }

--- a/src/com/osudroid/game/replay/ReplayPlaybackRate.kt
+++ b/src/com/osudroid/game/replay/ReplayPlaybackRate.kt
@@ -1,0 +1,54 @@
+package com.osudroid.game.replay
+
+import com.reco1l.andengine.Anchor
+import com.reco1l.andengine.container.Orientation
+import com.reco1l.andengine.container.UILinearContainer
+import com.reco1l.andengine.linearContainer
+import com.reco1l.andengine.textButton
+import com.reco1l.andengine.ui.form.FormSlider
+import com.reco1l.framework.math.Vec4
+import java.text.DecimalFormat
+
+class ReplayPlaybackRate : UILinearContainer() {
+    /**
+     * The rate at which gameplay should progress.
+     */
+    var rate = 1f
+        private set
+
+    private val rateFormatter = DecimalFormat("0.00x")
+
+    init {
+        orientation = Orientation.Vertical
+        width = FillParent
+
+        val slider = FormSlider(rate).apply {
+            label = "Playback speed"
+            control.min = 0.05f
+            control.max = 2f
+            valueFormatter = { rateFormatter.format(it) }
+            onValueChanged = { rate = it }
+        }
+
+        +slider
+
+        linearContainer {
+            spacing = 10f
+            padding = Vec4(0f, 16f)
+            anchor = Anchor.TopCenter
+            origin = Anchor.TopCenter
+
+            fun addStepButton(step: Float) = textButton {
+                text = "%+.2f".format(step)
+                height = 42f
+                padding = Vec4(12f, 0f)
+                onActionUp = { slider.value += step }
+            }
+
+            addStepButton(-0.05f)
+            addStepButton(-0.01f)
+            addStepButton(0.01f)
+            addStepButton(0.05f)
+        }
+    }
+}

--- a/src/com/osudroid/game/replay/ReplayPlaybackSeek.kt
+++ b/src/com/osudroid/game/replay/ReplayPlaybackSeek.kt
@@ -1,0 +1,137 @@
+package com.osudroid.game.replay
+
+import com.reco1l.andengine.Anchor
+import com.reco1l.andengine.container.Orientation
+import com.reco1l.andengine.container.UILinearContainer
+import com.reco1l.andengine.iconButton
+import com.reco1l.andengine.linearContainer
+import com.reco1l.andengine.textButton
+import com.reco1l.andengine.ui.form.FormSlider
+import com.reco1l.framework.math.Vec4
+import java.text.DecimalFormat
+import kotlin.math.abs
+import ru.nsu.ccfit.zuev.osu.ResourceManager
+
+class ReplayPlaybackSeek : UILinearContainer() {
+    /**
+     * Called when the user seeks to a position. The argument is the target time in seconds.
+     */
+    var onSeek: ((Float) -> Unit)? = null
+
+    /**
+     * Whether the user has paused playback via the play/pause button.
+     */
+    var isPlaybackPaused = false
+        private set
+
+    /**
+     * Called when the user presses the play/pause button. The argument is `true` when pausing, `false` when resuming.
+     */
+    var onPauseToggle: ((Boolean) -> Unit)? = null
+
+    private var minDuration = 0f
+    private var totalDuration = 0f
+    private var rawCurrentSeconds = 0f
+    private var isUserDragging = false
+
+    private val secondsFormatter = DecimalFormat("00")
+
+    private val seekBar = FormSlider().apply {
+        label = "Seek"
+        control.min = 0f
+        control.max = 0f
+        showResetButton = false
+
+        valueFormatter = {
+            val seconds = (rawCurrentSeconds - minDuration).toInt()
+            val duration = (totalDuration - minDuration).toInt().coerceAtLeast(0)
+
+            val sAbs = abs(seconds)
+            val sign = if (seconds < 0) "-" else ""
+
+            "$sign${sAbs / 60}:${secondsFormatter.format(sAbs % 60)} / ${duration / 60}:${secondsFormatter.format(duration % 60)}"
+        }
+
+        onValueChanged = {
+            if (isUserDragging) {
+                rawCurrentSeconds = it
+            }
+        }
+
+        control.onStartDragging = { isUserDragging = true }
+
+        control.onStopDragging = {
+            isUserDragging = false
+            onSeek?.invoke(value)
+        }
+    }
+
+    init {
+        orientation = Orientation.Vertical
+        width = FillParent
+
+        +seekBar
+
+        linearContainer {
+            spacing = 10f
+            padding = Vec4(0f, 16f)
+            anchor = Anchor.TopCenter
+            origin = Anchor.TopCenter
+
+            fun addSeekButton(delta: Float) = textButton {
+                text = "%+d s".format(delta.toInt())
+                height = 42f
+                padding = Vec4(12f, 0f)
+                onActionUp = { onSeek?.invoke((seekBar.value + delta).coerceIn(minDuration, totalDuration)) }
+            }
+
+            addSeekButton(-10f)
+            addSeekButton(-1f)
+
+            iconButton {
+                val resourceManager = ResourceManager.getInstance()
+
+                height = 42f
+                padding = Vec4(12f, 0f)
+                icon = resourceManager.getTexture("music_pause")
+
+                onActionUp = {
+                    isPlaybackPaused = !isPlaybackPaused
+                    icon = resourceManager.getTexture(if (isPlaybackPaused) "music_play" else "music_pause")
+                    onPauseToggle?.invoke(isPlaybackPaused)
+                }
+            }
+
+            addSeekButton(1f)
+            addSeekButton(10f)
+        }
+    }
+
+    /**
+     * Updates the seek bar to reflect the current playback position.
+     * Should be called from the game update thread each frame.
+     *
+     * @param currentSeconds The current playback position in seconds.
+     * @param minSeconds The earliest seekable position in seconds (first object's start time).
+     * @param maxSeconds The latest seekable position in seconds (last object's end time).
+     */
+    fun updateSeekPosition(currentSeconds: Float, minSeconds: Float, maxSeconds: Float) {
+        if (isUserDragging) {
+            return
+        }
+
+        minDuration = minSeconds
+        totalDuration = maxSeconds
+        rawCurrentSeconds = currentSeconds
+        seekBar.control.min = minSeconds
+        seekBar.control.max = maxSeconds
+
+        if (currentSeconds < minSeconds) {
+            // During lead-in, the slider stays pinned at min, so its value won't change and
+            // valueFormatter won't be triggered automatically. Force a refresh to update the displayed time.
+            seekBar.onControlValueChanged()
+        } else {
+            seekBar.value = currentSeconds.coerceAtMost(maxSeconds)
+        }
+    }
+}

--- a/src/com/osudroid/game/replay/ReplaySettingsPanel.kt
+++ b/src/com/osudroid/game/replay/ReplaySettingsPanel.kt
@@ -136,7 +136,7 @@ class ReplaySettingsPanel : UIContainer() {
     }
 
     companion object {
-        private const val PANEL_WIDTH = 460f
+        private const val PANEL_WIDTH = 440f
         private const val BUTTON_WIDTH = 48f
         private const val BUTTON_RADIUS = 12f
     }

--- a/src/com/osudroid/game/replay/ReplayVisualSettingsControl.kt
+++ b/src/com/osudroid/game/replay/ReplayVisualSettingsControl.kt
@@ -11,10 +11,24 @@ import ru.nsu.ccfit.zuev.osu.helper.StringTable
  */
 class ReplayVisualSettingsControl : UICard() {
     /**
-     * The background brightness.
+     * The default background brightness.
      */
-    var backgroundBrightness = Config.getBackgroundBrightness()
-        private set
+    var defaultBackgroundBrightness = Config.getBackgroundBrightness()
+        set(value) {
+            field = value
+            brightnessSlider.defaultValue = value * 100
+        }
+
+    private val brightnessSlider = FormSlider(defaultBackgroundBrightness * 100).apply {
+        label = StringTable.get(com.osudroid.resources.R.string.opt_bgbrightness_title)
+        control.min = 0f
+        control.max = 100f
+        valueFormatter = { "${it.roundToInt()}%"}
+        onValueChanged = {
+            defaultBackgroundBrightness = it / 100f
+            onBackgroundBrightnessChanged?.invoke(defaultBackgroundBrightness)
+        }
+    }
 
     /**
      * Called when the background brightness was changed. The argument is the background brightness (from 0 to 1).
@@ -25,17 +39,6 @@ class ReplayVisualSettingsControl : UICard() {
         width = FillParent
         title = "Visual Settings"
 
-        content.apply {
-            +FormSlider(backgroundBrightness * 100).apply {
-                label = StringTable.get(com.osudroid.resources.R.string.opt_bgbrightness_title)
-                control.min = 0f
-                control.max = 100f
-                valueFormatter = { "${it.roundToInt()}%"}
-                onValueChanged = {
-                    backgroundBrightness = it / 100f
-                    onBackgroundBrightnessChanged?.invoke(backgroundBrightness)
-                }
-            }
-        }
+        content += brightnessSlider
     }
 }

--- a/src/com/osudroid/game/replay/ReplayVisualSettingsControl.kt
+++ b/src/com/osudroid/game/replay/ReplayVisualSettingsControl.kt
@@ -29,10 +29,7 @@ class ReplayVisualSettingsControl : UICard() {
         control.min = 0f
         control.max = 100f
         valueFormatter = { "${it.roundToInt()}%"}
-        onValueChanged = {
-            defaultBackgroundBrightness = it / 100f
-            onBackgroundBrightnessChanged?.invoke(defaultBackgroundBrightness)
-        }
+        onValueChanged = { onBackgroundBrightnessChanged?.invoke(it / 100f) }
     }
 
     /**

--- a/src/com/osudroid/game/replay/ReplayVisualSettingsControl.kt
+++ b/src/com/osudroid/game/replay/ReplayVisualSettingsControl.kt
@@ -12,11 +12,16 @@ import ru.nsu.ccfit.zuev.osu.helper.StringTable
 class ReplayVisualSettingsControl : UICard() {
     /**
      * The default background brightness.
+     *
+     * Note that setting this value will also override the control's value.
      */
     var defaultBackgroundBrightness = Config.getBackgroundBrightness()
         set(value) {
             field = value
-            brightnessSlider.defaultValue = value * 100
+            val sliderValue = value * 100
+
+            brightnessSlider.defaultValue = sliderValue
+            brightnessSlider.value = sliderValue
         }
 
     private val brightnessSlider = FormSlider(defaultBackgroundBrightness * 100).apply {

--- a/src/com/osudroid/ui/v2/game/FollowPoints.kt
+++ b/src/com/osudroid/ui/v2/game/FollowPoints.kt
@@ -48,9 +48,17 @@ object FollowPointConnection {
 
     private val expire = OnModifierFinished { fp ->
         updateThread {
+            val poolable = fp as IPoolable
+
+            // `clearAll` may have already recycled this follow point, so we need to check if it's already recycled
+            // before releasing it again.
+            if (poolable.isRecycled) {
+                return@updateThread
+            }
+
             fp.detachSelf()
             fp.reset()
-            pool.release(fp as IPoolable)
+            pool.release(poolable)
         }
     }
 
@@ -67,6 +75,20 @@ object FollowPointConnection {
 
             width = newWidth
             height = newHeight
+        }
+    }
+
+    @JvmStatic
+    fun clearAll(scene: UIScene) {
+        for (i in scene.childCount - 1 downTo 0) {
+            val child = scene.getChild(i)
+
+            if (child is PoolableFollowPoint || child is PoolableAnimatedFollowPoint) {
+                child.clearEntityModifiers()
+                child.detachSelf()
+                child.reset()
+                pool.release(child as IPoolable)
+            }
         }
     }
 

--- a/src/ru/nsu/ccfit/zuev/osu/game/BreakAnimator.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/BreakAnimator.java
@@ -79,6 +79,29 @@ public class BreakAnimator extends GameObject {
         return isover;
     }
 
+    public void reset() {
+        isbreak = false;
+        over = false;
+        length = 0;
+        time = 0;
+
+        if (mark != null) {
+            mark.detachSelf();
+            mark = null;
+        }
+
+        if (passfail != null) {
+            passfail.detachSelf();
+            passfail = null;
+        }
+
+        for (final Sprite sp : arrows) {
+            sp.detachSelf();
+        }
+
+        resumeBgFade();
+    }
+
     public void init(final float length) {
         if (this.length > 0 && time < this.length) {
             return;

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -3921,37 +3921,39 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
     }
 
     private void applySpinnerResult(Spinner spinner, @Nullable Replay.ReplayObjectData data, boolean endCombo) {
-        if (data != null) {
-            // Spinner accuracy encoding: totalSpins * 4 + resultCode.
-            int totalSpins = (data.accuracy & 0xFFFF) >> 2;
+        float duration = (float) spinner.getDuration() / 1000;
+        float needRotations = (2 + 2 * playableBeatmap.getDifficulty().od / 10f) * duration;
 
-            for (int s = 0; s < totalSpins; s++) {
-                stat.registerHit(1000, false, false);
-            }
+        if (duration < 0.05f) {
+            needRotations = 0.1f;
+        }
+
+        int preClear;
+        int bonus;
+
+        if (data != null) {
+            // data.accuracy = totalSpins * 4 + resultCode, where totalSpins = fullRotations (pre-clear, 100 pts each)
+            // + (bonusScoreCounter - 1) (bonus, 1000 pts each). Split by needRotations to award the correct amounts.
+            int totalSpins = (data.accuracy & 0xFFFF) >> 2;
+            preClear = Math.min(totalSpins, (int) Math.ceil(needRotations) - 1);
+            bonus = totalSpins - preClear;
         } else {
             // Autoplay always clears the spinner. Reconstruct the pre-clear (100 pts each) and bonus (1000 pts each)
             // rotation split from the spinner's parameters.
-            float duration = (float) spinner.getDuration() / 1000;
-            float requiredRotations = (2 + 2 * playableBeatmap.getDifficulty().od / 10f) * duration;
-
-            if (duration < 0.05f) {
-                requiredRotations = 0.1f;
-            }
-
-            // On clear, rotations is reset to only the excess beyond requiredRotations (replay version 8+ behavior,
-            // which always applies for Autoplay). Therefore, ceil(requiredRotations) - 1 rotations are pre-clear and
-            // floor(totalRotations - requiredRotations) are bonus rotations.
+            // On clear, rotations is reset to only the excess beyond needRotations. Therefore, ceil(needRotations) - 1
+            // rotations are pre-clear and floor(totalRotations - needRotations) are bonus rotations.
             float totalRotations = 5f * duration;
-            int preClear = (int) Math.ceil(requiredRotations) - 1;
-            int bonus = Math.max(0, (int)(totalRotations - requiredRotations));
 
-            for (int s = 0; s < preClear; s++) {
-                stat.registerSpinnerHit();
-            }
+            preClear = (int) Math.ceil(needRotations) - 1;
+            bonus = Math.max(0, (int)(totalRotations - needRotations));
+        }
 
-            for (int s = 0; s < bonus; s++) {
-                stat.registerHit(1000, false, false);
-            }
+        for (int s = 0; s < preClear; s++) {
+            stat.registerSpinnerHit();
+        }
+
+        for (int s = 0; s < bonus; s++) {
+            stat.registerHit(1000, false, false);
         }
 
         applyCircleResult(data, endCombo);

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -1357,6 +1357,10 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
         applyPlayfieldSizeScale();
         applyBackground();
 
+        if (replaySettingsPanel != null) {
+            replaySettingsPanel.getVisualSettingsControl().setDefaultBackgroundBrightness(Config.getBackgroundBrightness());
+        }
+
         if (!isHUDEditorMode && !Config.isShowScoreboard()) {
             hud.detachChild(e -> e instanceof HUDLeaderboard);
         }

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -3611,7 +3611,18 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
 
         // Detach any lingering hit effects from the gameplay scene.
         for (int i = mgScene.getChildCount() - 1; i >= 0; --i) {
-            mgScene.getChild(i).detachSelf();
+            var child = mgScene.getChild(i);
+
+            if (child instanceof UISprite sprite) {
+                // Hit effects need to be pooled, so we cannot directly detach.
+                // finishModifiers() fires the effect's fade-out callback, which schedules putEffect() so the GameEffect
+                // wrapper is returned to the pool rather than orphaned.
+                sprite.finishModifiers();
+            }
+
+            // We detach directly so that the next frame is not orphaned with hit effects that were not detached (since
+            // GameEffect's callback is scheduled for the next update tick).
+            child.detachSelf();
         }
 
         // Remove follow points spawned for objects before the seek point.

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -63,6 +63,8 @@ import com.osudroid.beatmaps.hitobjects.HitCircle;
 import com.osudroid.beatmaps.hitobjects.HitObject;
 import com.osudroid.beatmaps.hitobjects.Slider;
 import com.osudroid.beatmaps.hitobjects.Spinner;
+import com.osudroid.beatmaps.hitobjects.sliderobject.SliderRepeat;
+import com.osudroid.beatmaps.hitobjects.sliderobject.SliderTick;
 import com.osudroid.beatmaps.sections.BeatmapDifficulty;
 import com.osudroid.beatmaps.timings.BreakPeriod;
 import com.osudroid.beatmaps.timings.EffectControlPoint;
@@ -1276,7 +1278,9 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
         if (!startedFromHUDEditor && (GameHelper.isAutoplay() || replaying)) {
             hud.attachChild(replaySettingsPanel = new ReplaySettingsPanel());
 
-            replaySettingsPanel.getPlaybackControl().setOnPauseToggle(isPaused -> {
+            var seekControl = replaySettingsPanel.getPlaybackControl().getSeekControl();
+
+            seekControl.setOnPauseToggle(isPaused -> {
                 if (isPaused) {
                     beatmapClock.stop();
                     stopLoopingSamples();
@@ -1307,6 +1311,17 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
                     dimRectangle.setAlpha(1f - brightness);
                 }
 
+                return Unit.INSTANCE;
+            });
+
+            seekControl.updateSeekPosition(
+                beatmapClock.getCurrentTime(),
+                (float) (objects[0].startTime / 1000),
+                (float) (objects[objects.length - 1].getEndTime() / 1000)
+            );
+
+            seekControl.setOnSeek(targetTime -> {
+                Execution.updateThread(() -> seekTo(targetTime));
                 return Unit.INSTANCE;
             });
         }
@@ -1442,7 +1457,7 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
             float currentSpeedMultiplier = ModUtils.calculateRateWithTrackRateMods(rateAdjustingMods, mSecPassed);
 
             if (replaySettingsPanel != null) {
-                currentSpeedMultiplier *= replaySettingsPanel.getPlaybackControl().getRate();
+                currentSpeedMultiplier *= replaySettingsPanel.getPlaybackControl().getRateControl().getRate();
             }
 
             if (currentSpeedMultiplier != GameHelper.getSpeedMultiplier()) {
@@ -1450,6 +1465,14 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
                 GlobalManager.getInstance().getSongService().setSpeed(currentSpeedMultiplier);
                 beatmapClock.setRate(currentSpeedMultiplier);
             }
+        }
+
+        if (replaySettingsPanel != null) {
+            replaySettingsPanel.getPlaybackControl().getSeekControl().updateSeekPosition(
+                beatmapClock.getCurrentTime(),
+                (float) (objects[0].startTime / 1000),
+                (float) (objects[objects.length - 1].getEndTime() / 1000)
+            );
         }
 
         if (storyboardSprite != null && storyboardSprite.hasParent()) {
@@ -2877,7 +2900,7 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
         }
 
         if (!beatmapClock.isRunning()
-                && (replaySettingsPanel == null || !replaySettingsPanel.getPlaybackControl().isPlaybackPaused())) {
+                && (replaySettingsPanel == null || !replaySettingsPanel.getPlaybackControl().getSeekControl().isPlaybackPaused())) {
             beatmapClock.start();
 
             if (video != null && videoStarted) {
@@ -3545,4 +3568,388 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
 
         return estimatedMaxActiveObjects;
     }
+
+    //region Seeking
+
+    private void seekTo(float targetTimeSeconds) {
+        var playableBeatmap = this.playableBeatmap;
+
+        if (playableBeatmap == null || objects == null) {
+            return;
+        }
+
+        float clampedTime = FMath.clamp(
+            targetTimeSeconds,
+            (float) (objects[0].startTime / 1000),
+            (float) (objects[objects.length - 1].getEndTime() / 1000)
+        );
+
+        float targetMs = clampedTime * 1000;
+
+        // Force-expire all active objects (detach from scene and return to pool).
+        for (int i = 0, size = activeObjects.size(); i < size; ++i) {
+            var obj = activeObjects.get(i);
+
+            if (processedExpiredObjects.add(obj)) {
+                obj.onExpire();
+            }
+        }
+
+        // Also expire objects that were queued for cleanup but not yet processed.
+        for (int i = 0, size = expiredObjects.size(); i < size; ++i) {
+            var obj = expiredObjects.get(i);
+
+            if (processedExpiredObjects.add(obj)) {
+                obj.onExpire();
+            }
+        }
+
+        activeObjects.clear();
+        expiredObjects.clear();
+        processedExpiredObjects.clear();
+        judgeableObject = null;
+
+        // Detach any lingering hit effects from the gameplay scene.
+        for (int i = mgScene.getChildCount() - 1; i >= 0; --i) {
+            mgScene.getChild(i).detachSelf();
+        }
+
+        // Remove follow points spawned for objects before the seek point.
+        FollowPointConnection.clearAll(bgScene);
+
+        // Reset spawn counters.
+        objectIndex = 0;
+        sliderIndex = 0;
+        lastObjectId = -1;
+        gameStarted = false;
+        leadOut = 0;
+        comboWasMissed = false;
+        comboWas100 = false;
+        failcount = 0;
+        isGameOver = false;
+        hasFailed = false;
+
+        // Reset auto cursor modifiers.
+        if (autoCursor != null) {
+            autoCursor.clearEntityModifiers();
+        }
+
+        // Clear pending cursor events.
+        for (int i = 0; i < cursors.length; ++i) {
+            var cursor = cursors[i];
+
+            if (cursor != null) {
+                cursor.reset(SystemClock.uptimeMillis(), 0);
+                cursor.latestProcessedDownEventIndex = 0;
+                cursor.latestProcessedEventIndex = 0;
+            }
+        }
+
+        // Advance timing and effect control points to the target time.
+        timingControlPointIndex = 0;
+        effectControlPointIndex = 0;
+
+        while (timingControlPointIndex + 1 < timingControlPoints.length && timingControlPoints[timingControlPointIndex + 1].time <= targetMs) {
+            timingControlPointIndex++;
+        }
+
+        while (effectControlPointIndex + 1 < effectControlPoints.length && effectControlPoints[effectControlPointIndex + 1].time <= targetMs) {
+            effectControlPointIndex++;
+        }
+
+        activeTimingPoint = timingControlPoints[timingControlPointIndex];
+        activeEffectPoint = effectControlPoints[effectControlPointIndex];
+
+        // Advance break period index past fully elapsed breaks.
+        breakPeriodIndex = 0;
+
+        if (breakPeriods != null) {
+            while (breakPeriodIndex < breakPeriods.length && breakPeriods[breakPeriodIndex].endTime <= targetMs) {
+                breakPeriodIndex++;
+            }
+        }
+
+        // Reset replay cursor movement indices.
+        if (replaying && replay.cursorIndex != null) {
+            Arrays.fill(replay.cursorIndex, 0);
+            Arrays.fill(replay.lastMoveIndex, -1);
+        }
+
+        // Reconstruct scoring state up to the seek target.
+        stat.reset();
+        reconstructStatAtTime(targetMs);
+
+        // Reset any in-progress break animation, then re-initialize if the seek target is inside a break.
+        breakAnimator.reset();
+
+        if (breakPeriods != null && breakPeriodIndex < breakPeriods.length) {
+            var bp = breakPeriods[breakPeriodIndex];
+
+            if (bp.startTime <= targetMs && targetMs < bp.endTime) {
+                gameStarted = false;
+                float remainingDuration = (float) ((bp.endTime - targetMs) / 1000.0);
+                breakAnimator.init(remainingDuration);
+                hud.onBreakStateChange(true);
+            } else {
+                hud.onBreakStateChange(false);
+            }
+        } else {
+            hud.onBreakStateChange(false);
+        }
+
+        hud.onNoteHit(stat);
+
+        // Seek the beatmap clock (also seeks the audio source).
+        beatmapClock.seek(clampedTime);
+
+        // Seek video.
+        if (videoEnabled && video != null) {
+            video.seekTo(Math.max(0, (int) ((clampedTime - videoOffset) * 1000)));
+        }
+    }
+
+    private void reconstructStatAtTime(float targetMs) {
+        var playableBeatmap = this.playableBeatmap;
+
+        if (playableBeatmap == null || objects == null) {
+            return;
+        }
+
+        var difficulty = playableBeatmap.getDifficulty();
+        int localTimingIdx = 0;
+        int localBreakIdx = 0;
+        double segStartMs = Double.MIN_VALUE;
+        var objectData = replaying ? replay.objectData : null;
+
+        for (int i = 0; i < objects.length; i++) {
+            var obj = objects[i];
+
+            double judgementTimeMs = getJudgementTimeMs(i, obj, objectData);
+
+            if (judgementTimeMs > targetMs) {
+                break;
+            }
+
+            // Advance local timing point index to this object's position.
+            while (localTimingIdx + 1 < timingControlPoints.length && timingControlPoints[localTimingIdx + 1].time <= obj.startTime) {
+                localTimingIdx++;
+            }
+
+            // Simulate HP drain between the previous object's lifetime start and this one's.
+            if (i > 0 && gameStarted) {
+                var prevObj = objects[i - 1];
+
+                double msPerBeat = timingControlPoints[localTimingIdx].msPerBeat;
+                double distToNextObject = Math.max(obj.startTime - prevObj.startTime, msPerBeat / 2) / 1000;
+
+                double drainRate = difficulty.hp > 0 && distToNextObject > 0
+                        ? 1 + difficulty.hp / (2 * distToNextObject)
+                        : 0.375;
+
+                double segEndMs = obj.startTime - obj.timePreempt;
+
+                // Advance past breaks that fully precede the current segment.
+                if (breakPeriods != null) {
+                    while (localBreakIdx < breakPeriods.length && breakPeriods[localBreakIdx].endTime <= segStartMs) {
+                        localBreakIdx++;
+                    }
+                }
+
+                double effectiveSecs = calculateEffectiveDrainDuration(segStartMs, segEndMs, localBreakIdx);
+
+                stat.changeHp((float) (-drainRate * 0.01 * effectiveSecs));
+
+                if (stat.getHp() <= 0 && stat.canFail) {
+                    if (GameHelper.isEasy() && failcount < 3) {
+                        failcount++;
+                        stat.changeHp(1f);
+                    } else {
+                        return;
+                    }
+                }
+            }
+
+            segStartMs = obj.startTime - obj.timePreempt;
+
+            if (!gameStarted) {
+                gameStarted = true;
+            }
+
+            var data = (objectData != null && i < objectData.length) ? objectData[i] : null;
+
+            boolean endCombo = obj.isLastInCombo();
+
+            if (obj instanceof HitCircle) {
+                applyCircleResult(data, endCombo);
+            } else if (obj instanceof Slider slider) {
+                sliderIndex++;
+                applySliderResult(slider, data, endCombo);
+            } else if (obj instanceof Spinner) {
+                applySpinnerResult(data, endCombo);
+            }
+
+            lastObjectId = i;
+            objectIndex = i + 1;
+        }
+    }
+
+    private double getJudgementTimeMs(int idx, HitObject obj, @Nullable Replay.ReplayObjectData[] objectData) {
+        if (obj instanceof Slider || obj instanceof Spinner) {
+            return obj.getEndTime();
+        }
+
+        // Circle: judged when hit (or miss window expires).
+        if (objectData != null && idx < objectData.length) {
+            var data = objectData[idx];
+
+            if (data != null && data.result != ResultType.MISS.getId()) {
+                return obj.startTime + Math.abs(data.accuracy);
+            }
+        }
+
+        double mehWindow = obj.hitWindow != null ? obj.hitWindow.getMehWindow() : HitWindow.MISS_WINDOW;
+
+        return obj.startTime + mehWindow;
+    }
+
+    private void applyCircleResult(@Nullable Replay.ReplayObjectData data, boolean endCombo) {
+        byte result = data != null ? data.result : ResultType.HIT300.getId();
+
+        if (result == ResultType.MISS.getId()) {
+            comboWasMissed = true;
+            stat.registerHit(0, false, false);
+        } else if (result == ResultType.HIT50.getId()) {
+            stat.registerHit(50, false, false);
+            comboWas100 = true;
+        } else if (result == ResultType.HIT100.getId()) {
+            comboWas100 = true;
+            stat.registerHit(100, endCombo && !comboWasMissed, false);
+        } else {
+            if (endCombo && !comboWasMissed) {
+                stat.registerHit(300, true, !comboWas100);
+            } else {
+                stat.registerHit(300, false, false);
+            }
+        }
+
+        if (endCombo) {
+            comboWas100 = false;
+            comboWasMissed = false;
+        }
+    }
+
+    private void applySliderResult(Slider slider, @Nullable Replay.ReplayObjectData data, boolean endCombo) {
+        byte result = data != null ? data.result : ResultType.HIT300.getId();
+
+        if (result == ResultType.MISS.getId()) {
+            comboWasMissed = true;
+            stat.registerHit(0, false, false);
+
+            if (endCombo) {
+                comboWas100 = false;
+                comboWasMissed = false;
+            }
+
+            return;
+        }
+
+        // Slider head was tracked.
+        stat.registerHit(30, false, false);
+        stat.addSliderHeadHit();
+
+        // Ticks and repeats from tickSet.
+        var nested = slider.getNestedHitObjects();
+
+        // Skip head (index 0) and tail (last index).
+        for (int i = 1, end = nested.size() - 1; i < end; i++) {
+            boolean wasHit = data == null || (data.tickSet != null && data.tickSet.get(i - 1));
+
+            if (!wasHit) {
+                stat.registerHit(0, true, false);
+                continue;
+            }
+
+            var nestedObj = nested.get(i);
+
+            if (nestedObj instanceof SliderTick) {
+                stat.registerHit(10, false, false);
+                stat.addSliderTickHit();
+            } else if (nestedObj instanceof SliderRepeat) {
+                stat.registerHit(30, false, false);
+                stat.addSliderRepeatHit();
+            }
+        }
+
+        // Slider tail: combo is only awarded when the player was tracking at the endpoint.
+        // Unlike circles, the result score reflects ticks hit, not timing accuracy.
+        boolean tailTracked = data == null || (data.tickSet != null && data.tickSet.get(nested.size() - 2));
+        byte tailResult = data != null ? data.result : ResultType.HIT300.getId();
+
+        if (tailResult == ResultType.HIT50.getId()) {
+            comboWas100 = true;
+            stat.registerHit(50, false, false, tailTracked);
+        } else if (tailResult == ResultType.HIT100.getId()) {
+            comboWas100 = true;
+            stat.registerHit(100, endCombo && !comboWasMissed, false, tailTracked);
+        } else {
+            if (endCombo && !comboWasMissed) {
+                stat.registerHit(300, true, !comboWas100, tailTracked);
+            } else {
+                stat.registerHit(300, false, false, tailTracked);
+            }
+        }
+
+        if (endCombo) {
+            comboWas100 = false;
+            comboWasMissed = false;
+        }
+
+        if (tailTracked) {
+            stat.addSliderEndHit();
+        }
+    }
+
+    private void applySpinnerResult(@Nullable Replay.ReplayObjectData data, boolean endCombo) {
+        // Spinner accuracy encoding: totalSpins * 4 + resultCode.
+        int totalSpins = data != null ? (data.accuracy & 0xFFFF) >> 2 : 0;
+
+        for (int s = 0; s < totalSpins; s++) {
+            stat.registerHit(1000, false, false);
+        }
+
+        applyCircleResult(data, endCombo);
+    }
+
+    /**
+     * Returns the effective drain duration in seconds for the segment [startMs, endMs], subtracting any time that falls
+     * within a break period. {@code startBreakIdx} should be the first break period index whose end time is >= startMs
+     * (caller advances this monotonically as segments progress forward in time).
+     */
+    private double calculateEffectiveDrainDuration(double startMs, double endMs, int startBreakIdx) {
+        if (startMs >= endMs) {
+            return 0;
+        }
+
+        double total = endMs - startMs;
+
+        if (breakPeriods != null) {
+            for (int i = startBreakIdx; i < breakPeriods.length; ++i) {
+                var bp = breakPeriods[i];
+
+                if (bp.startTime >= endMs) {
+                    break;
+                }
+
+                double overlap = Math.min(bp.endTime, endMs) - Math.max(bp.startTime, startMs);
+
+                if (overlap > 0) {
+                    total -= overlap;
+                }
+            }
+        }
+
+        return Math.max(0, total) / 1000;
+    }
+
+    //endregion
 }

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -3938,14 +3938,12 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
                 requiredRotations = 0.1f;
             }
 
-            // The clear-transition does not decrement the rotation accumulator, so the triggering rotation persists and
-            // fires as the first bonus on the following frame. Therefore, ceil(requiredRotations) - 1 rotations are
-            // pre-clear and all remaining (totalRotations - preClear) are bonuses. This can overcount by 1 if the
-            // spinner clears on its very last frame and the bonus never fires, but that edge case is unreachable
-            // in practice.
-            int totalRotations = (int) (5f * duration);
-            int preClear = Math.min(totalRotations, (int) Math.ceil(requiredRotations) - 1);
-            int bonus = Math.max(0, totalRotations - preClear);
+            // On clear, rotations is reset to only the excess beyond requiredRotations (replay version 8+ behavior,
+            // which always applies for Autoplay). Therefore, ceil(requiredRotations) - 1 rotations are pre-clear and
+            // floor(totalRotations - requiredRotations) are bonus rotations.
+            float totalRotations = 5f * duration;
+            int preClear = (int) Math.ceil(requiredRotations) - 1;
+            int bonus = Math.max(0, (int)(totalRotations - requiredRotations));
 
             for (int s = 0; s < preClear; s++) {
                 stat.registerSpinnerHit();

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -3795,8 +3795,8 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
             } else if (obj instanceof Slider slider) {
                 sliderIndex++;
                 applySliderResult(slider, data, endCombo);
-            } else if (obj instanceof Spinner) {
-                applySpinnerResult(data, endCombo);
+            } else if (obj instanceof Spinner parsedSpinner) {
+                applySpinnerResult(parsedSpinner, data, endCombo);
             }
 
             lastObjectId = i;
@@ -3920,12 +3920,40 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
         }
     }
 
-    private void applySpinnerResult(@Nullable Replay.ReplayObjectData data, boolean endCombo) {
-        // Spinner accuracy encoding: totalSpins * 4 + resultCode.
-        int totalSpins = data != null ? (data.accuracy & 0xFFFF) >> 2 : 0;
+    private void applySpinnerResult(Spinner spinner, @Nullable Replay.ReplayObjectData data, boolean endCombo) {
+        if (data != null) {
+            // Spinner accuracy encoding: totalSpins * 4 + resultCode.
+            int totalSpins = (data.accuracy & 0xFFFF) >> 2;
 
-        for (int s = 0; s < totalSpins; s++) {
-            stat.registerHit(1000, false, false);
+            for (int s = 0; s < totalSpins; s++) {
+                stat.registerHit(1000, false, false);
+            }
+        } else {
+            // Autoplay always clears the spinner. Reconstruct the pre-clear (100 pts each) and bonus (1000 pts each)
+            // rotation split from the spinner's parameters.
+            float duration = (float) spinner.getDuration() / 1000;
+            float requiredRotations = (2 + 2 * playableBeatmap.getDifficulty().od / 10f) * duration;
+
+            if (duration < 0.05f) {
+                requiredRotations = 0.1f;
+            }
+
+            // The clear-transition does not decrement the rotation accumulator, so the triggering rotation persists and
+            // fires as the first bonus on the following frame. Therefore, ceil(requiredRotations) - 1 rotations are
+            // pre-clear and all remaining (totalRotations - preClear) are bonuses. This can overcount by 1 if the
+            // spinner clears on its very last frame and the bonus never fires, but that edge case is unreachable
+            // in practice.
+            int totalRotations = (int) (5f * duration);
+            int preClear = Math.min(totalRotations, (int) Math.ceil(requiredRotations) - 1);
+            int bonus = Math.max(0, totalRotations - preClear);
+
+            for (int s = 0; s < preClear; s++) {
+                stat.registerSpinnerHit();
+            }
+
+            for (int s = 0; s < bonus; s++) {
+                stat.registerHit(1000, false, false);
+            }
         }
 
         applyCircleResult(data, endCombo);

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -3768,9 +3768,26 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
 
                 double effectiveSecs = calculateEffectiveDrainDuration(segStartMs, segEndMs, localBreakIdx);
 
-                stat.changeHp((float) (-drainRate * 0.01 * effectiveSecs));
+                // Apply drain incrementally so that a large drain section can consume multiple Easy lives.
+                // A one-shot stat.changeHp clamps at 0 and loses the excess, causing at most one Easy revive per drain
+                // section regardless of how deep HP would have gone.
+                float remainingDrain = (float) (drainRate * 0.01 * effectiveSecs);
 
-                if (stat.getHp() <= 0 && stat.canFail) {
+                while (remainingDrain > 0) {
+                    float currentHp = stat.getHp();
+
+                    if (remainingDrain < currentHp) {
+                        stat.changeHp(-remainingDrain);
+                        break;
+                    }
+
+                    remainingDrain -= currentHp;
+                    stat.changeHp(-currentHp);
+
+                    if (!stat.canFail) {
+                        break;
+                    }
+
                     if (GameHelper.isEasy() && failcount < 3) {
                         failcount++;
                         stat.changeHp(1f);

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameplayModernSpinner.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameplayModernSpinner.java
@@ -153,6 +153,18 @@ public class GameplayModernSpinner extends GameplaySpinner {
         if (!startHit) {
             listener.onSpinnerStart(id);
             startHit = true;
+
+            // Fast-forward rotation state when spawned mid-spinner after a seek in Autoplay.
+            if (autoPlay && passedTime > 0) {
+                applySeekRotations();
+
+                // Unlike GameplaySpinner, GameplayModernSpinner has no clearText sprite; clear state is applied
+                // visually on next frame.
+                if (bonusScoreCounter > 1) {
+                    bonusScore.setText(String.valueOf((bonusScoreCounter - 1) * 1000));
+                    scene.attachChild(bonusScore);
+                }
+            }
         }
 
         if (passedTime >= duration) {

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameplaySlider.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameplaySlider.java
@@ -1130,24 +1130,31 @@ public class GameplaySlider extends GameObject {
         if (isTracking() && replayObjectData == null) {
             allTicksInRange = true;
 
-            // Do not judge the slider end as it will be judged in onSpanFinish.
-            for (int i = 1; i < nestedObjects.size() - 1; ++i) {
-                var nestedObject = nestedObjects.get(i);
+            // In Autoplay, the cursor is always at the ball's exact position, so the distance check below
+            // is always satisfied and can be skipped. This also avoids false misses after seeking: when
+            // seeking into the middle of a slider, elapsedSpanTime > 0 immediately, so past ticks are
+            // evaluated with the ball already ahead of them — their positions would fail the distance
+            // check even though Autoplay would always have tracked them.
+            if (!autoPlay) {
+                // Do not judge the slider end as it will be judged in onSpanFinish.
+                for (int i = 1; i < nestedObjects.size() - 1; ++i) {
+                    var nestedObject = nestedObjects.get(i);
 
-                // Stop the process when a nested object that can't be hit before the current time is reached.
-                if (nestedObject.startTime > currentTime) {
-                    break;
-                }
+                    // Stop the process when a nested object that can't be hit before the current time is reached.
+                    if (nestedObject.startTime > currentTime) {
+                        break;
+                    }
 
-                // When the first nested object that is further outside the follow area is reached,
-                // forcefully miss all other nested objects that would otherwise be valid to be hit.
-                // This covers a case of a slider overlapping itself that requires tracking to a tick on an outer edge.
-                var nestedPosition = nestedObject.getScreenSpaceGameplayStackedPosition();
-                var distanceSquared = Utils.squaredDistance(nestedPosition.x, nestedPosition.y, ballPos.x, ballPos.y);
+                    // When the first nested object that is further outside the follow area is reached,
+                    // forcefully miss all other nested objects that would otherwise be valid to be hit.
+                    // This covers a case of a slider overlapping itself that requires tracking to a tick on an outer edge.
+                    var nestedPosition = nestedObject.getScreenSpaceGameplayStackedPosition();
+                    var distanceSquared = Utils.squaredDistance(nestedPosition.x, nestedPosition.y, ballPos.x, ballPos.y);
 
-                if (distanceSquared > distanceTrackingThresholdSquared) {
-                    allTicksInRange = false;
-                    break;
+                    if (distanceSquared > distanceTrackingThresholdSquared) {
+                        allTicksInRange = false;
+                        break;
+                    }
                 }
             }
         }

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameplaySpinner.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameplaySpinner.java
@@ -288,6 +288,20 @@ public class GameplaySpinner extends GameObject {
         if (!startHit) {
             listener.onSpinnerStart(id);
             startHit = true;
+
+            // Fast-forward rotation state when spawned mid-spinner after a seek in Autoplay.
+            if (autoPlay && passedTime > 0) {
+                applySeekRotations();
+
+                if (clear) {
+                    scene.attachChild(clearText);
+                }
+
+                if (bonusScoreCounter > 1) {
+                    bonusScore.setText(String.valueOf((bonusScoreCounter - 1) * 1000));
+                    scene.attachChild(bonusScore);
+                }
+            }
         }
 
         if (passedTime >= duration) {
@@ -418,6 +432,39 @@ public class GameplaySpinner extends GameObject {
         // In remove spinner lock mode, the spinner is assumed to be judged to allow other objects to be judged while
         // the spinner is still active.
         return Config.isRemoveSliderLock() || passedTime >= duration;
+    }
+
+    protected void applySeekRotations() {
+        rotations = 5f * passedTime;
+
+        while (Math.abs(rotations) >= 1f) {
+            float percentfill = (Math.abs(rotations) + fullRotations) / needRotations;
+
+            if (percentfill > 1f || clear) {
+                clear = true;
+                rotations -= Math.signum(rotations);
+                listener.onSpinnerHit(id, 1000, false, 0);
+                bonusScoreCounter++;
+                float rate = 0.375f;
+
+                if (GameHelper.getHealthDrain() > 0) {
+                    rate = 1 + (GameHelper.getHealthDrain() / 4f);
+                }
+
+                stat.changeHp(rate * 0.01f * duration / needRotations);
+            } else {
+                rotations -= Math.signum(rotations);
+                fullRotations++;
+                stat.registerSpinnerHit();
+                float rate = 0.375f;
+
+                if (GameHelper.getHealthDrain() > 0) {
+                    rate = 1 + (GameHelper.getHealthDrain() / 2f);
+                }
+
+                stat.changeHp(rate * 0.01f * duration / needRotations);
+            }
+        }
     }
 
     protected void reloadHitSounds() {

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameplaySpinner.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameplaySpinner.java
@@ -460,12 +460,12 @@ public class GameplaySpinner extends GameObject {
 
                 stat.changeHp(rate * 0.01f * duration / needRotations);
             }
+
+            rotations = totalRotations - wholeRotations;
         } else {
-            // The clear-transition does not decrement the rotation accumulator, so the triggering rotation persists and
-            // fires as the first bonus on the following frame. Therefore ceil(needRotations) - 1 rotations are
-            // pre-clear and all remaining (wholeRotations - preClear) are bonuses. This can overcount by 1 if
-            // passedTime falls within one frame of the clear-transition (before the re-fire), but that window is ~16 ms
-            // and unreachable in practice from a seek operation.
+            // On clear, rotations is reset to only the excess beyond needRotations (replay version 8+ behavior, which
+            // always applies for Autoplay). Therefore ceil(needRotations) - 1 rotations are pre-clear, and
+            // floor(totalRotations - needRotations) are bonus rotations.
             int preClear = Math.min(wholeRotations, (int) Math.ceil(needRotations) - 1);
 
             for (int i = 0; i < preClear; i++) {
@@ -480,9 +480,9 @@ public class GameplaySpinner extends GameObject {
                 stat.changeHp(rate * 0.01f * duration / needRotations);
             }
 
-            if (wholeRotations > preClear) {
+            if (totalRotations > needRotations) {
                 clear = true;
-                int bonus = wholeRotations - preClear;
+                int bonus = (int)(totalRotations - needRotations);
 
                 for (int i = 0; i < bonus; i++) {
                     bonusScoreCounter++;
@@ -495,11 +495,12 @@ public class GameplaySpinner extends GameObject {
 
                     stat.changeHp(rate * 0.01f * duration / needRotations);
                 }
+
+                rotations = (totalRotations - needRotations) - bonus;
+            } else {
+                rotations = totalRotations - wholeRotations;
             }
         }
-
-        // Carry the fractional sub-rotation so the update loop resumes from the correct position.
-        rotations = totalRotations - wholeRotations;
     }
 
     protected void reloadHitSounds() {

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameplaySpinner.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameplaySpinner.java
@@ -435,16 +435,14 @@ public class GameplaySpinner extends GameObject {
     }
 
     protected void applySeekRotations() {
-        rotations = 5f * passedTime;
+        float totalRotations = 5f * passedTime;
+        int wholeRotations = (int) totalRotations;
 
-        while (Math.abs(rotations) >= 1f) {
-            float percentfill = (Math.abs(rotations) + fullRotations) / needRotations;
-
-            if (percentfill > 1f || clear) {
-                clear = true;
-                rotations -= Math.signum(rotations);
-                listener.onSpinnerHit(id, 1000, false, 0);
+        if (clear) {
+            // Already cleared (e.g. zero-duration spinner); all whole rotations are bonus.
+            for (int i = 0; i < wholeRotations; i++) {
                 bonusScoreCounter++;
+                listener.onSpinnerHit(id, 1000, false, 0);
                 float rate = 0.375f;
 
                 if (GameHelper.getHealthDrain() > 0) {
@@ -452,8 +450,16 @@ public class GameplaySpinner extends GameObject {
                 }
 
                 stat.changeHp(rate * 0.01f * duration / needRotations);
-            } else {
-                rotations -= Math.signum(rotations);
+            }
+        } else {
+            // The clear-transition does not decrement the rotation accumulator, so the triggering rotation persists and
+            // fires as the first bonus on the following frame. Therefore ceil(needRotations) - 1 rotations are
+            // pre-clear and all remaining (wholeRotations - preClear) are bonuses. This can overcount by 1 if
+            // passedTime falls within one frame of the clear-transition (before the re-fire), but that window is ~16 ms
+            // and unreachable in practice from a seek operation.
+            int preClear = Math.min(wholeRotations, (int) Math.ceil(needRotations) - 1);
+
+            for (int i = 0; i < preClear; i++) {
                 fullRotations++;
                 stat.registerSpinnerHit();
                 float rate = 0.375f;
@@ -464,7 +470,27 @@ public class GameplaySpinner extends GameObject {
 
                 stat.changeHp(rate * 0.01f * duration / needRotations);
             }
+
+            if (wholeRotations > preClear) {
+                clear = true;
+                int bonus = wholeRotations - preClear;
+
+                for (int i = 0; i < bonus; i++) {
+                    bonusScoreCounter++;
+                    listener.onSpinnerHit(id, 1000, false, 0);
+                    float rate = 0.375f;
+
+                    if (GameHelper.getHealthDrain() > 0) {
+                        rate = 1 + (GameHelper.getHealthDrain() / 4f);
+                    }
+
+                    stat.changeHp(rate * 0.01f * duration / needRotations);
+                }
+            }
         }
+
+        // Carry the fractional sub-rotation so the update loop resumes from the correct position.
+        rotations = totalRotations - wholeRotations;
     }
 
     protected void reloadHitSounds() {


### PR DESCRIPTION
This adds the ability to seek to any point in the beatmap when watching replay or Autoplay.

Because replays are not stored in frames (but rather events), a simulation of the beatmap's progression from the beginning is done to ensure that correct states are applied at the sought time. Due to this, performance may suffer if you seek too far in long beatmaps. However, I have tested seeking to 15 minutes in https://osu.ppy.sh/beatmapsets/724192#osu/1529189 (which has over 6350 hitobjects) during Autoplay using a Snapdragon 778G device, and the operation was completed pretty fast.

Unfortunately, I could not find any other way to avoid this other than aggressively storing state changes, which will result in long loading times and high memory usage.

This PR also fixes an issue with `ReplayVisualSettingsControl` that would take background brightness at the time `prepareScene` has finished as its default value, not when gameplay is actually starting via `start` (during `prepareScene`, the player can still change the setting in `GameLoaderScene`).

<img width="2800" height="1260" alt="image" src="https://github.com/user-attachments/assets/a209e6ba-9f24-4b4a-8a79-62ec0a8c4db2" />
