### PR TITLE
Replace `MediaPlayer` with FFmpeg-backed `ExoPlayer`

### DIFF
--- a/BUILDING_FFMPEG_AAR.md
+++ b/BUILDING_FFMPEG_AAR.md
@@ -1,0 +1,130 @@
+# Building media3-decoder-ffmpeg.aar
+
+This guide documents how to rebuild `libs/media3-decoder-ffmpeg.aar` from source.
+The AAR available on Maven Central ships only Java/Kotlin wrappers, so the compiled
+FFmpeg `.so` files must be built manually via the Android NDK.
+
+All shell commands run on **Linux**, **macOS**, or **WSL** on Windows.
+
+---
+
+## Prerequisites
+
+- **Android NDK r26b** (recommended by Media3) — download from the [Android NDK archive](https://github.com/android/ndk/wiki/Unsupported-Downloads). Other recent versions (r25b confirmed working) should also work when targeting API 24.
+- **Android SDK** with at least one platform installed
+- **Java 17**
+- **Git**
+
+---
+
+## Step 0 — Set shell variables
+
+Define these variables once. All subsequent commands reference them.
+
+```bash
+# Root of the cloned androidx/media repository
+MEDIA3_ROOT=~/media3
+
+# Android NDK location
+NDK_PATH=~/android-ndk-r26b
+
+# Android SDK location
+ANDROID_HOME=~/android-sdk
+
+# Java 17 home (adjust to match your installation)
+JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+
+# Shorthand used by build_ffmpeg.sh
+FFMPEG_JNI="$MEDIA3_ROOT/libraries/decoder_ffmpeg/src/main/jni"
+```
+
+---
+
+## Step 1 — Clone Media3
+
+```bash
+git clone https://github.com/androidx/media.git "$MEDIA3_ROOT"
+```
+
+---
+
+## Step 2 — Fetch the FFmpeg source
+
+The Media3 decoder module expects FFmpeg source at `$FFMPEG_JNI/ffmpeg/`.
+It is not included in the Media3 repository, so clone it separately:
+
+```bash
+cd "$FFMPEG_JNI"
+git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg
+cd ffmpeg && git checkout release/6.0
+```
+
+---
+
+## Step 3 — Compile FFmpeg static libraries
+
+Run the bundled build script from the `jni/` directory:
+
+```bash
+cd "$FFMPEG_JNI"
+
+./build_ffmpeg.sh \
+  "$NDK_PATH" \
+  linux-x86_64 \
+  "armeabi-v7a arm64-v8a x86 x86_64" \
+  24
+```
+
+**Arguments:**
+| Argument | Description |
+|---|---|
+| `"$NDK_PATH"` | Path to the NDK root directory |
+| `linux-x86_64` | Host platform (use `darwin-arm64` on Apple Silicon Macs, `darwin-x86_64` on Intel Macs) |
+| `"armeabi-v7a arm64-v8a x86 x86_64"` | Target ABIs, space-separated and quoted |
+| `24` | Android API level. Must match or exceed `minSdkVersion` in [`build.gradle`](build.gradle) |
+
+> **Important:** The 4th argument controls both FFmpeg's `./configure` step and
+> the CMake linker sysroot. Passing an API level below 23 causes a linker error
+> because `stderr` is not exported by Android's `libc.so` stubs until API 23.
+> Always pass at least `24` here.
+
+On success, static libraries appear at:
+
+```
+$FFMPEG_JNI/ffmpeg/android-libs/arm64-v8a/libavcodec.a
+$FFMPEG_JNI/ffmpeg/android-libs/arm64-v8a/libavutil.a
+$FFMPEG_JNI/ffmpeg/android-libs/arm64-v8a/libswresample.a
+# (same for armeabi-v7a, x86, x86_64)
+```
+
+---
+
+## Step 4 — Build the AAR with Gradle
+
+```bash
+cd "$MEDIA3_ROOT"
+
+ANDROID_HOME="$ANDROID_HOME" \
+JAVA_HOME="$JAVA_HOME" \
+./gradlew :lib-decoder-ffmpeg:assembleRelease
+```
+
+The AAR is written to:
+
+```
+$MEDIA3_ROOT/libraries/decoder_ffmpeg/buildout/outputs/aar/lib-decoder-ffmpeg-release.aar
+```
+
+> Note: the output directory is `buildout/`, not the standard `build/`.
+
+---
+
+## Step 5 — Copy the AAR into the project
+
+```bash
+# Set this to your project root
+OSU_DROID_ROOT=~/osu-droid
+
+cp "$MEDIA3_ROOT/libraries/decoder_ffmpeg/buildout/outputs/aar/lib-decoder-ffmpeg-release.aar" \
+   "$OSU_DROID_ROOT/libs/media3-decoder-ffmpeg.aar"
+```

--- a/build.gradle
+++ b/build.gradle
@@ -218,6 +218,10 @@ dependencies {
         exclude group: 'org.json', module: 'json'
     }
 
+    // Video playback
+    implementation "androidx.media3:media3-exoplayer:1.4.1"
+    implementation files('libs/media3-decoder-ffmpeg.aar')
+
     // Room
     implementation "androidx.room:room-runtime:$room_version"
     annotationProcessor "androidx.room:room-compiler:$room_version"

--- a/res/xml/settings_library.xml
+++ b/res/xml/settings_library.xml
@@ -26,13 +26,6 @@
             app:layout="@layout/settings_preference_checkbox" />
 
         <CheckBoxPreference
-            android:defaultValue="true"
-            android:key="deleteUnsupportedVideos"
-            android:summary="@string/opt_delete_unsupported_videos_summary"
-            android:title="@string/opt_delete_unsupported_videos_title"
-            app:layout="@layout/settings_preference_checkbox" />
-
-        <CheckBoxPreference
             android:defaultValue="false"
             android:key="preferNoVideoDownloads"
             android:summary="@string/opt_prefer_no_video_downloads_summary"

--- a/src/com/reco1l/andengine/sprite/UIVideoSprite.kt
+++ b/src/com/reco1l/andengine/sprite/UIVideoSprite.kt
@@ -67,7 +67,8 @@ class UIVideoSprite(source: String, private val engine: Engine) : Sprite(0f, 0f,
     }
 
     fun release() {
-        mainHandler.post { texture.player.release() }
+        // Unloading the texture triggers deleteTextureOnHardware, which posts a single ordered block
+        // to the main handler: setVideoSurface(null) --> surface teardown --> player.release().
         engine.textureManager.unloadTexture(texture)
     }
 

--- a/src/com/reco1l/andengine/sprite/UIVideoSprite.kt
+++ b/src/com/reco1l/andengine/sprite/UIVideoSprite.kt
@@ -3,6 +3,7 @@ package com.reco1l.andengine.sprite
 import android.opengl.GLES11Ext.GL_TEXTURE_EXTERNAL_OES
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.util.UnstableApi
+import androidx.annotation.OptIn
 import com.reco1l.andengine.texture.*
 import org.anddev.andengine.engine.Engine
 import org.anddev.andengine.engine.camera.Camera
@@ -11,7 +12,7 @@ import org.anddev.andengine.opengl.texture.region.*
 import org.anddev.andengine.opengl.util.GLHelper
 import javax.microedition.khronos.opengles.GL10
 
-@UnstableApi
+@OptIn(UnstableApi::class)
 class UIVideoSprite(source: String, private val engine: Engine) : Sprite(0f, 0f, VideoTexture(source).let {
     TextureRegion(it, 0, 0, it.width, it.height)
 }) {

--- a/src/com/reco1l/andengine/sprite/UIVideoSprite.kt
+++ b/src/com/reco1l/andengine/sprite/UIVideoSprite.kt
@@ -1,6 +1,8 @@
 package com.reco1l.andengine.sprite
 
 import android.opengl.GLES11Ext.GL_TEXTURE_EXTERNAL_OES
+import android.os.Handler
+import android.os.Looper
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.util.UnstableApi
 import androidx.annotation.OptIn
@@ -57,24 +59,24 @@ class UIVideoSprite(source: String, private val engine: Engine) : Sprite(0f, 0f,
     }
 
     fun release() {
-        texture.player.release()
+        mainHandler.post { texture.player.release() }
         engine.textureManager.unloadTexture(texture)
     }
 
     fun play() {
-        texture.player.play()
+        mainHandler.post { texture.player.play() }
     }
 
     fun pause() {
-        texture.player.pause()
+        mainHandler.post { texture.player.pause() }
     }
 
     fun seekTo(ms: Int) {
-        texture.player.seekTo(ms.toLong())
+        mainHandler.post { texture.player.seekTo(ms.toLong()) }
     }
 
     fun setPlaybackSpeed(speed: Float) {
-        texture.player.playbackParameters = PlaybackParameters(speed)
+        mainHandler.post { texture.player.playbackParameters = PlaybackParameters(speed) }
     }
 
 
@@ -86,5 +88,9 @@ class UIVideoSprite(source: String, private val engine: Engine) : Sprite(0f, 0f,
         } catch (_: Throwable) {}
 
         super.finalize()
+    }
+
+    companion object {
+        private val mainHandler = Handler(Looper.getMainLooper())
     }
 }

