### PR TITLE
Fix font atlas overflow for CJK metadata

### DIFF
--- a/src/ru/nsu/ccfit/zuev/osu/ResourceManager.java
+++ b/src/ru/nsu/ccfit/zuev/osu/ResourceManager.java
@@ -50,6 +50,9 @@ import ru.nsu.ccfit.zuev.skins.SkinJsonReader;
 import ru.nsu.ccfit.zuev.skins.BeatmapSkinManager;
 
 public class ResourceManager {
+    private static final int FONT_TEXTURE_SIZE = 1024;
+    private static final int STROKE_FONT_TEXTURE_WIDTH = 1024;
+    private static final int STROKE_FONT_TEXTURE_HEIGHT = 512;
 
     /**
      * The textures that shouldn't fallback to the default skin if they're not present in the skin folder.
@@ -416,7 +419,7 @@ public class ResourceManager {
     public Font loadFont(final String resname, final String file, int size,
                          final int color) {
         size /= Config.getTextureQuality();
-        final BitmapTextureAtlas texture = new BitmapTextureAtlas(512, 512,
+        final BitmapTextureAtlas texture = new BitmapTextureAtlas(FONT_TEXTURE_SIZE, FONT_TEXTURE_SIZE,
                 TextureOptions.BILINEAR_PREMULTIPLYALPHA);
         Font font;
         if (file == null) {
@@ -435,7 +438,7 @@ public class ResourceManager {
     public StrokeFont loadStrokeFont(final String resname, final String file,
                                      int size, final int color1, final int color2) {
         size /= Config.getTextureQuality();
-        final BitmapTextureAtlas texture = new BitmapTextureAtlas(512, 256,
+        final BitmapTextureAtlas texture = new BitmapTextureAtlas(STROKE_FONT_TEXTURE_WIDTH, STROKE_FONT_TEXTURE_HEIGHT,
                 TextureOptions.BILINEAR_PREMULTIPLYALPHA);
         StrokeFont font;
         if (file == null) {


### PR DESCRIPTION
## Summary

- Fix font atlas overflow when song metadata loads many unique CJK glyphs.
- Keep generated letter texture coordinates inside the atlas bounds.
- Retry text texture buffer generation if the font atlas resets while text is being populated.
- Increase legacy font atlas sizes to reduce resets in CJK-heavy song select screens.

Fixes #433.

## Reproduction videos

**Before fix:** metadata text disappears / renders partially with CJK beatmap metadata and `Force romanized` enabled.

https://github.com/user-attachments/assets/23340492-c702-4110-a75b-dcea63bec7fa

**After fix:** the same scenario renders the CJK metadata correctly.

https://github.com/user-attachments/assets/7b032a63-0ff2-4cec-8be2-edb3b90a080b

## Testing

- `./gradlew testDebugUnitTest --tests org.anddev.andengine.opengl.font.FontTest`
- Manual verification on an Android device with CJK metadata test beatmaps and `Force romanized` enabled.

### Reproduction algorithm

Test data was prepared manually on the device:

- Added 8 minimal test beatmaps under `/sdcard/osu!droid/Songs/CJK01` ... `/sdcard/osu!droid/Songs/CJK08`.
- Each beatmap uses CJK-heavy metadata in `Title` / `Artist`.
- `TitleUnicode` / `ArtistUnicode` were also populated with Unicode metadata, not ASCII-only fallback values.
- This exercises the issue when `Force romanized` is enabled, because song select reads `Title` / `Artist` in that mode.
- Each beatmap has a tiny valid `.osu` body and a short audio file, enough to appear in song select and be selected by `Random`.

Example metadata:

```ini
[Metadata]
Title:桜吹雪紅葉祭囃子灯籠神社鳥居温泉夜空花火
TitleUnicode:京都夜祭幻想曲
Artist:雪月花夢幻譚星屑旅人風鈴小路
ArtistUnicode:東方幻想楽団
Creator:Codex CJK
Version:難易度
```

App versions tested:

- Broken build: current `master`, built with `./gradlew assembleDebug` and installed with `adb install -r`.
- Fixed build: this PR branch, built and installed the same way.

Manual reproduction steps:

1. Launch osu!droid debug build on the device.
2. Enable `Options -> Library -> Force romanized`.
3. Go to `Play -> Solo`.
4. Press `Random` until one of the prepared CJK test beatmaps is selected.
5. On `master`, the selected beatmap metadata text sometimes disappears or renders only partially.
6. Install the fixed build from this PR and repeat the same steps.
7. With the fix, the same CJK metadata remains visible and renders correctly.

Device used for verification:

- Android 12
- Debug build: `osu!droid 2026.711.0`

Assisted with Codex