### PR TITLE
Use `content://` URI scheme for better intent filter matching

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -135,36 +135,34 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
-            <!-- file:// URIs matched by application/octet-stream and path extension -->
-            <intent-filter android:label="Import file">
+            <!-- file:// URIs matched by .osz extension -->
+            <intent-filter android:label="Import beatmap">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.EDIT" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:scheme="file" android:host="*"
-                      android:mimeType="application/octet-stream" android:pathPattern=".*\\.osz"/>
-                <data android:scheme="file" android:host="*"
-                      android:mimeType="application/octet-stream" android:pathPattern=".*\\.osk"/>
-                <data android:scheme="file" android:host="*"
-                      android:mimeType="application/octet-stream" android:pathPattern=".*\\.odr"/>
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="file" android:host="*" android:mimeType="application/octet-stream" android:pathPattern=".*\\.osz" />
+                <data android:scheme="file" android:host="*" android:mimeType="application/zip" android:pathPattern=".*\\.osz" />
+                <data android:scheme="file" android:host="*" android:mimeType="application/x-zip-compressed" android:pathPattern=".*\\.osz" />
             </intent-filter>
 
-            <!-- firefox and file explorer -->
-            <intent-filter android:label="Import file">
-                <action
-                    android:name="android.intent.action.VIEW" />
-                <category
-                    android:name="android.intent.category.DEFAULT" />
-                <category
-                    android:name="android.intent.category.BROWSABLE" />
-                <data
-                    android:mimeType="application/zip"
-                    android:scheme="file" />
-                <data
-                    android:mimeType="application/x-zip-compressed"
-                    android:scheme="file" />
-                <data
-                    android:mimeType="application/octet-stream"
-                    android:scheme="file" />
+            <!-- file:// URIs matched by .osk extension -->
+            <intent-filter android:label="Import skin">
+                <action android:name="android.intent.action.VIEW" />
+                <action android:name="android.intent.action.EDIT" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="file" android:host="*" android:mimeType="application/octet-stream" android:pathPattern=".*\\.osk" />
+                <data android:scheme="file" android:host="*" android:mimeType="application/zip" android:pathPattern=".*\\.osk" />
+                <data android:scheme="file" android:host="*" android:mimeType="application/x-zip-compressed" android:pathPattern=".*\\.osk" />
+            </intent-filter>
+
+            <!-- file:// URIs matched by .odr extension -->
+            <intent-filter android:label="Import replay">
+                <action android:name="android.intent.action.VIEW" />
+                <action android:name="android.intent.action.EDIT" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="file" android:host="*" android:mimeType="application/octet-stream" android:pathPattern=".*\\.odr" />
             </intent-filter>
 
             <!-- qq -->

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -182,6 +182,7 @@
             <intent-filter android:label="Import beatmap">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="content" android:mimeType="application/x-osu-beatmap-archive" />
             </intent-filter>
 
@@ -189,6 +190,7 @@
             <intent-filter android:label="Import skin">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="content" android:mimeType="application/x-osu-skin-archive" />
             </intent-filter>
 

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -87,6 +87,24 @@
                 <data android:pathPattern=".*\.edr" />
             </intent-filter>
 
+            <!-- content:// URIs matched by .edr extension (modern file managers / browsers) -->
+            <intent-filter android:label="Import replay">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="content" android:host="*" android:mimeType="*/*" android:pathPattern=".*\\.edr" />
+            </intent-filter>
+
+            <!-- content:// URIs matched by generic archive MIME type -->
+            <intent-filter android:label="Import replay">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="content" android:mimeType="application/zip" />
+                <data android:scheme="content" android:mimeType="application/x-zip-compressed" />
+                <data android:scheme="content" android:mimeType="application/octet-stream" />
+            </intent-filter>
+
         </activity>
 
         <activity

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -134,7 +134,7 @@
                 <data android:scheme="file" android:host="*"
                       android:mimeType="application/octet-stream" android:pathPattern=".*\\.osz"/>
                 <data android:scheme="file" android:host="*"
-                      android:mimeType="application/octet-stream" android:pathPattern=".*\\.zip"/>
+                      android:mimeType="application/octet-stream" android:pathPattern=".*\\.osk"/>
                 <data android:scheme="file" android:host="*"
                       android:mimeType="application/octet-stream" android:pathPattern=".*\\.odr"/>
             </intent-filter>

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -129,7 +129,6 @@
             <!-- file:// URIs matched by .osz extension -->
             <intent-filter android:label="Import beatmap">
                 <action android:name="android.intent.action.VIEW" />
-                <action android:name="android.intent.action.EDIT" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="file" android:host="*" android:mimeType="application/octet-stream" android:pathPattern=".*\\.osz" />
@@ -140,7 +139,6 @@
             <!-- file:// URIs matched by .osk extension -->
             <intent-filter android:label="Import skin">
                 <action android:name="android.intent.action.VIEW" />
-                <action android:name="android.intent.action.EDIT" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="file" android:host="*" android:mimeType="application/octet-stream" android:pathPattern=".*\\.osk" />
@@ -151,7 +149,6 @@
             <!-- file:// URIs matched by .odr extension -->
             <intent-filter android:label="Import replay">
                 <action android:name="android.intent.action.VIEW" />
-                <action android:name="android.intent.action.EDIT" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:scheme="file" android:host="*" android:mimeType="application/octet-stream" android:pathPattern=".*\\.odr" />
             </intent-filter>

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -61,21 +61,12 @@
 
             <!-- firefox and file explorer -->
             <intent-filter android:label="Import replay">