--- a/src/com/reco1l/andengine/sprite/UIVideoSprite.kt
+++ b/src/com/reco1l/andengine/sprite/UIVideoSprite.kt
@@ -1,8 +1,8 @@
 package com.reco1l.andengine.sprite
 
-import android.media.*
 import android.opengl.GLES11Ext.GL_TEXTURE_EXTERNAL_OES
-import android.os.*
+import androidx.media3.common.PlaybackParameters
+import androidx.media3.common.util.UnstableApi
 import com.reco1l.andengine.texture.*
 import org.anddev.andengine.engine.Engine
 import org.anddev.andengine.engine.camera.Camera
@@ -11,6 +11,7 @@ import org.anddev.andengine.opengl.texture.region.*
 import org.anddev.andengine.opengl.util.GLHelper
 import javax.microedition.khronos.opengles.GL10
 
+@UnstableApi
 class UIVideoSprite(source: String, private val engine: Engine) : Sprite(0f, 0f, VideoTexture(source).let {
     TextureRegion(it, 0, 0, it.width, it.height)
 }) {
@@ -50,13 +51,17 @@ class UIVideoSprite(source: String, private val engine: Engine) : Sprite(0f, 0f,
     }
 
 
+    fun setOnReady(callback: Runnable) {
+        texture.onReady = callback
+    }
+
     fun release() {
         texture.player.release()
         engine.textureManager.unloadTexture(texture)
     }
 
     fun play() {
-        texture.player.start()
+        texture.player.play()
     }
 
     fun pause() {
@@ -64,16 +69,11 @@ class UIVideoSprite(source: String, private val engine: Engine) : Sprite(0f, 0f,
     }
 
     fun seekTo(ms: Int) {
-        // Unfortunately in old versions we can't seek at closest frame from the desired position.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            texture.player.seekTo(ms.toLong(), MediaPlayer.SEEK_CLOSEST)
-        } else {
-            texture.player.seekTo(ms)
-        }
+        texture.player.seekTo(ms.toLong())
     }
 
     fun setPlaybackSpeed(speed: Float) {
-        texture.player.playbackParams = texture.player.playbackParams.setSpeed(speed)
+        texture.player.playbackParameters = PlaybackParameters(speed)
     }
 
 
@@ -82,5 +82,3 @@ class UIVideoSprite(source: String, private val engine: Engine) : Sprite(0f, 0f,
         super.finalize()
     }
 }
