### PR TITLE
Include original difficulty value in `ModDifficultyAdjust` serialization

### DIFF
--- a/src/com/osudroid/mods/ModDifficultyAdjust.kt
+++ b/src/com/osudroid/mods/ModDifficultyAdjust.kt
@@ -27,11 +27,10 @@ class ModDifficultyAdjust @JvmOverloads constructor(
     /**
      * The circle size to enforce.
      */
-    var cs by NullableFloatModSetting(
+    var cs by DifficultyAdjustModSetting(
         name = "Circle size",
         key = "cs",
         valueFormatter = { (it ?: defaultValue)?.roundBy(1)?.toString() ?: "None" },
-        defaultValue = null,
         minValue = 0f,
         maxValue = 15f,
         step = 0.1f,
@@ -42,11 +41,10 @@ class ModDifficultyAdjust @JvmOverloads constructor(
     /**
      * The approach rate to enforce.
      */
-    var ar by NullableFloatModSetting(
+    var ar by DifficultyAdjustModSetting(
         name = "Approach rate",
         key = "ar",
         valueFormatter = { (it ?: defaultValue)?.roundBy(1)?.toString() ?: "None" },
-        defaultValue = null,
         minValue = 0f,
         maxValue = 12.5f,
         step = 0.1f,
@@ -57,11 +55,10 @@ class ModDifficultyAdjust @JvmOverloads constructor(
     /**
      * The overall difficulty to enforce.
      */
-    var od by NullableFloatModSetting(
+    var od by DifficultyAdjustModSetting(
         name = "Overall difficulty",
         key = "od",
         valueFormatter = { (it ?: defaultValue)?.roundBy(1)?.toString() ?: "None" },
-        defaultValue = null,
         minValue = 0f,
         maxValue = 11f,
         step = 0.1f,
@@ -72,11 +69,10 @@ class ModDifficultyAdjust @JvmOverloads constructor(
     /**
      * The health drain rate to enforce.
      */
-    var hp by NullableFloatModSetting(
+    var hp by DifficultyAdjustModSetting(
         name = "Health drain",
         key = "hp",
         valueFormatter = { (it ?: defaultValue)?.roundBy(1)?.toString() ?: "None" },
-        defaultValue = null,
         minValue = 0f,
         maxValue = 11f,
         step = 0.1f,
@@ -111,23 +107,31 @@ class ModDifficultyAdjust @JvmOverloads constructor(
         get() {
             // Graph: https://www.desmos.com/calculator/yrggkhrkzz
             var multiplier = 1f
-            val cs = getModSettingDelegate<NullableFloatModSetting>(::cs)
-            val od = getModSettingDelegate<NullableFloatModSetting>(::od)
+            val cs = getModSettingDelegate<DifficultyAdjustModSetting>(::cs)
+            val od = getModSettingDelegate<DifficultyAdjustModSetting>(::od)
 
-            if (cs.value != null && cs.defaultValue != null) {
-                val diff = cs.value!! - cs.defaultValue!!
+            if (cs.value != null) {
+                val original = cs.originalValue ?: cs.defaultValue
 
-                multiplier *=
-                    if (diff >= 0) 1 + 0.0075f * diff.pow(1.5f)
-                    else 2 / (1 + exp(-0.5f * diff))
+                if (original != null) {
+                    val diff = cs.value!! - original
+
+                    multiplier *=
+                        if (diff >= 0) 1 + 0.0075f * diff.pow(1.5f)
+                        else 2 / (1 + exp(-0.5f * diff))
+                }
             }
 
-            if (od.value != null && od.defaultValue != null) {
-                val diff = od.value!! - od.defaultValue!!
+            if (od.value != null) {
+                val original = od.originalValue ?: od.defaultValue
 
-                multiplier *=
-                    if (diff >= 0) 1 + 0.005f * diff.pow(1.3f)
-                    else 2 / (1 + exp(-0.25f * diff))
+                if (original != null) {
+                    val diff = od.value!! - original
+
+                    multiplier *=
+                        if (diff >= 0) 1 + 0.005f * diff.pow(1.3f)
+                        else 2 / (1 + exp(-0.25f * diff))
+                }
             }
 
             return multiplier
@@ -188,16 +192,21 @@ class ModDifficultyAdjust @JvmOverloads constructor(
     override fun applyFromBeatmap(beatmap: Beatmap) {
         val difficulty = beatmap.difficulty
 
-        updateDefaultValue(::cs, difficulty.gameplayCS)
-        updateDefaultValue(::ar, difficulty.ar)
-        updateDefaultValue(::od, difficulty.od)
-        updateDefaultValue(::hp, difficulty.hp)
+        updateBeatmapValue(::cs, difficulty.gameplayCS)
+        updateBeatmapValue(::ar, difficulty.ar)
+        updateBeatmapValue(::od, difficulty.od)
+        updateBeatmapValue(::hp, difficulty.hp)
     }
 
     private fun updateDefaultValue(property: KProperty0<Float?>, value: Float?) {
-        val delegate = getModSettingDelegate<NullableFloatModSetting>(property)
+        getModSettingDelegate<DifficultyAdjustModSetting>(property).defaultValue = value
+    }
+
+    private fun updateBeatmapValue(property: KProperty0<Float?>, value: Float?) {
+        val delegate = getModSettingDelegate<DifficultyAdjustModSetting>(property)
 
         delegate.defaultValue = value
+        delegate.originalValue = value
     }
 
     private fun applyOldFadeAdjustment(hitObject: HitObject, mods: Iterable<Mod>) {

--- a/src/com/osudroid/mods/settings/DifficultyAdjustModSetting.kt
+++ b/src/com/osudroid/mods/settings/DifficultyAdjustModSetting.kt
@@ -1,0 +1,99 @@
+package com.osudroid.mods.settings
+
+import com.osudroid.mods.IModRequiresOriginalBeatmap
+import com.osudroid.mods.ModDifficultyAdjust
+import kotlinx.serialization.json.*
+
+/**
+ * A [NullableFloatModSetting] variant for [ModDifficultyAdjust] that embeds the beatmap's original difficulty value
+ * alongside the user's adjusted value in the serialized format:
+ *
+ * ```json
+ * {"adjusted": 7.0, "original": 4.0}
+ * ```
+ *
+ * When [originalValue] is non-null, the score multiplier can be computed from the serialized format alone, without a
+ * beatmap lookup. When `null` (old data or beatmap absent at migration time), the caller must invoke
+ * [IModRequiresOriginalBeatmap.applyFromBeatmap] first.
+ *
+ * Old scalar values (`"cs": 7.0`) are accepted on [load] for backward compatibility.
+ */
+class DifficultyAdjustModSetting(
+    name: String,
+    key: String,
+    valueFormatter: ModSetting<Float?>.(Float?) -> String,
+    minValue: Float,
+    maxValue: Float,
+    step: Float,
+    precision: Int,
+    orderPosition: Int,
+    useManualInput: Boolean = false
+) : NullableFloatModSetting(
+    name = name,
+    key = key,
+    valueFormatter = valueFormatter,
+    defaultValue = null,
+    minValue = minValue,
+    maxValue = maxValue,
+    step = step,
+    precision = precision,
+    orderPosition = orderPosition,
+    useManualInput = useManualInput
+) {
+    /**
+     * The beatmap's original value for this setting, populated by [IModRequiresOriginalBeatmap.applyFromBeatmap].
+     *
+     * Non-null means the score multiplier is self-contained; `null` means a beatmap lookup is needed.
+     */
+    var originalValue: Float? = null
+
+    override fun load(json: JsonObject) {
+        if (key == null) {
+            return
+        }
+
+        val element = json[key]
+
+        if (element is JsonObject) {
+            value = element["adjusted"]?.takeUnless { it is JsonNull }?.jsonPrimitive?.floatOrNull
+
+            val original = element["original"]?.takeUnless { it is JsonNull }?.jsonPrimitive?.floatOrNull
+            originalValue = original
+
+            if (original != null) {
+                defaultValue = original
+            }
+        } else {
+            // This is in old scalar format (or null / JsonNull). Delegate to parent for backward compatibility.
+            super.load(json)
+
+            originalValue = null
+        }
+    }
+
+    override fun save(builder: JsonObjectBuilder) {
+        if (key == null || value == null) {
+            return
+        }
+
+        builder.put(key, buildJsonObject {
+            put("adjusted", value!!)
+
+            val original = originalValue
+
+            if (original != null) {
+                put("original", original)
+            } else {
+                put("original", JsonNull)
+            }
+        })
+    }
+
+    override fun copyFrom(other: ModSetting<Float?>) {
+        super.copyFrom(other)
+
+        if (other is DifficultyAdjustModSetting) {
+            originalValue = other.originalValue
+        }
+    }
+}

--- a/src/com/osudroid/mods/settings/NumberModSetting.kt
+++ b/src/com/osudroid/mods/settings/NumberModSetting.kt
@@ -164,7 +164,7 @@ open class NullableNumberModSetting<T>(
         super.copyFrom(other)
     }
 
-    final override fun load(json: JsonObject) {
+    override fun load(json: JsonObject) {
         if (key == null) {
             return
         }
@@ -189,7 +189,7 @@ open class NullableNumberModSetting<T>(
         } as? T ?: defaultValue
     }
 
-    final override fun save(builder: JsonObjectBuilder) = saveToJSON(builder)
+    override fun save(builder: JsonObjectBuilder) = saveToJSON(builder)
 }
 
 /**

--- a/tests/test/kotlin/com/osudroid/mods/ModDifficultyAdjustTest.kt
+++ b/tests/test/kotlin/com/osudroid/mods/ModDifficultyAdjustTest.kt
@@ -7,6 +7,13 @@ import com.osudroid.beatmaps.hitobjects.SliderPathType
 import com.osudroid.beatmaps.sections.BeatmapControlPoints
 import com.osudroid.beatmaps.sections.BeatmapDifficulty
 import com.osudroid.math.Vector2
+import com.osudroid.mods.settings.DifficultyAdjustModSetting
+import com.osudroid.utils.ModUtils
+import kotlin.math.pow
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.float
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert
 import org.junit.Test
 
@@ -155,4 +162,138 @@ class ModDifficultyAdjustTest {
         Assert.assertTrue(ModDifficultyAdjust().usesDefaultSettings)
         Assert.assertFalse(ModDifficultyAdjust(cs = 4f).usesDefaultSettings)
     }
+
+    @Test
+    fun `Test serialization embeds original value`() {
+        // Set adjusted values after construction so value != defaultValue (isDefault = false).
+        ModDifficultyAdjust().also {
+            it.cs = 7f
+            it.od = 9f
+            it.setOriginals(cs = 4f, od = 8f)
+        }.toAPIMod().settings!!.apply {
+            Assert.assertEquals(7f, get("cs")!!.jsonObject["adjusted"]!!.jsonPrimitive.float, 0f)
+            Assert.assertEquals(4f, get("cs")!!.jsonObject["original"]!!.jsonPrimitive.float, 0f)
+            Assert.assertEquals(9f, get("od")!!.jsonObject["adjusted"]!!.jsonPrimitive.float, 0f)
+            Assert.assertEquals(8f, get("od")!!.jsonObject["original"]!!.jsonPrimitive.float, 0f)
+        }
+    }
+
+    @Test
+    fun `Test serialization writes null original when beatmap is unknown`() {
+        ModDifficultyAdjust().also { it.cs = 7f }.toAPIMod().settings!!.apply {
+            Assert.assertEquals(7f, get("cs")!!.jsonObject["adjusted"]!!.jsonPrimitive.float, 0f)
+            Assert.assertSame(JsonNull, get("cs")!!.jsonObject["original"])
+        }
+    }
+
+    @Test
+    fun `Test deserialization of new format`() {
+        val mod = ModDifficultyAdjust().also {
+            it.cs = 7f
+            it.od = 9f
+            it.setOriginals(cs = 4f, od = 8f)
+        }
+
+        val deserialized = mod.roundTrip()
+
+        Assert.assertEquals(7f, deserialized.cs)
+        Assert.assertEquals(4f, deserialized.csDelegate().originalValue)
+        Assert.assertEquals(9f, deserialized.od)
+        Assert.assertEquals(8f, deserialized.odDelegate().originalValue)
+    }
+
+    @Test
+    fun `Test deserialization of old scalar format`() {
+        val json = """[{"acronym":"DA","settings":{"cs":7.0,"od":9.0}}]"""
+        val deserialized = ModUtils.deserializeMods(json).ofType<ModDifficultyAdjust>()!!
+
+        Assert.assertEquals(7f, deserialized.cs)
+        Assert.assertNull(deserialized.csDelegate().originalValue)
+        Assert.assertEquals(9f, deserialized.od)
+        Assert.assertNull(deserialized.odDelegate().originalValue)
+    }
+
+    @Test
+    fun `Test deserialization of new format with null original`() {
+        val json = """[{"acronym":"DA","settings":{"cs":{"adjusted":7.0,"original":null}}}]"""
+        val deserialized = ModUtils.deserializeMods(json).ofType<ModDifficultyAdjust>()!!
+
+        Assert.assertEquals(7f, deserialized.cs)
+        Assert.assertNull(deserialized.csDelegate().originalValue)
+    }
+
+    @Test
+    fun `Test score multiplier uses embedded original`() {
+        val mod = ModDifficultyAdjust().also {
+            it.cs = 7f
+            it.od = 9f
+            it.setOriginals(cs = 4f, od = 8f)
+        }
+
+        val csDiff = 7f - 4f
+        val odDiff = 9f - 8f
+        val expected = (1 + 0.0075f * csDiff.toDouble().pow(1.5).toFloat()) *
+                       (1 + 0.005f  * odDiff.toDouble().pow(1.3).toFloat())
+
+        Assert.assertEquals(expected, mod.scoreMultiplier, 1e-6f)
+    }
+
+    @Test
+    fun `Test score multiplier is 1 without original or default`() {
+        // value is set but both originalValue and defaultValue are null, so there is no delta to compute.
+        val mod = ModDifficultyAdjust().also {
+            it.cs = 7f
+            it.od = 9f
+        }
+
+        Assert.assertEquals(1f, mod.scoreMultiplier, 0f)
+    }
+
+    @Test
+    fun `Test score multiplier falls back to defaultValue when original is absent`() {
+        val mod = ModDifficultyAdjust().also {
+            it.cs = 7f
+            // Simulate applyFromBeatmap without embedded original.
+            it.csDelegate().defaultValue = 4f
+        }
+
+        val diff = 7f - 4f
+        val expected = 1 + 0.0075f * diff.toDouble().pow(1.5).toFloat()
+
+        Assert.assertEquals(expected, mod.scoreMultiplier, 1e-6f)
+    }
+
+    @Test
+    fun `Test deep copy preserves original values`() {
+        val mod = ModDifficultyAdjust().also {
+            it.cs = 7f
+            it.od = 9f
+            it.setOriginals(cs = 4f, od = 8f)
+        }
+
+        val copy = mod.deepCopy() as ModDifficultyAdjust
+
+        Assert.assertEquals(7f, copy.cs)
+        Assert.assertEquals(4f, copy.csDelegate().originalValue)
+        Assert.assertEquals(9f, copy.od)
+        Assert.assertEquals(8f, copy.odDelegate().originalValue)
+    }
+
+    private fun ModDifficultyAdjust.csDelegate() = getModSettingDelegate<DifficultyAdjustModSetting>(::cs)
+    private fun ModDifficultyAdjust.odDelegate() = getModSettingDelegate<DifficultyAdjustModSetting>(::od)
+
+    /**
+     * Sets both [DifficultyAdjustModSetting.originalValue] and [DifficultyAdjustModSetting.defaultValue] for the
+     * named dimensions, mirroring what [ModDifficultyAdjust.updateBeatmapValue] does when
+     * [com.osudroid.mods.IModRequiresOriginalBeatmap.applyFromBeatmap] is called.
+     */
+    private fun ModDifficultyAdjust.setOriginals(cs: Float? = null, ar: Float? = null, od: Float? = null, hp: Float? = null) {
+        cs?.let { getModSettingDelegate<DifficultyAdjustModSetting>(::cs).also { d -> d.defaultValue = it; d.originalValue = it } }
+        ar?.let { getModSettingDelegate<DifficultyAdjustModSetting>(::ar).also { d -> d.defaultValue = it; d.originalValue = it } }
+        od?.let { getModSettingDelegate<DifficultyAdjustModSetting>(::od).also { d -> d.defaultValue = it; d.originalValue = it } }
+        hp?.let { getModSettingDelegate<DifficultyAdjustModSetting>(::hp).also { d -> d.defaultValue = it; d.originalValue = it } }
+    }
+
+    private fun ModDifficultyAdjust.roundTrip() =
+        ModUtils.deserializeMods(ModUtils.serializeMods(listOf(this))).ofType<ModDifficultyAdjust>()!!
 }


### PR DESCRIPTION
A bit of side task for #639 but is required to alleviate the complexity of that PR.

Currently, if a beatmap does not exist, there is no way to derive the real score multiplier of `ModDifficultyAdjust`. This is because the mod relies on the beatmap's difficulty to compute its score multiplier. This PR solves that problem by including the original difficulty value alongside the adjusted one in the mod's serialized format. This transitions the format from:
```json
{"settings": {"cs": 4.2 }}
```
to:
```json
{"settings": {"cs": {"original": 4, "adjusted": 4.2 }}
```
which will allow for score multiplier calculation without needing the beatmap. Because the server accepts scores from all beatmaps, this is crucial if the mod is ranked in the future so that server-side score multiplier calculation can be done for all scores.

This will be merged before #639 and version 4 to 5 database migration in that PR will include a migration to this new serialization format before score conversion. If the beatmap is not present, the original difficulty value will be `null`.