-                <action
-                    android:name="android.intent.action.VIEW" />
-                <category
-                    android:name="android.intent.category.DEFAULT" />
-                <category
-                    android:name="android.intent.category.BROWSABLE" />
-                <data
-                    android:mimeType="application/zip"
-                    android:scheme="file" />
-                <data
-                    android:mimeType="application/x-zip-compressed"
-                    android:scheme="file" />
-                <data
-                    android:mimeType="application/octet-stream"
-                    android:scheme="file" />
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="file" android:mimeType="application/zip" android:pathPattern=".*\\.edr" />
+                <data android:scheme="file" android:mimeType="application/x-zip-compressed" android:pathPattern=".*\\.edr" />
+                <data android:scheme="file" android:mimeType="application/octet-stream" android:pathPattern=".*\\.edr" />
             </intent-filter>
 
             <!-- qq -->
@@ -95,14 +86,14 @@
                 <data android:scheme="content" android:host="*" android:mimeType="*/*" android:pathPattern=".*\\.edr" />
             </intent-filter>
 
-            <!-- content:// URIs matched by generic archive MIME type -->
+            <!-- content:// URIs matched by generic archive MIME type and .edr path -->
             <intent-filter android:label="Import replay">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="content" android:mimeType="application/zip" />
-                <data android:scheme="content" android:mimeType="application/x-zip-compressed" />
-                <data android:scheme="content" android:mimeType="application/octet-stream" />
+                <data android:scheme="content" android:host="*" android:mimeType="application/zip" android:pathPattern=".*\\.edr" />
+                <data android:scheme="content" android:host="*" android:mimeType="application/x-zip-compressed" android:pathPattern=".*\\.edr" />
+                <data android:scheme="content" android:host="*" android:mimeType="application/octet-stream" android:pathPattern=".*\\.edr" />
             </intent-filter>
 
         </activity>

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -150,6 +150,7 @@
             <intent-filter android:label="Import replay">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="file" android:host="*" android:mimeType="application/octet-stream" android:pathPattern=".*\\.odr" />
             </intent-filter>
 

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -60,7 +60,7 @@
             android:exported="true">
 
             <!-- firefox and file explorer -->
-            <intent-filter android:label="Import replay">
+            <intent-filter android:label="@string/act_import_replay">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
@@ -70,7 +70,7 @@
             </intent-filter>
 
             <!-- content:// URIs matched by .edr extension (modern file managers / browsers) -->
-            <intent-filter android:label="Import replay">
+            <intent-filter android:label="@string/act_import_replay">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
@@ -78,7 +78,7 @@
             </intent-filter>
 
             <!-- content:// URIs matched by generic archive MIME type and .edr path -->
-            <intent-filter android:label="Import replay">
+            <intent-filter android:label="@string/act_import_replay">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
@@ -127,7 +127,7 @@
             </intent-filter>
 
             <!-- file:// URIs matched by .osz extension -->
-            <intent-filter android:label="Import beatmap">
+            <intent-filter android:label="@string/act_import_beatmap">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
@@ -137,7 +137,7 @@
             </intent-filter>
 
             <!-- file:// URIs matched by .osk extension -->
-            <intent-filter android:label="Import skin">
+            <intent-filter android:label="@string/act_import_skin">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
@@ -147,7 +147,7 @@
             </intent-filter>
 
             <!-- file:// URIs matched by .odr extension -->
-            <intent-filter android:label="Import replay">
+            <intent-filter android:label="@string/act_import_replay">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
@@ -155,7 +155,7 @@
             </intent-filter>
 
             <!-- content:// URIs matched by .osz extension (modern file managers / browsers) -->
-            <intent-filter android:label="Import beatmap">
+            <intent-filter android:label="@string/act_import_beatmap">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
@@ -163,7 +163,7 @@
             </intent-filter>
 
             <!-- content:// URIs matched by .osk extension (modern file managers / browsers) -->
-            <intent-filter android:label="Import skin">
+            <intent-filter android:label="@string/act_import_skin">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
@@ -171,7 +171,7 @@
             </intent-filter>
 
             <!-- content:// URIs matched by .odr extension (modern file managers / browsers) -->
-            <intent-filter android:label="Import replay">
+            <intent-filter android:label="@string/act_import_replay">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
@@ -179,7 +179,7 @@
             </intent-filter>
 
             <!-- content:// URIs matched by osu beatmap MIME type -->
-            <intent-filter android:label="Import beatmap">
+            <intent-filter android:label="@string/act_import_beatmap">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
@@ -187,7 +187,7 @@
             </intent-filter>
 
             <!-- content:// URIs matched by osu skin MIME type -->
-            <intent-filter android:label="Import skin">
+            <intent-filter android:label="@string/act_import_skin">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
@@ -201,7 +201,7 @@
                 The label is intentionally generic — the file type cannot be determined until the
                 activity reads the display name at runtime via OpenableColumns.DISPLAY_NAME.
             -->
-            <intent-filter android:label="Import file">
+            <intent-filter android:label="@string/act_import_file">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -194,17 +194,6 @@
                 <data android:scheme="content" android:mimeType="application/x-osu-skin-archive" />
             </intent-filter>
 