-
-

--- a/src/com/reco1l/andengine/sprite/UIVideoSprite.kt
+++ b/src/com/reco1l/andengine/sprite/UIVideoSprite.kt
@@ -55,7 +55,15 @@ class UIVideoSprite(source: String, private val engine: Engine) : Sprite(0f, 0f,
 
 
     fun setOnReady(callback: Runnable) {
-        texture.onReady = callback
+        texture.onReady = Runnable {
+            // Update the TextureRegion UV extents and Sprite vertex dimensions now that the actual video resolution is
+            // known.
+            // Both were constructed as 0×0 because ExoPlayer reports dimensions asynchronously via onVideoSizeChanged.
+            textureRegion.setWidth(texture.videoWidth)
+            textureRegion.setHeight(texture.videoHeight)
+            setSize(texture.videoWidth.toFloat(), texture.videoHeight.toFloat())
+            callback.run()
+        }
     }
 
     fun release() {

--- a/src/com/reco1l/andengine/sprite/UIVideoSprite.kt
+++ b/src/com/reco1l/andengine/sprite/UIVideoSprite.kt
@@ -79,7 +79,12 @@ class UIVideoSprite(source: String, private val engine: Engine) : Sprite(0f, 0f,
 
 
     override fun finalize() {
-        release()
+        // Guard against a partially-constructed object: if VideoTexture's init threw,
+        // texture.player is null at the bytecode level despite Kotlin's non-null type.
+        try {
+            release()
+        } catch (_: Throwable) {}
+
         super.finalize()
     }
 }

--- a/src/com/reco1l/andengine/sprite/UIVideoSprite.kt
+++ b/src/com/reco1l/andengine/sprite/UIVideoSprite.kt
@@ -6,6 +6,7 @@ import android.os.Looper
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.util.UnstableApi
 import androidx.annotation.OptIn
+import com.osudroid.utils.updateThread
 import com.reco1l.andengine.texture.*
 import org.anddev.andengine.engine.Engine
 import org.anddev.andengine.engine.camera.Camera
@@ -56,13 +57,16 @@ class UIVideoSprite(source: String, private val engine: Engine) : Sprite(0f, 0f,
 
     fun setOnReady(callback: Runnable) {
         texture.onReady = Runnable {
-            // Update the TextureRegion UV extents and Sprite vertex dimensions now that the actual video resolution is
-            // known.
-            // Both were constructed as 0×0 because ExoPlayer reports dimensions asynchronously via onVideoSizeChanged.
-            textureRegion.setWidth(texture.videoWidth)
-            textureRegion.setHeight(texture.videoHeight)
-            setSize(texture.videoWidth.toFloat(), texture.videoHeight.toFloat())
-            callback.run()
+            updateThread {
+                // Update the TextureRegion UV extents and Sprite vertex dimensions now that the actual video resolution is
+                // known.
+                // Both were constructed as 0×0 because ExoPlayer reports dimensions asynchronously via onVideoSizeChanged.
+                textureRegion.setWidth(texture.videoWidth)
+                textureRegion.setHeight(texture.videoHeight)
+                setSize(texture.videoWidth.toFloat(), texture.videoHeight.toFloat())
+
+                mainHandler.post(callback)
+            }
         }
     }
 

--- a/src/com/reco1l/andengine/texture/VideoTexture.kt
+++ b/src/com/reco1l/andengine/texture/VideoTexture.kt
@@ -88,26 +88,29 @@ class VideoTexture(val source: String) : Texture(
             }
         }.setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON)
 
+        // ExoPlayer's builder is thread-safe, but subsequent API calls are not.
+        // ExoPlayer enforces that they run on its designated looper (main thread here).
         player = ExoPlayer.Builder(context, renderersFactory)
             .setLooper(Looper.getMainLooper())
             .build()
-            .apply {
-                volume = 0f
-                repeatMode = Player.REPEAT_MODE_OFF
-                addListener(object : Player.Listener {
-                    override fun onVideoSizeChanged(videoSize: VideoSize) {
-                        videoWidth = videoSize.width
-                        videoHeight = videoSize.height
-                        onReady?.run()
-                    }
 
-                    override fun onPlayerError(error: PlaybackException) {
-                        Log.e("VideoTexture", "ExoPlayer error occurred", error)
-                    }
-                })
-                setMediaItem(MediaItem.fromUri(Uri.fromFile(File(source))))
-                prepare()
-            }
+        mainHandler.post {
+            player.volume = 0f
+            player.repeatMode = Player.REPEAT_MODE_OFF
+            player.addListener(object : Player.Listener {
+                override fun onVideoSizeChanged(videoSize: VideoSize) {
+                    videoWidth = videoSize.width
+                    videoHeight = videoSize.height
+                    onReady?.run()
+                }
+
+                override fun onPlayerError(error: PlaybackException) {
+                    Log.e("VideoTexture", "ExoPlayer error occurred", error)
+                }
+            })
+            player.setMediaItem(MediaItem.fromUri(Uri.fromFile(File(source))))
+            player.prepare()
+        }
     }
 
     override fun writeTextureToHardware(pGL: GL10) {
@@ -120,15 +123,30 @@ class VideoTexture(val source: String) : Texture(
 
         surfaceTexture = SurfaceTexture(mHardwareTextureID)
 
+        // SurfaceTexture must be created on the GL thread (tied to the GL texture ID),
+        // but setVideoSurface must be called on ExoPlayer's main-thread looper.
         val surface = Surface(surfaceTexture)
-        player.setVideoSurface(surface)
-        surface.release()
+
+        mainHandler.post {
+            player.setVideoSurface(surface)
+            surface.release()
+        }
     }
 
     override fun deleteTextureOnHardware(pGL: GL10?) {
 
-        surfaceTexture?.release()
+        val st = surfaceTexture
         surfaceTexture = null
+
+        mainHandler.post {
+            // Detach the surface before releasing the SurfaceTexture so ExoPlayer
+            // stops rendering to it. Ignored silently if the player is already released.
+            try {
+                player.setVideoSurface(null)
+            } catch (_: Exception) {}
+
+            st?.release()
+        }
 
         super.deleteTextureOnHardware(pGL)
     }
@@ -143,4 +161,8 @@ class VideoTexture(val source: String) : Texture(
 
     override fun getWidth() = videoWidth
     override fun getHeight() = videoHeight
+
+    companion object {
+        private val mainHandler = Handler(Looper.getMainLooper())
+    }
 }

--- a/src/com/reco1l/andengine/texture/VideoTexture.kt
+++ b/src/com/reco1l/andengine/texture/VideoTexture.kt
@@ -149,18 +149,18 @@ class VideoTexture(val source: String) : Texture(
         surface = null
 
         mainHandler.post {
-            // The order matters here:
-            // - Clear ExoPlayer's surface reference first so its playback thread stops writing to the native window
-            // - Release the Java wrapper
-            // - Release the SurfaceTexture
-            //
-            // Ignored silently if the player is already released.
+            // Order matters:
+            // 1. Clear ExoPlayer's surface so the codec thread stops writing to the native window.
+            // 2. Release the Java Surface wrapper.
+            // 3. Release the SurfaceTexture.
+            // 4. Release the player last, after the surface it was writing to is fully torn down.
             try {
                 player.setVideoSurface(null)
             } catch (_: Exception) {}
 
             s?.release()
             st?.release()
+            player.release()
         }
 
         super.deleteTextureOnHardware(pGL)

--- a/src/com/reco1l/andengine/texture/VideoTexture.kt
+++ b/src/com/reco1l/andengine/texture/VideoTexture.kt
@@ -1,15 +1,26 @@
 package com.reco1l.andengine.texture
 
 import android.graphics.*
-import android.media.*
+import android.net.Uri
 import android.opengl.*
+import android.os.Looper
 import android.util.Log
 import android.view.*
+import androidx.media3.common.*
+import androidx.media3.common.util.UnstableApi
+import android.content.Context
+import android.os.Handler
+import androidx.media3.exoplayer.*
+import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
+import androidx.media3.exoplayer.video.VideoRendererEventListener
+import androidx.media3.decoder.ffmpeg.ExperimentalFfmpegVideoRenderer
 import org.anddev.andengine.opengl.texture.*
+import ru.nsu.ccfit.zuev.osu.GlobalManager
 import java.io.*
 import javax.microedition.khronos.opengles.*
 import javax.microedition.khronos.opengles.GL10.*
 
+@UnstableApi
 class VideoTexture(val source: String) : Texture(
     PixelFormat.UNDEFINED,
     TextureOptions(
@@ -22,21 +33,82 @@ class VideoTexture(val source: String) : Texture(
     null
 ) {
 
-    val player = MediaPlayer().apply {
+    val player: ExoPlayer
 
-        setDataSource(source)
-        setVolume(0f, 0f)
-        isLooping = false
-        setOnErrorListener { _, what, extra ->
-            Log.e("VideoTexture", "MediaPlayer error: what=$what extra=$extra")
-            true
+    /**
+     * The callback that is invoked when the video dimensions are available. This is necessary because the dimensions
+     * are not known until the video is prepared, which happens asynchronously.
+     *
+     * The callback will be invoked on the main thread.
+     */
+    @Volatile
+    var onReady: Runnable? = null
+        set(value) {
+            field = value
+
+            // Handle the race where dimensions arrived before the callback was registered.
+            if (videoWidth > 0) {
+                value?.run()
+            }
         }
-        prepare()
-    }
 
+    @Volatile
+    var videoWidth = 0
+        private set
+
+    @Volatile
+    var videoHeight = 0
+        private set
 
     private var surfaceTexture: SurfaceTexture? = null
 
+
+    init {
+        val context = GlobalManager.getInstance().mainActivity.applicationContext
+
+        // DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON auto-discovers FfmpegAudioRenderer via reflection.
+        // ExperimentalFfmpegVideoRenderer must be appended manually because DefaultRenderersFactory looks for the old
+        // name "FfmpegVideoRenderer" (since renamed).
+        val renderersFactory = object : DefaultRenderersFactory(context) {
+            override fun buildVideoRenderers(
+                context: Context,
+                extensionRendererMode: Int,
+                mediaCodecSelector: MediaCodecSelector,
+                enableDecoderFallback: Boolean,
+                eventHandler: Handler,
+                eventListener: VideoRendererEventListener,
+                allowedVideoJoiningTimeMs: Long,
+                out: ArrayList<Renderer>
+            ) {
+                super.buildVideoRenderers(context, extensionRendererMode, mediaCodecSelector,
+                    enableDecoderFallback, eventHandler, eventListener, allowedVideoJoiningTimeMs, out)
+
+                out.add(ExperimentalFfmpegVideoRenderer(
+                    allowedVideoJoiningTimeMs, eventHandler, eventListener, 50))
+            }
+        }.setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON)
+
+        player = ExoPlayer.Builder(context, renderersFactory)
+            .setLooper(Looper.getMainLooper())
+            .build()
+            .apply {
+                volume = 0f
+                repeatMode = Player.REPEAT_MODE_OFF
+                addListener(object : Player.Listener {
+                    override fun onVideoSizeChanged(videoSize: VideoSize) {
+                        videoWidth = videoSize.width
+                        videoHeight = videoSize.height
+                        onReady?.run()
+                    }
+
+                    override fun onPlayerError(error: PlaybackException) {
+                        Log.e("VideoTexture", "ExoPlayer error occurred", error)
+                    }
+                })
+                setMediaItem(MediaItem.fromUri(Uri.fromFile(File(source))))
+                prepare()
+            }
+    }
 
     override fun writeTextureToHardware(pGL: GL10) {
         // Nothing to write, the texture is handled externally by the SurfaceTexture.
@@ -49,7 +121,7 @@ class VideoTexture(val source: String) : Texture(
         surfaceTexture = SurfaceTexture(mHardwareTextureID)
 
         val surface = Surface(surfaceTexture)
-        player.setSurface(surface)
+        player.setVideoSurface(surface)
         surface.release()
     }
 
@@ -69,29 +141,19 @@ class VideoTexture(val source: String) : Texture(
     }
 
 
-    override fun getWidth(): Int {
-        return player.videoWidth
-    }
-
-    override fun getHeight(): Int {
-        return player.videoHeight
-    }
+    override fun getWidth() = videoWidth
+    override fun getHeight() = videoHeight
 
 
     companion object {
 
         /**
-         * See [MediaPlayer documentation](https://developer.android.com/guide/topics/media/platform/supported-formats)
+         * Checks if the file is a video that can be loaded. Since ExoPlayer with Media3's
+         * built-in extractors supports a broad range of container formats (MP4, MKV, WebM,
+         * AVI, FLV, …), we accept any file that exists and let playback fail gracefully if
+         * the format turns out to be unsupported.
          */
-        private val SUPPORTED_VIDEO_FORMATS = arrayOf("3gp", "mp4", "mkv", "webm")
-
-
-        /**
-         * Checks if the file is a supported video format.
-         */
-        fun isSupportedVideo(file: File): Boolean {
-            return file.extension.lowercase() in SUPPORTED_VIDEO_FORMATS
-        }
+        fun isSupportedVideo(file: File) = file.exists()
 
     }
 }

--- a/src/com/reco1l/andengine/texture/VideoTexture.kt
+++ b/src/com/reco1l/andengine/texture/VideoTexture.kt
@@ -143,17 +143,4 @@ class VideoTexture(val source: String) : Texture(
 
     override fun getWidth() = videoWidth
     override fun getHeight() = videoHeight
-
-
-    companion object {
-
-        /**
-         * Checks if the file is a video that can be loaded. Since ExoPlayer with Media3's
-         * built-in extractors supports a broad range of container formats (MP4, MKV, WebM,
-         * AVI, FLV, …), we accept any file that exists and let playback fail gracefully if
-         * the format turns out to be unsupported.
-         */
-        fun isSupportedVideo(file: File) = file.exists()
-
-    }
 }

--- a/src/com/reco1l/andengine/texture/VideoTexture.kt
+++ b/src/com/reco1l/andengine/texture/VideoTexture.kt
@@ -61,7 +61,7 @@ class VideoTexture(val source: String) : Texture(
         private set
 
     private var surfaceTexture: SurfaceTexture? = null
-
+    private var surface: Surface? = null
 
     init {
         val context = GlobalManager.getInstance().mainActivity.applicationContext
@@ -125,26 +125,33 @@ class VideoTexture(val source: String) : Texture(
 
         // SurfaceTexture must be created on the GL thread (tied to the GL texture ID),
         // but setVideoSurface must be called on ExoPlayer's main-thread looper.
-        val surface = Surface(surfaceTexture)
+        // The Surface is stored as a field — releasing it immediately would free the native
+        // window before ExoPlayer's playback thread has a chance to configure MediaCodec against it.
+        surface = Surface(surfaceTexture)
 
-        mainHandler.post {
-            player.setVideoSurface(surface)
-            surface.release()
-        }
+        mainHandler.post { player.setVideoSurface(surface) }
     }
 
     override fun deleteTextureOnHardware(pGL: GL10?) {
 
         val st = surfaceTexture
+        val s = surface
+
         surfaceTexture = null
+        surface = null
 
         mainHandler.post {
-            // Detach the surface before releasing the SurfaceTexture so ExoPlayer
-            // stops rendering to it. Ignored silently if the player is already released.
+            // The order matters here:
+            // - Clear ExoPlayer's surface reference first so its playback thread stops writing to the native window
+            // - Release the Java wrapper
+            // - Release the SurfaceTexture
+            //
+            // Ignored silently if the player is already released.
             try {
                 player.setVideoSurface(null)
             } catch (_: Exception) {}
 
+            s?.release()
             st?.release()
         }
 

--- a/src/com/reco1l/andengine/texture/VideoTexture.kt
+++ b/src/com/reco1l/andengine/texture/VideoTexture.kt
@@ -17,6 +17,7 @@ import androidx.media3.decoder.ffmpeg.ExperimentalFfmpegVideoRenderer
 import org.anddev.andengine.opengl.texture.*
 import ru.nsu.ccfit.zuev.osu.GlobalManager
 import java.io.*
+import java.util.concurrent.atomic.AtomicReference
 import javax.microedition.khronos.opengles.*
 import javax.microedition.khronos.opengles.GL10.*
 
@@ -35,20 +36,23 @@ class VideoTexture(val source: String) : Texture(
 
     val player: ExoPlayer
 
+    private val onReadyRef = AtomicReference<Runnable?>()
+
     /**
      * The callback that is invoked when the video dimensions are available. This is necessary because the dimensions
      * are not known until the video is prepared, which happens asynchronously.
      *
-     * The callback will be invoked on the main thread.
+     * The callback will be invoked on the main thread exactly once.
      */
-    @Volatile
-    var onReady: Runnable? = null
+    var onReady
+        get() = onReadyRef.get()
         set(value) {
-            field = value
+            onReadyRef.set(value)
 
             // Handle the race where dimensions arrived before the callback was registered.
+            // Uses getAndSet(null) so only one caller (this path or onVideoSizeChanged) wins.
             if (videoWidth > 0) {
-                value?.run()
+                mainHandler.post { onReadyRef.getAndSet(null)?.run() }
             }
         }
 
@@ -101,7 +105,7 @@ class VideoTexture(val source: String) : Texture(
                 override fun onVideoSizeChanged(videoSize: VideoSize) {
                     videoWidth = videoSize.width
                     videoHeight = videoSize.height
-                    onReady?.run()
+                    onReadyRef.getAndSet(null)?.run()
                 }
 
                 override fun onPlayerError(error: PlaybackException) {

--- a/src/com/reco1l/andengine/texture/VideoTexture.kt
+++ b/src/com/reco1l/andengine/texture/VideoTexture.kt
@@ -103,6 +103,10 @@ class VideoTexture(val source: String) : Texture(
             player.repeatMode = Player.REPEAT_MODE_OFF
             player.addListener(object : Player.Listener {
                 override fun onVideoSizeChanged(videoSize: VideoSize) {
+                    if (videoSize.width == 0 || videoSize.height == 0) {
+                        return
+                    }
+
                     videoWidth = videoSize.width
                     videoHeight = videoSize.height
                     onReadyRef.getAndSet(null)?.run()

--- a/src/ru/nsu/ccfit/zuev/osu/Config.java
+++ b/src/ru/nsu/ccfit/zuev/osu/Config.java
@@ -75,7 +75,6 @@ public class Config {
         safeBeatmapBg,
         useNightcoreOnMultiplayer,
         videoEnabled,
-        deleteUnsupportedVideos,
         submitScoreOnMultiplayer,
         preferModAcronymInMultiplayer,
         keepBackgroundAspectRatio,
@@ -217,7 +216,6 @@ public class Config {
         if (beatmapPath.charAt(beatmapPath.length() - 1) != '/') {
             beatmapPath += "/";
         }
-        deleteUnsupportedVideos = prefs.getBoolean("deleteUnsupportedVideos", true);
 
         // other
         playMusicPreview = prefs.getBoolean("musicpreview", true);
@@ -744,10 +742,6 @@ public class Config {
 
     public static void setVideoEnabled(boolean value) {
         videoEnabled = value;
-    }
-
-    public static boolean isDeleteUnsupportedVideos() {
-        return deleteUnsupportedVideos;
     }
 
     public static boolean isSubmitScoreOnMultiplayer() {

--- a/src/ru/nsu/ccfit/zuev/osu/LibraryManager.java
+++ b/src/ru/nsu/ccfit/zuev/osu/LibraryManager.java
@@ -8,7 +8,6 @@ import com.osudroid.beatmaps.BeatmapCache;
 import com.osudroid.beatmaps.DifficultyCalculationManager;
 import com.osudroid.data.BeatmapSetInfo;
 import com.osudroid.data.DatabaseManager;
-import com.reco1l.andengine.texture.VideoTexture;
 import com.osudroid.beatmaps.parser.BeatmapParser;
 import kotlin.io.FilesKt;
 import org.jetbrains.annotations.Nullable;
@@ -147,19 +146,6 @@ public class LibraryManager {
             try {
                 var data = new BeatmapParser(osuFile).parse(false);
                 var beatmapInfo = BeatmapInfo(data, directory.lastModified(), false);
-
-                if (data.getEvents().videoFilename != null && Config.isDeleteUnsupportedVideos()) {
-                    try {
-                        var videoFile = new File(beatmapInfo.getSetDirectory(), data.getEvents().videoFilename);
-
-                        if (!VideoTexture.Companion.isSupportedVideo(videoFile)) {
-                            //noinspection ResultOfMethodCallIgnored
-                            videoFile.delete();
-                        }
-                    } catch (Exception e) {
-                        Log.e("LibraryManager", "Failed to delete video file", e);
-                    }
-                }
 
                 pendingBeatmaps.add(beatmapInfo);
                 beatmapsFound++;

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -1781,13 +1781,7 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
         {
             if (!videoStarted) {
                 video.play();
-                // Some devices do not support custom playback speed for whatever reason.
-                try {
-                    video.setPlaybackSpeed(GameHelper.getSpeedMultiplier());
-                } catch (Exception e) {
-                    Log.e("GameScene", "Failed to change video playback speed.", e);
-                    ToastLogger.showText(com.osudroid.resources.R.string.message_video_custom_speed_unsupported, false);
-                }
+                video.setPlaybackSpeed(GameHelper.getSpeedMultiplier());
                 videoStarted = true;
             }
 
@@ -2891,13 +2885,7 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
                     float decreasedSpeed = GameHelper.getSpeedMultiplier() * (1 - (initialFrequency - decreasedFrequency) / initialFrequency);
 
                     if (videoEnabled && video != null) {
-                        // In some devices this can throw an exception, unfortunately there's no
-                        // documentation that explains how to avoid that scenario. Thanks Google.
-                        try {
-                            video.setPlaybackSpeed(decreasedSpeed);
-                        } catch (Exception e) {
-                            Log.e("GameScene", "Failed to change video playback speed during game over animation.", e);
-                        }
+                        video.setPlaybackSpeed(decreasedSpeed);
                     }
 
                     songService.setFrequencyForcefully(decreasedFrequency);

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -481,8 +481,10 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
 
                 this.video = video;
 
-                // The video may only load after gameplay is started, in which case we must apply it immediately.
-                Execution.updateThread(this::applyBackground);
+                // applyBackground is called from the onReady callback once ExoPlayer reports the video dimensions via
+                // onVideoSizeChanged, rather than blocking here.
+                // If dimensions are already known (fast local file), the callback fires immediately.
+                video.setOnReady(() -> Execution.updateThread(this::applyBackground));
             } catch (Exception e) {
                 video = null;
                 Log.e("GameScene", "Error while loading video background.", e);
@@ -508,6 +510,12 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
     }
 
     private void applyBackground() {
+        // Guard: video sprite exists but dimensions not yet reported by ExoPlayer.
+        // onVideoSizeChanged will trigger another applyBackground call when they arrive.
+        if (video != null && (video.getWidth() == 0 || video.getHeight() == 0)) {
+            return;
+        }
+
         // This is used instead of getBackgroundBrightness to directly obtain the
         // updated value from the brightness slider.
         float brightness = Config.getInt("bgbrightness", 25) / 100f;

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -472,6 +472,13 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
             return;
         }
 
+        // Check if video file exists before attempting to load.
+        var videoFile = new File(beatmapInfo.getAbsoluteSetDirectory() + "/" + videoFilename);
+
+        if (!videoFile.exists()) {
+            return;
+        }
+
         videoLoadingJob = Execution.async(scope -> {
             try {
                 var video = new UIVideoSprite(beatmapInfo.getAbsoluteSetDirectory() + "/" + videoFilename, engine);

--- a/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
+++ b/src/ru/nsu/ccfit/zuev/osu/game/GameScene.java
@@ -1500,6 +1500,10 @@ public class GameScene implements GameObjectListener, IOnSceneTouchListener {
                 GameHelper.setSpeedMultiplier(currentSpeedMultiplier);
                 beatmapClock.setRate(currentSpeedMultiplier);
 
+                if (videoEnabled && video != null) {
+                    video.setPlaybackSpeed(currentSpeedMultiplier);
+                }
+
                 var songService = GlobalManager.getInstance().getSongService();
                 songService.setSpeed(modRate);
                 songService.setPitchRate(replaySettingsRate);


### PR DESCRIPTION
Closes #165.

This PR replaces the use of [`MediaPlayer`](https://developer.android.com/media/platform/mediaplayer) in `VideoTexture` with Jetpack Media3's [`ExoPlayer`](https://developer.android.com/media/media3/exoplayer). `ExoPlayer` allows for extension using FFmpeg, allowing it to fallback to software decoding when needed. As a result, this PR provides wider video codec support in devices with limited built-in codecs.

Note that battery consumption will increase when `ExoPlayer` falls back to software decoding. This is a tradeoff that cannot be avoided to achieve the goals of this PR.

The Android resource file for FFmpeg used in this PR was built from source. See the AAR building guide in this PR for more details. I decided to write it in case a rebuild is required in the future (and for others to follow).

Other small changes as an indirect result of this PR:
- `Config.isDeleteUnsupportedVideos` has been removed
- Replay seeking can now reliably adjust video playback speed without worrying about exceptions that emerged from `MediaPlayer`