-            <!-- content:// URIs matched by generic archive MIME type -->
-            <intent-filter android:label="Import file">
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="content" android:mimeType="application/zip" />
-                <data android:scheme="content" android:mimeType="application/octet-stream" />
-                <data android:scheme="content" android:mimeType="application/download" />
-                <data android:scheme="content" android:mimeType="application/x-zip" />
-                <data android:scheme="content" android:mimeType="application/x-zip-compressed" />
-            </intent-filter>
         </activity>
 
         <service

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -69,15 +69,6 @@
                 <data android:scheme="file" android:mimeType="application/octet-stream" android:pathPattern=".*\\.edr" />
             </intent-filter>
 
-            <!-- qq -->
-            <intent-filter android:label="Import replay">
-                <action android:name="android.intent.action.VIEW" />
-                <action android:name="android.intent.action.EDIT" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data android:scheme="file"/>
-                <data android:pathPattern=".*\.edr" />
-            </intent-filter>
-
             <!-- content:// URIs matched by .edr extension (modern file managers / browsers) -->
             <intent-filter android:label="Import replay">
                 <action android:name="android.intent.action.VIEW" />
@@ -163,15 +154,6 @@
                 <action android:name="android.intent.action.EDIT" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:scheme="file" android:host="*" android:mimeType="application/octet-stream" android:pathPattern=".*\\.odr" />
-            </intent-filter>
-
-            <!-- qq -->
-            <intent-filter android:label="Import beatmap">
-                <action android:name="android.intent.action.VIEW" />
-                <action android:name="android.intent.action.EDIT" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data android:scheme="file"/>
-                <data android:pathPattern=".*\.osz" />
             </intent-filter>
 
             <!-- content:// URIs matched by .osz extension (modern file managers / browsers) -->

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -184,6 +184,56 @@
                 <data android:scheme="file"/>
                 <data android:pathPattern=".*\.osz" />
             </intent-filter>
+
+            <!-- content:// URIs matched by .osz extension (modern file managers / browsers) -->
+            <intent-filter android:label="Import beatmap">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="content" android:host="*" android:mimeType="*/*" android:pathPattern=".*\\.osz" />
+            </intent-filter>
+
+            <!-- content:// URIs matched by .osk extension (modern file managers / browsers) -->
+            <intent-filter android:label="Import skin">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="content" android:host="*" android:mimeType="*/*" android:pathPattern=".*\\.osk" />
+            </intent-filter>
+
+            <!-- content:// URIs matched by .odr extension (modern file managers / browsers) -->
+            <intent-filter android:label="Import replay">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="content" android:host="*" android:mimeType="*/*" android:pathPattern=".*\\.odr" />
+            </intent-filter>
+
+            <!-- content:// URIs matched by osu beatmap MIME type -->
+            <intent-filter android:label="Import beatmap">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="content" android:mimeType="application/x-osu-beatmap-archive" />
+            </intent-filter>
+
+            <!-- content:// URIs matched by osu skin MIME type -->
+            <intent-filter android:label="Import skin">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="content" android:mimeType="application/x-osu-skin-archive" />
+            </intent-filter>
+
+            <!-- content:// URIs matched by generic archive MIME type -->
+            <intent-filter android:label="Import file">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="content" android:mimeType="application/zip" />
+                <data android:scheme="content" android:mimeType="application/octet-stream" />
+                <data android:scheme="content" android:mimeType="application/download" />
+                <data android:scheme="content" android:mimeType="application/x-zip" />
+                <data android:scheme="content" android:mimeType="application/x-zip-compressed" />
+            </intent-filter>
         </activity>
 
         <service

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -60,7 +60,7 @@
             android:exported="true">
 
             <!-- firefox and file explorer -->
-            <intent-filter>
+            <intent-filter android:label="Import replay">
                 <action
                     android:name="android.intent.action.VIEW" />
                 <category
@@ -79,13 +79,12 @@
             </intent-filter>
 
             <!-- qq -->
-            <intent-filter>
+            <intent-filter android:label="Import replay">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.EDIT" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:scheme="file"/>
-                <data
-                    android:pathPattern=".*\.edr" />
+                <data android:pathPattern=".*\.edr" />
             </intent-filter>
 
         </activity>
@@ -126,7 +125,9 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-            <intent-filter>
+
+            <!-- file:// URIs matched by application/octet-stream and path extension -->
+            <intent-filter android:label="Import file">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.EDIT" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -139,7 +140,7 @@
             </intent-filter>
 
             <!-- firefox and file explorer -->
-            <intent-filter>
+            <intent-filter android:label="Import file">
                 <action
                     android:name="android.intent.action.VIEW" />
                 <category
@@ -158,13 +159,12 @@
             </intent-filter>
 
             <!-- qq -->
-            <intent-filter>
+            <intent-filter android:label="Import beatmap">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.EDIT" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:scheme="file"/>
-                <data
-                    android:pathPattern=".*\.osz" />
+                <data android:pathPattern=".*\.osz" />
             </intent-filter>
         </activity>
 

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -194,6 +194,23 @@
                 <data android:scheme="content" android:mimeType="application/x-osu-skin-archive" />
             </intent-filter>
 
+            <!--
+                Fallback for content:// URIs with generic archive MIME types and opaque paths
+                (e.g. Downloads provider: content://downloads/public_downloads/1234).
+                Path-pattern filters above cannot match these since the URI contains no filename.
+                The label is intentionally generic — the file type cannot be determined until the
+                activity reads the display name at runtime via OpenableColumns.DISPLAY_NAME.
+            -->
+            <intent-filter android:label="Import file">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="content" android:mimeType="application/zip" />
+                <data android:scheme="content" android:mimeType="application/octet-stream" />
+                <data android:scheme="content" android:mimeType="application/download" />
+                <data android:scheme="content" android:mimeType="application/x-zip" />
+                <data android:scheme="content" android:mimeType="application/x-zip-compressed" />
+            </intent-filter>
         </activity>
 
         <service

--- a/res/values/strings_temporary_for_locals.xml
+++ b/res/values/strings_temporary_for_locals.xml
@@ -109,5 +109,8 @@
     <string name="opt_offset_calibration_feedback_early">Early</string>
     <string name="opt_offset_calibration_feedback_tap_count">taps</string>
 
+    <string name="act_import_beatmap">Import beatmap into osu!droid</string>
+    <string name="act_import_file">Import file into osu!droid</string>
+    <string name="act_import_skin">Import skin into osu!droid</string>
 
 </resources>

--- a/res/values/strings_temporary_for_locals.xml
+++ b/res/values/strings_temporary_for_locals.xml
@@ -86,6 +86,8 @@
     <string name="multi_mode_window_alert_message">osu!droid does not support multi-window mode. Please switch back to single-window mode to continue playing.</string>
 
 
+    <string name="library_skin_importing">Importing skin...</string>
+
     <!--  Calibration Offset    -->
     <string name="opt_offset_calibration_title">Offset Calibration</string>
     <string name="opt_offset_calibration_summary">Tap along with a metronome to measure your device\'s audio latency</string>

--- a/res/values/strings_temporary_for_locals.xml
+++ b/res/values/strings_temporary_for_locals.xml
@@ -85,8 +85,8 @@
     <string name="multi_mode_window_alert_title">Multi-window Mode</string>
     <string name="multi_mode_window_alert_message">osu!droid does not support multi-window mode. Please switch back to single-window mode to continue playing.</string>
 
-
     <string name="library_skin_importing">Importing skin...</string>
+    <string name="import_failed_open_file">Failed to open file for import.</string>
 
     <!--  Calibration Offset    -->
     <string name="opt_offset_calibration_title">Offset Calibration</string>

--- a/src/com/edlplan/ui/ImportReplayActivity.java
+++ b/src/com/edlplan/ui/ImportReplayActivity.java
@@ -28,9 +28,11 @@ public class ImportReplayActivity extends Activity {
         Uri data = getIntent().getData();
         if (data != null) {
             try {
-                InputStream inputStream;
+                final InputStream inputStream;
+
                 if (ContentResolver.SCHEME_CONTENT.equals(data.getScheme())) {
                     inputStream = getContentResolver().openInputStream(data);
+
                     if (inputStream == null) {
                         Toast.makeText(this, com.osudroid.resources.R.string.invalid_edr_file, Toast.LENGTH_SHORT).show();
                         finish();
@@ -38,32 +40,39 @@ public class ImportReplayActivity extends Activity {
                     }
                 } else {
                     File file = new File(data.getPath());
+
                     if (!file.exists() || file.isDirectory()) {
                         Toast.makeText(this, com.osudroid.resources.R.string.invalid_edr_file, Toast.LENGTH_SHORT).show();
                         finish();
                         return;
                     }
+
                     inputStream = new FileInputStream(file);
                 }
 
-                OsuDroidReplayPack.ReplayEntry entry = OsuDroidReplayPack.unpack(inputStream);
-                File rep = new File(entry.scoreInfo.getReplayPath());
-                if (!rep.exists()) {
-                    if (!rep.createNewFile()) {
+                try (inputStream) {
+                    OsuDroidReplayPack.ReplayEntry entry = OsuDroidReplayPack.unpack(inputStream);
+                    File rep = new File(entry.scoreInfo.getReplayPath());
+
+                    if (!rep.exists()) {
+                        if (!rep.createNewFile()) {
+                            Toast.makeText(this, com.osudroid.resources.R.string.failed_to_import_edr, Toast.LENGTH_SHORT).show();
+                            finish();
+                            return;
+                        }
+                    }
+
+                    try (var outputStream = new FileOutputStream(rep)) {
+                        outputStream.write(entry.replayFile);
+                    }
+
+                    if (DatabaseManager.getScoreInfoTable().insertScore(entry.scoreInfo) >= 0) {
+                        Toast.makeText(this, com.osudroid.resources.R.string.import_edr_successfully, Toast.LENGTH_SHORT).show();
+                        finish();
+                    } else {
                         Toast.makeText(this, com.osudroid.resources.R.string.failed_to_import_edr, Toast.LENGTH_SHORT).show();
                         finish();
-                        return;
                     }
-                }
-                FileOutputStream outputStream = new FileOutputStream(rep);
-                outputStream.write(entry.replayFile);
-                outputStream.close();
-                if (DatabaseManager.getScoreInfoTable().insertScore(entry.scoreInfo) >= 0) {
-                    Toast.makeText(this, com.osudroid.resources.R.string.import_edr_successfully, Toast.LENGTH_SHORT).show();
-                    finish();
-                } else {
-                    Toast.makeText(this, com.osudroid.resources.R.string.failed_to_import_edr, Toast.LENGTH_SHORT).show();
-                    finish();
                 }
             } catch (Exception e) {
                 e.printStackTrace();

--- a/src/com/edlplan/ui/ImportReplayActivity.java
+++ b/src/com/edlplan/ui/ImportReplayActivity.java
@@ -26,6 +26,7 @@ public class ImportReplayActivity extends Activity {
     protected void onStart() {
         super.onStart();
         Uri data = getIntent().getData();
+
         if (data != null) {
             try {
                 final InputStream inputStream;
@@ -35,7 +36,6 @@ public class ImportReplayActivity extends Activity {
 
                     if (inputStream == null) {
                         Toast.makeText(this, com.osudroid.resources.R.string.invalid_edr_file, Toast.LENGTH_SHORT).show();
-                        finish();
                         return;
                     }
                 } else {
@@ -43,7 +43,6 @@ public class ImportReplayActivity extends Activity {
 
                     if (!file.exists() || file.isDirectory()) {
                         Toast.makeText(this, com.osudroid.resources.R.string.invalid_edr_file, Toast.LENGTH_SHORT).show();
-                        finish();
                         return;
                     }
 
@@ -57,7 +56,6 @@ public class ImportReplayActivity extends Activity {
                     if (!rep.exists()) {
                         if (!rep.createNewFile()) {
                             Toast.makeText(this, com.osudroid.resources.R.string.failed_to_import_edr, Toast.LENGTH_SHORT).show();
-                            finish();
                             return;
                         }
                     }
@@ -68,15 +66,14 @@ public class ImportReplayActivity extends Activity {
 
                     if (DatabaseManager.getScoreInfoTable().insertScore(entry.scoreInfo) >= 0) {
                         Toast.makeText(this, com.osudroid.resources.R.string.import_edr_successfully, Toast.LENGTH_SHORT).show();
-                        finish();
                     } else {
                         Toast.makeText(this, com.osudroid.resources.R.string.failed_to_import_edr, Toast.LENGTH_SHORT).show();
-                        finish();
                     }
                 }
             } catch (Exception e) {
                 e.printStackTrace();
                 Toast.makeText(this, String.format(getResources().getString(com.osudroid.resources.R.string.failed_to_import_edr_with_err), e), Toast.LENGTH_SHORT).show();
+            } finally {
                 finish();
             }
         }

--- a/src/com/edlplan/ui/ImportReplayActivity.java
+++ b/src/com/edlplan/ui/ImportReplayActivity.java
@@ -1,6 +1,8 @@
 package com.edlplan.ui;
 
 import android.app.Activity;
+import android.content.ContentResolver;
+import android.net.Uri;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
 import android.widget.Toast;
@@ -11,7 +13,7 @@ import com.osudroid.data.DatabaseManager;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-
+import java.io.InputStream;
 
 public class ImportReplayActivity extends Activity {
 
@@ -23,23 +25,32 @@ public class ImportReplayActivity extends Activity {
     @Override
     protected void onStart() {
         super.onStart();
-        if (getIntent().getData() != null) {
-            String path = getIntent().getData().getPath();
-            System.out.println("path: " + path);
-            File file = new File(path);
-            if ((!file.exists()) || file.isDirectory()) {
-                Toast.makeText(this, com.osudroid.resources.R.string.invalid_edr_file, Toast.LENGTH_SHORT).show();
-                super.onStart();
-                finish();
-                return;
-            }
+        Uri data = getIntent().getData();
+        if (data != null) {
             try {
-                OsuDroidReplayPack.ReplayEntry entry = OsuDroidReplayPack.unpack(new FileInputStream(file));
+                InputStream inputStream;
+                if (ContentResolver.SCHEME_CONTENT.equals(data.getScheme())) {
+                    inputStream = getContentResolver().openInputStream(data);
+                    if (inputStream == null) {
+                        Toast.makeText(this, com.osudroid.resources.R.string.invalid_edr_file, Toast.LENGTH_SHORT).show();
+                        finish();
+                        return;
+                    }
+                } else {
+                    File file = new File(data.getPath());
+                    if (!file.exists() || file.isDirectory()) {
+                        Toast.makeText(this, com.osudroid.resources.R.string.invalid_edr_file, Toast.LENGTH_SHORT).show();
+                        finish();
+                        return;
+                    }
+                    inputStream = new FileInputStream(file);
+                }
+
+                OsuDroidReplayPack.ReplayEntry entry = OsuDroidReplayPack.unpack(inputStream);
                 File rep = new File(entry.scoreInfo.getReplayPath());
                 if (!rep.exists()) {
                     if (!rep.createNewFile()) {
                         Toast.makeText(this, com.osudroid.resources.R.string.failed_to_import_edr, Toast.LENGTH_SHORT).show();
-                        super.onStart();
                         finish();
                         return;
                     }
@@ -56,12 +67,9 @@ public class ImportReplayActivity extends Activity {
                 }
             } catch (Exception e) {
                 e.printStackTrace();
-                Toast.makeText(this, String.format(getResources().getString(com.osudroid.resources.R.string.failed_to_import_edr_with_err), e.toString()), Toast.LENGTH_SHORT).show();
-                super.onStart();
+                Toast.makeText(this, String.format(getResources().getString(com.osudroid.resources.R.string.failed_to_import_edr_with_err), e), Toast.LENGTH_SHORT).show();
                 finish();
-                return;
             }
         }
-        super.onStart();
     }
 }

--- a/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
+++ b/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
@@ -440,6 +440,8 @@ public class MainActivity extends BaseGameActivity implements
                 fileToAdd = null;
             } else if (file.getName().toLowerCase().endsWith(".odr")) {
                 willReplay = true;
+            } else {
+                fileToAdd = null;
             }
         } else if (mainDir.exists() && mainDir.isDirectory()) {
             File[] filelist = FileUtils.listFiles(mainDir, ".osz");

--- a/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
+++ b/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
@@ -438,7 +438,7 @@ public class MainActivity extends BaseGameActivity implements
                 ToastLogger.showText(StringTable.get(R.string.library_skin_importing), false);
                 FileUtils.extractZip(fileToAdd, Config.getSkinTopPath());
                 fileToAdd = null;
-            } else if (file.getName().endsWith(".odr")) {
+            } else if (file.getName().toLowerCase().endsWith(".odr")) {
                 willReplay = true;
             }
         } else if (mainDir.exists() && mainDir.isDirectory()) {

--- a/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
+++ b/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
@@ -656,7 +656,8 @@ public class MainActivity extends BaseGameActivity implements
         }
 
         if (displayName != null && !displayName.isEmpty()) {
-            fileName = displayName;
+            // Strip any directory components a malicious provider might include.
+            fileName = new File(displayName).getName();
         } else {
             String mimeType = getContentResolver().getType(uri);
             String ext;
@@ -673,6 +674,16 @@ public class MainActivity extends BaseGameActivity implements
         }
 
         var tempFile = new File(getCacheDir(), fileName);
+
+        try {
+            if (!tempFile.getCanonicalPath().startsWith(getCacheDir().getCanonicalPath() + File.separator)) {
+                Debug.e("MainActivity.copyContentUriToCache: rejected unsafe display name: " + displayName);
+                return null;
+            }
+        } catch (IOException e) {
+            Debug.e("MainActivity.copyContentUriToCache: " + e.getMessage(), e);
+            return null;
+        }
 
         try (var in = getContentResolver().openInputStream(uri);
              var sink = Okio.buffer(Okio.sink(tempFile))) {

--- a/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
+++ b/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
@@ -7,7 +7,6 @@ import android.annotation.SuppressLint;
 import android.content.ComponentName;
 import android.content.ContentResolver;
 import android.content.Intent;
-import android.database.Cursor;
 import android.provider.OpenableColumns;
 import android.content.ServiceConnection;
 import android.content.SharedPreferences;
@@ -657,17 +656,26 @@ public class MainActivity extends BaseGameActivity implements
         String displayName = null;
         String fileName;
 
-        try (Cursor cursor = getContentResolver().query(uri, new String[]{OpenableColumns.DISPLAY_NAME}, null, null, null)) {
+        try (var cursor = getContentResolver().query(uri, new String[]{ OpenableColumns.DISPLAY_NAME }, null, null, null)) {
             if (cursor != null && cursor.moveToFirst()) {
                 displayName = cursor.getString(0);
             }
+        } catch (IllegalArgumentException | SecurityException e) {
+            Debug.e("MainActivity.copyContentUriToCache: cannot query display name: " + e.getMessage(), e);
         }
 
         if (displayName != null && !displayName.isEmpty()) {
             // Strip any directory components a malicious provider might include.
             fileName = new File(displayName).getName();
         } else {
-            String mimeType = getContentResolver().getType(uri);
+            String mimeType = null;
+
+            try {
+                mimeType = getContentResolver().getType(uri);
+            } catch (SecurityException e) {
+                Debug.e("MainActivity.copyContentUriToCache: cannot query MIME type: " + e.getMessage(), e);
+            }
+
             String ext;
 
             if ("application/x-osu-beatmap-archive".equals(mimeType)) {
@@ -695,11 +703,16 @@ public class MainActivity extends BaseGameActivity implements
 
         try (var in = getContentResolver().openInputStream(uri);
              var sink = Okio.buffer(Okio.sink(tempFile))) {
-            if (in == null) return null;
+            if (in == null) {
+                ToastLogger.showText(StringTable.get(R.string.import_failed_open_file), false);
+                return null;
+            }
+
             sink.writeAll(Okio.source(in));
             return tempFile.getAbsolutePath();
-        } catch (IOException e) {
+        } catch (IOException | SecurityException e) {
             Debug.e("MainActivity.copyContentUriToCache: " + e.getMessage(), e);
+            ToastLogger.showText(StringTable.get(R.string.import_failed_open_file), false);
             return null;
         }
     }

--- a/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
+++ b/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
@@ -433,7 +433,7 @@ public class MainActivity extends BaseGameActivity implements
                 forceImportedBeatmaps.add(file.getName().substring(0, file.getName().length() - 4));
                 // LibraryManager.INSTANCE.sort();
             } else if (file.getName().toLowerCase().endsWith(".osk")) {
-                ToastLogger.showText("Importing skin...", false);
+                ToastLogger.showText("Importing skins...", false);
                 FileUtils.extractZip(beatmapToAdd, Config.getSkinTopPath());
             } else if (file.getName().endsWith(".odr")) {
                 willReplay = true;

--- a/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
+++ b/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
@@ -364,6 +364,7 @@ public class MainActivity extends BaseGameActivity implements
                     Multiplayer.connectFromLink(roomInviteLink);
                 } else if (willReplay) {
                     GlobalManager.getInstance().getMainScene().watchReplay(fileToAdd);
+                    fileToAdd = null;
                     willReplay = false;
                 }
 

--- a/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
+++ b/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
@@ -7,6 +7,8 @@ import android.annotation.SuppressLint;
 import android.content.ComponentName;
 import android.content.ContentResolver;
 import android.content.Intent;
+import android.database.Cursor;
+import android.provider.OpenableColumns;
 import android.content.ServiceConnection;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
@@ -85,6 +87,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import okio.Okio;
 import ru.nsu.ccfit.zuev.audio.serviceAudio.SaveServiceObject;
 import ru.nsu.ccfit.zuev.audio.serviceAudio.SongService;
 import ru.nsu.ccfit.zuev.osu.helper.FileUtils;
@@ -429,6 +432,9 @@ public class MainActivity extends BaseGameActivity implements
                 FileUtils.extractZip(beatmapToAdd, Config.getBeatmapPath());
                 forceImportedBeatmaps.add(file.getName().substring(0, file.getName().length() - 4));
                 // LibraryManager.INSTANCE.sort();
+            } else if (file.getName().toLowerCase().endsWith(".osk")) {
+                ToastLogger.showText("Importing skin...", false);
+                FileUtils.extractZip(beatmapToAdd, Config.getSkinTopPath());
             } else if (file.getName().endsWith(".odr")) {
                 willReplay = true;
             }
@@ -625,11 +631,56 @@ public class MainActivity extends BaseGameActivity implements
                 if (data.toString().startsWith(LobbyAPI.INVITE_HOST))
                     roomInviteLink = data;
 
-                if (ContentResolver.SCHEME_FILE.equals(getIntent().getData().getScheme()))
-                    beatmapToAdd = getIntent().getData().getPath();
+                String scheme = data.getScheme();
+
+                if (ContentResolver.SCHEME_FILE.equals(scheme)) {
+                    beatmapToAdd = data.getPath();
+                } else if (ContentResolver.SCHEME_CONTENT.equals(scheme)) {
+                    beatmapToAdd = copyContentUriToCache(data);
+                }
             }
         }
         super.onStart();
+    }
+
+    private String copyContentUriToCache(Uri uri) {
+        String displayName = null;
+        String fileName;
+
+        try (Cursor cursor = getContentResolver().query(uri, new String[]{OpenableColumns.DISPLAY_NAME}, null, null, null)) {
+            if (cursor != null && cursor.moveToFirst()) {
+                displayName = cursor.getString(0);
+            }
+        }
+
+        if (displayName != null && !displayName.isEmpty()) {
+            fileName = displayName;
+        } else {
+            String mimeType = getContentResolver().getType(uri);
+            String ext;
+
+            if ("application/x-osu-beatmap-archive".equals(mimeType)) {
+                ext = ".osz";
+            } else if ("application/x-osu-skin-archive".equals(mimeType)) {
+                ext = ".osk";
+            } else {
+                ext = ".zip";
+            }
+
+            fileName = "import_" + System.currentTimeMillis() + ext;
+        }
+
+        var tempFile = new File(getCacheDir(), fileName);
+
+        try (var in = getContentResolver().openInputStream(uri);
+             var sink = Okio.buffer(Okio.sink(tempFile))) {
+            if (in == null) return null;
+            sink.writeAll(Okio.source(in));
+            return tempFile.getAbsolutePath();
+        } catch (IOException e) {
+            Debug.e("MainActivity.copyContentUriToCache: " + e.getMessage(), e);
+            return null;
+        }
     }
 
     @Override

--- a/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
+++ b/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
@@ -104,7 +104,7 @@ public class MainActivity extends BaseGameActivity implements
     public static String versionName;
     public static SongService songService;
     public ServiceConnection connection;
-    private String beatmapToAdd = null;
+    private String fileToAdd = null;
     private SaveServiceObject saveServiceObject;
     private FirebaseAnalytics analytics;
     private FirebaseCrashlytics crashlytics;
@@ -363,7 +363,7 @@ public class MainActivity extends BaseGameActivity implements
                 if (roomInviteLink != null) {
                     Multiplayer.connectFromLink(roomInviteLink);
                 } else if (willReplay) {
-                    GlobalManager.getInstance().getMainScene().watchReplay(beatmapToAdd);
+                    GlobalManager.getInstance().getMainScene().watchReplay(fileToAdd);
                     willReplay = false;
                 }
 
@@ -422,21 +422,21 @@ public class MainActivity extends BaseGameActivity implements
         GlobalManager.getInstance().setInfo("Checking for new maps...");
         final File mainDir = new File(Config.getCorePath());
         final HashSet<String> forceImportedBeatmaps = new HashSet<>();
-        if (beatmapToAdd != null) {
-            File file = new File(beatmapToAdd);
+        if (fileToAdd != null) {
+            File file = new File(fileToAdd);
             if (file.getName().toLowerCase().endsWith(".osz")) {
                 ToastLogger.showText(
                         StringTable.get(com.osudroid.resources.R.string.library_importing),
                         false);
 
-                FileUtils.extractZip(beatmapToAdd, Config.getBeatmapPath());
+                FileUtils.extractZip(fileToAdd, Config.getBeatmapPath());
                 forceImportedBeatmaps.add(file.getName().substring(0, file.getName().length() - 4));
                 // LibraryManager.INSTANCE.sort();
-                beatmapToAdd = null;
+                fileToAdd = null;
             } else if (file.getName().toLowerCase().endsWith(".osk")) {
                 ToastLogger.showText("Importing skins...", false);
-                FileUtils.extractZip(beatmapToAdd, Config.getSkinTopPath());
-                beatmapToAdd = null;
+                FileUtils.extractZip(fileToAdd, Config.getSkinTopPath());
+                fileToAdd = null;
             } else if (file.getName().endsWith(".odr")) {
                 willReplay = true;
             }
@@ -636,9 +636,9 @@ public class MainActivity extends BaseGameActivity implements
                 String scheme = data.getScheme();
 
                 if (ContentResolver.SCHEME_FILE.equals(scheme)) {
-                    beatmapToAdd = data.getPath();
+                    fileToAdd = data.getPath();
                 } else if (ContentResolver.SCHEME_CONTENT.equals(scheme)) {
-                    beatmapToAdd = copyContentUriToCache(data);
+                    fileToAdd = copyContentUriToCache(data);
                 }
             }
         }

--- a/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
+++ b/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
@@ -432,9 +432,11 @@ public class MainActivity extends BaseGameActivity implements
                 FileUtils.extractZip(beatmapToAdd, Config.getBeatmapPath());
                 forceImportedBeatmaps.add(file.getName().substring(0, file.getName().length() - 4));
                 // LibraryManager.INSTANCE.sort();
+                beatmapToAdd = null;
             } else if (file.getName().toLowerCase().endsWith(".osk")) {
                 ToastLogger.showText("Importing skins...", false);
                 FileUtils.extractZip(beatmapToAdd, Config.getSkinTopPath());
+                beatmapToAdd = null;
             } else if (file.getName().endsWith(".odr")) {
                 willReplay = true;
             }

--- a/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
+++ b/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
@@ -434,7 +434,7 @@ public class MainActivity extends BaseGameActivity implements
                 // LibraryManager.INSTANCE.sort();
                 fileToAdd = null;
             } else if (file.getName().toLowerCase().endsWith(".osk")) {
-                ToastLogger.showText(StringTable.get(com.osudroid.resources.R.string.library_skin_importing), false);
+                ToastLogger.showText(StringTable.get(R.string.library_skin_importing), false);
                 FileUtils.extractZip(fileToAdd, Config.getSkinTopPath());
                 fileToAdd = null;
             } else if (file.getName().endsWith(".odr")) {

--- a/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
+++ b/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
@@ -434,7 +434,7 @@ public class MainActivity extends BaseGameActivity implements
                 // LibraryManager.INSTANCE.sort();
                 fileToAdd = null;
             } else if (file.getName().toLowerCase().endsWith(".osk")) {
-                ToastLogger.showText("Importing skins...", false);
+                ToastLogger.showText(StringTable.get(com.osudroid.resources.R.string.library_skin_importing), false);
                 FileUtils.extractZip(fileToAdd, Config.getSkinTopPath());
                 fileToAdd = null;
             } else if (file.getName().endsWith(".odr")) {

--- a/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
+++ b/src/ru/nsu/ccfit/zuev/osu/MainActivity.java
@@ -105,6 +105,7 @@ public class MainActivity extends BaseGameActivity implements
     public static SongService songService;
     public ServiceConnection connection;
     private String fileToAdd = null;
+    private Uri contentUriToAdd = null;
     private SaveServiceObject saveServiceObject;
     private FirebaseAnalytics analytics;
     private FirebaseCrashlytics crashlytics;
@@ -421,6 +422,10 @@ public class MainActivity extends BaseGameActivity implements
 
     public void loadBeatmapLibrary() {
         GlobalManager.getInstance().setInfo("Checking for new maps...");
+        if (contentUriToAdd != null) {
+            fileToAdd = copyContentUriToCache(contentUriToAdd);
+            contentUriToAdd = null;
+        }
         final File mainDir = new File(Config.getCorePath());
         final HashSet<String> forceImportedBeatmaps = new HashSet<>();
         if (fileToAdd != null) {
@@ -641,7 +646,7 @@ public class MainActivity extends BaseGameActivity implements
                 if (ContentResolver.SCHEME_FILE.equals(scheme)) {
                     fileToAdd = data.getPath();
                 } else if (ContentResolver.SCHEME_CONTENT.equals(scheme)) {
-                    fileToAdd = copyContentUriToCache(data);
+                    contentUriToAdd = data;
                 }
             }
         }


### PR DESCRIPTION
Intent filters have been quite outdated for a while. Since Android 7, [the `file://` URI scheme has been discouraged](https://developer.android.com/about/versions/nougat/android-7.0-changes#perm). The `content://` URI scheme should be used instead. That URI scheme was not used in the manifest at all, so modern file managers, browsers (Google Chrome, Firefox), and download managers were unable to locate the game.

This PR adds the URI scheme across all supported file types (`.osz`, `.osk`, `.odr`, `.edr`) as well as their MIME types (`application/x-osu-beatmap-archive`, `application/x-osu-skin-archive`, etc.). It also adds necessary explicit handling for `content://` URI scheme. For example, `ImportReplayActivity` would previously fail on some `content://` URIs (often a numeric download ID like `/public_downloads/1234`), which prevents the activity from locating the file.

In addition to that, several small issues were noticed, which this PR also fixed:
- `beatmapToAdd` was never cleared after processing, so every subsequent call to `beatmapLoadLibrary` would reattempt the import. The file may have been deleted by then, which causes `FileUtils.extractZip` to fail and delete the successfully extracted beatmap/skin folder on its failure path.
- `.osk` files were treated as `.zip` files, so the import would silently fail.