### PR TITLE
Support multiple atlases in `Font`

### DIFF
--- a/AndEngine/build.gradle
+++ b/AndEngine/build.gradle
@@ -5,7 +5,7 @@ android {
     compileSdk 34
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 24
         //noinspection ExpiredTargetSdkVersion
         targetSdkVersion 29
     }

--- a/AndEngine/src/org/anddev/andengine/entity/text/ChangeableText.java
+++ b/AndEngine/src/org/anddev/andengine/entity/text/ChangeableText.java
@@ -1,10 +1,6 @@
 package org.anddev.andengine.entity.text;
 
-import javax.microedition.khronos.opengles.GL10;
-
-import org.anddev.andengine.engine.camera.Camera;
 import org.anddev.andengine.opengl.font.Font;
-import org.anddev.andengine.opengl.vertex.TextVertexBuffer;
 import org.anddev.andengine.util.HorizontalAlign;
 import org.anddev.andengine.util.StringUtils;
 
@@ -15,6 +11,8 @@ import org.anddev.andengine.util.StringUtils;
  * @author Nicolas Gramlich
  * @since 18:07:06 - 08.07.2010
  */
+// osu!droid modified: drawVertices() override removed as the base Text implementation's
+// page-run-based drawing already handles variable-length text correctly.
 public class ChangeableText extends Text {
 	// ===========================================================
 	// Constants
@@ -26,8 +24,6 @@ public class ChangeableText extends Text {
 	// ===========================================================
 	// Fields
 	// ===========================================================
-
-	private int mCharacterCountCurrentText;
 
 	// ===========================================================
 	// Constructors
@@ -43,7 +39,6 @@ public class ChangeableText extends Text {
 
 	public ChangeableText(final float pX, final float pY, final Font pFont, final String pText, final HorizontalAlign pHorizontalAlign, final int pCharactersMaximum) {
 		super(pX, pY, pFont, pText, pHorizontalAlign, pCharactersMaximum);
-		this.mCharacterCountCurrentText = pText.length() - StringUtils.countOccurrences(pText, '\n');
 	}
 
 	// ===========================================================
@@ -67,10 +62,8 @@ public class ChangeableText extends Text {
 			} else {
 				this.updateText(pText.substring(0, this.mCharactersMaximum)); // TODO This allocation could be avoided...
 			}
-			this.mCharacterCountCurrentText = this.mCharactersMaximum;
 		} else {
 			this.updateText(pText);
-			this.mCharacterCountCurrentText = textCharacterCount;
 		}
 	}
 
@@ -78,10 +71,9 @@ public class ChangeableText extends Text {
 	// Methods for/from SuperClass/Interfaces
 	// ===========================================================
 
-	@Override
-	protected void drawVertices(final GL10 pGL, final Camera pCamera) {
-		pGL.glDrawArrays(GL10.GL_TRIANGLES, 0, this.mCharacterCountCurrentText * TextVertexBuffer.VERTICES_PER_CHARACTER);
-	}
+	// osu!droid modified: drawVertices() no longer needs to be overridden here. The base Text
+	// implementation now draws exactly the page runs produced by the last update(), which are
+	// already sized to the current text's actual character count (see TextTextureBuffer.update()).
 
 	// ===========================================================
 	// Methods

--- a/AndEngine/src/org/anddev/andengine/entity/text/Text.java
+++ b/AndEngine/src/org/anddev/andengine/entity/text/Text.java
@@ -135,6 +135,10 @@ public class Text extends RectangularShape {
 		return (TextVertexBuffer)this.mVertexBuffer;
 	}
 
+	protected List<TextTextureBuffer.PageRun> getPageRuns() {
+		return this.mTextTextureBuffer.getPageRuns();
+	}
+
 	// ===========================================================
 	// Methods for/from SuperClass/Interfaces
 	// ===========================================================
@@ -150,7 +154,7 @@ public class Text extends RectangularShape {
 	protected void drawVertices(final GL10 pGL, final Camera pCamera) {
 		// osu!droid modified: A Font may span multiple atlas pages, so this text's characters can
 		// reference more than one texture. Bind and draw each contiguous same-page run separately.
-		final List<TextTextureBuffer.PageRun> pageRuns = this.mTextTextureBuffer.getPageRuns();
+		final List<TextTextureBuffer.PageRun> pageRuns = this.getPageRuns();
 		final int pageRunCount = pageRuns.size();
 
 		for (int i = 0; i < pageRunCount; i++) {

--- a/AndEngine/src/org/anddev/andengine/entity/text/Text.java
+++ b/AndEngine/src/org/anddev/andengine/entity/text/Text.java
@@ -1,5 +1,7 @@
 package org.anddev.andengine.entity.text;
 
+import java.util.List;
+
 import javax.microedition.khronos.opengles.GL10;
 import javax.microedition.khronos.opengles.GL11;
 
@@ -19,6 +21,9 @@ import org.anddev.andengine.util.StringUtils;
  * @author Nicolas Gramlich
  * @since 10:54:59 - 03.04.2010
  */
+// osu!droid modified:
+// * A Font may now span multiple atlas pages. drawVertices() and applyTexture() bind each
+//   page run's texture separately instead of assuming every character shares one texture.
 public class Text extends RectangularShape {
 	// ===========================================================
 	// Constants
@@ -143,7 +148,16 @@ public class Text extends RectangularShape {
 
 	@Override
 	protected void drawVertices(final GL10 pGL, final Camera pCamera) {
-		pGL.glDrawArrays(GL10.GL_TRIANGLES, 0, this.mVertexCount);
+		// osu!droid modified: A Font may span multiple atlas pages, so this text's characters can
+		// reference more than one texture. Bind and draw each contiguous same-page run separately.
+		final List<TextTextureBuffer.PageRun> pageRuns = this.mTextTextureBuffer.getPageRuns();
+		final int pageRunCount = pageRuns.size();
+
+		for (int i = 0; i < pageRunCount; i++) {
+			final TextTextureBuffer.PageRun pageRun = pageRuns.get(i);
+			pageRun.texture.bind(pGL);
+			pGL.glDrawArrays(GL10.GL_TRIANGLES, pageRun.startVertex, pageRun.vertexCount);
+		}
 	}
 
 	@Override
@@ -173,21 +187,21 @@ public class Text extends RectangularShape {
 	// ===========================================================
 
 	private void initBlendFunction() {
-		if(this.mFont.getTexture().getTextureOptions().mPreMultipyAlpha) {
+		if(this.mFont.getTextureOptions().mPreMultipyAlpha) {
 			this.setBlendFunction(BLENDFUNCTION_SOURCE_PREMULTIPLYALPHA_DEFAULT, BLENDFUNCTION_DESTINATION_PREMULTIPLYALPHA_DEFAULT);
 		}
 	}
 
 	private void applyTexture(final GL10 pGL) {
+		// osu!droid modified: Texture binding now happens per page run in drawVertices(), since a
+		// Font may span multiple atlas pages. This method only sets up the texture coordinate pointer.
 		if(GLHelper.EXTENSIONS_VERTEXBUFFEROBJECTS) {
 			final GL11 gl11 = (GL11)pGL;
 
 			this.mTextTextureBuffer.selectOnHardware(gl11);
 
-			this.mFont.getTexture().bind(pGL);
 			GLHelper.texCoordZeroPointer(gl11);
 		} else {
-			this.mFont.getTexture().bind(pGL);
 			GLHelper.texCoordPointer(pGL, this.mTextTextureBuffer.getFloatBuffer());
 		}
 	}

--- a/AndEngine/src/org/anddev/andengine/entity/text/TickerText.java
+++ b/AndEngine/src/org/anddev/andengine/entity/text/TickerText.java
@@ -1,9 +1,12 @@
 package org.anddev.andengine.entity.text;
 
+import java.util.List;
+
 import javax.microedition.khronos.opengles.GL10;
 
 import org.anddev.andengine.engine.camera.Camera;
 import org.anddev.andengine.opengl.font.Font;
+import org.anddev.andengine.opengl.texture.buffer.TextTextureBuffer;
 import org.anddev.andengine.opengl.vertex.TextVertexBuffer;
 import org.anddev.andengine.util.HorizontalAlign;
 
@@ -88,7 +91,25 @@ public class TickerText extends Text {
 
 	@Override
 	protected void drawVertices(final GL10 pGL, final Camera pCamera) {
-		pGL.glDrawArrays(GL10.GL_TRIANGLES, 0, this.mCharactersVisible * TextVertexBuffer.VERTICES_PER_CHARACTER);
+		// osu!droid modified: A Font may span multiple atlas pages, so the visible character range can
+		// straddle more than one texture. Draw each same-page run separately, clipped to the range of
+		// vertices currently revealed by the ticker, instead of assuming a single texture for everything.
+		final int visibleVertexCount = this.mCharactersVisible * TextVertexBuffer.VERTICES_PER_CHARACTER;
+
+		final List<TextTextureBuffer.PageRun> pageRuns = this.getPageRuns();
+		final int pageRunCount = pageRuns.size();
+
+		for (int i = 0; i < pageRunCount; i++) {
+			final TextTextureBuffer.PageRun pageRun = pageRuns.get(i);
+			if (pageRun.startVertex >= visibleVertexCount) {
+				break;
+			}
+
+			final int vertexCount = Math.min(pageRun.vertexCount, visibleVertexCount - pageRun.startVertex);
+
+			pageRun.texture.bind(pGL);
+			pGL.glDrawArrays(GL10.GL_TRIANGLES, pageRun.startVertex, vertexCount);
+		}
 	}
 
 	@Override

--- a/AndEngine/src/org/anddev/andengine/opengl/font/Font.java
+++ b/AndEngine/src/org/anddev/andengine/opengl/font/Font.java
@@ -122,6 +122,10 @@ public class Font {
 		return this.mPages.get(0);
 	}
 
+	public synchronized List<ITexture> getPages() {
+		return List.copyOf(this.mPages);
+	}
+
 	public synchronized TextureOptions getTextureOptions() {
 		return this.mPages.get(0).getTextureOptions();
 	}

--- a/AndEngine/src/org/anddev/andengine/opengl/font/Font.java
+++ b/AndEngine/src/org/anddev/andengine/opengl/font/Font.java
@@ -2,11 +2,14 @@ package org.anddev.andengine.opengl.font;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import javax.microedition.khronos.opengles.GL10;
 
 import org.anddev.andengine.opengl.texture.ITexture;
+import org.anddev.andengine.opengl.texture.TextureOptions;
 
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
@@ -30,6 +33,8 @@ import android.util.SparseArray;
 // osu!droid modified:
 // * Support for UTF-16 characters by using String instead of Char where needed.
 // * Removal of non-sense padding.
+// * Use multiple atlas pages instead of overflowing a single fixed-size texture,
+//   so already-placed glyphs remain valid.
 public class Font {
 	// ===========================================================
 	// Constants
@@ -44,9 +49,10 @@ public class Font {
 	// Fields
 	// ===========================================================
 
-	private final ITexture mTexture;
-	private final float mTextureWidth;
-	private final float mTextureHeight;
+	private final List<ITexture> mPages = new ArrayList<>();
+	private final Supplier<ITexture> mPageFactory;
+	private final float mPageWidth;
+	private final float mPageHeight;
 	private int mCurrentTextureX = 0;
 	private int mCurrentTextureY = 0;
 
@@ -72,10 +78,18 @@ public class Font {
 	// Constructors
 	// ===========================================================
 
-	public Font(final ITexture pTexture, final Typeface pTypeface, final float pSize, final boolean pAntiAlias, final int pColor) {
-		this.mTexture = pTexture;
-		this.mTextureWidth = pTexture.getWidth();
-		this.mTextureHeight = pTexture.getHeight();
+	/**
+	 * @param pPageFactory creates and registers (e.g. with the {@link org.anddev.andengine.opengl.texture.TextureManager})
+	 *                     an atlas page, invoked once immediately for the first page and again whenever the current
+	 *                     page runs out of room for new glyphs. Every page it produces <b>must</b> share the same dimensions
+	 *                     and options, since those of the first page are cached and reused for all subsequent pages.
+	 */
+	public Font(final Supplier<ITexture> pPageFactory, final Typeface pTypeface, final float pSize, final boolean pAntiAlias, final int pColor) {
+		final ITexture firstPage = pPageFactory.get();
+		this.mPages.add(firstPage);
+		this.mPageFactory = pPageFactory;
+		this.mPageWidth = firstPage.getWidth();
+		this.mPageHeight = firstPage.getHeight();
 
 		this.mPaint = new Paint();
 		this.mPaint.setTypeface(pTypeface);
@@ -105,7 +119,15 @@ public class Font {
 	}
 
 	public ITexture getTexture() {
-		return this.mTexture;
+		return this.mPages.get(0);
+	}
+
+	public synchronized TextureOptions getTextureOptions() {
+		return this.mPages.get(0).getTextureOptions();
+	}
+
+	private ITexture getCurrentPage() {
+		return this.mPages.get(this.mPages.size() - 1);
 	}
 
 	// ===========================================================
@@ -185,8 +207,8 @@ public class Font {
 	}
 
 	private Letter createLetter(final String pCharacter) {
-		final float textureWidth = this.mTextureWidth;
-		final float textureHeight = this.mTextureHeight;
+		final float textureWidth = this.mPageWidth;
+		final float textureHeight = this.mPageHeight;
 
 		final Size createLetterTemporarySize = this.mCreateLetterTemporarySize;
 		this.getLetterBounds(pCharacter, createLetterTemporarySize);
@@ -199,27 +221,47 @@ public class Font {
 			this.mCurrentTextureY += this.getLineGap() + this.getLineHeight();
 		}
 
+		if (this.mCurrentTextureY + letterHeight > textureHeight) {
+			this.addPage();
+		}
+
 		final float letterTextureX = this.mCurrentTextureX / textureWidth;
 		final float letterTextureY = this.mCurrentTextureY / textureHeight;
 		final float letterTextureWidth = letterWidth / textureWidth;
 		final float letterTextureHeight = letterHeight / textureHeight;
 
-		final Letter letter = new Letter(pCharacter, this.getLetterAdvance(pCharacter), (int)letterWidth, (int)letterHeight, letterTextureX, letterTextureY, letterTextureWidth, letterTextureHeight);
+		final Letter letter = new Letter(this.getCurrentPage(), pCharacter, this.getLetterAdvance(pCharacter), (int)letterWidth, (int)letterHeight, letterTextureX, letterTextureY, letterTextureWidth, letterTextureHeight);
 		this.mCurrentTextureX += letterWidth;
 
 		return letter;
 	}
 
+	/**
+	 * Allocates a new, empty atlas page rather than reusing/clearing the current one, so that
+	 * {@link Letter}s already handed out (and any {@link org.anddev.andengine.entity.text.Text}
+	 * built from them) keep pointing at valid, unmodified texture data.
+	 */
+	private void addPage() {
+		this.mPages.add(this.mPageFactory.get());
+		this.mCurrentTextureX = 0;
+		this.mCurrentTextureY = 0;
+	}
+
 	public synchronized void update(final GL10 pGL) {
 		final ArrayList<Letter> lettersPendingToBeDrawnToTexture = this.mLettersPendingToBeDrawnToTexture;
 		if(lettersPendingToBeDrawnToTexture.size() > 0) {
-			this.mTexture.bind(pGL);
+			final float textureWidth = this.mPageWidth;
+			final float textureHeight = this.mPageHeight;
 
-			final float textureWidth = this.mTextureWidth;
-			final float textureHeight = this.mTextureHeight;
-
+			ITexture boundPage = null;
 			for(int i = lettersPendingToBeDrawnToTexture.size() - 1; i >= 0; i--) {
 				final Letter letter = lettersPendingToBeDrawnToTexture.get(i);
+				final ITexture page = letter.getTexture();
+				if (page != boundPage) {
+					page.bind(pGL);
+					boundPage = page;
+				}
+
 				final Bitmap bitmap = this.getLetterBitmap(letter.mCharacter);
 
 				// TODO What about premultiplyalpha of the textureOptions?

--- a/AndEngine/src/org/anddev/andengine/opengl/font/FontFactory.java
+++ b/AndEngine/src/org/anddev/andengine/opengl/font/FontFactory.java
@@ -1,5 +1,7 @@
 package org.anddev.andengine.opengl.font;
 
+import java.util.function.Supplier;
+
 import org.anddev.andengine.opengl.texture.ITexture;
 
 import android.content.Context;
@@ -12,6 +14,9 @@ import android.graphics.Typeface;
  * @author Nicolas Gramlich
  * @since 17:17:28 - 16.06.2010
  */
+// osu!droid modified: Factory methods now take a Supplier<ITexture> pPageFactory in place of a
+// single texture. Font uses it to create the first atlas page as well as any additional ones
+// allocated on overflow.
 public class FontFactory {
 	// ===========================================================
 	// Constants
@@ -54,28 +59,28 @@ public class FontFactory {
 	// Methods
 	// ===========================================================
 
-	public static Font create(final ITexture pTexture, final Typeface pTypeface, final float pSize, final boolean pAntiAlias, final int pColor) {
-		return new Font(pTexture, pTypeface, pSize, pAntiAlias, pColor);
+	public static Font create(final Supplier<ITexture> pPageFactory, final Typeface pTypeface, final float pSize, final boolean pAntiAlias, final int pColor) {
+		return new Font(pPageFactory, pTypeface, pSize, pAntiAlias, pColor);
 	}
 
-	public static StrokeFont createStroke(final ITexture pTexture, final Typeface pTypeface, final float pSize, final boolean pAntiAlias, final int pColor, final float pStrokeWidth, final int pStrokeColor) {
-		return new StrokeFont(pTexture, pTypeface, pSize, pAntiAlias, pColor, pStrokeWidth, pStrokeColor);
+	public static StrokeFont createStroke(final Supplier<ITexture> pPageFactory, final Typeface pTypeface, final float pSize, final boolean pAntiAlias, final int pColor, final float pStrokeWidth, final int pStrokeColor) {
+		return new StrokeFont(pPageFactory, pTypeface, pSize, pAntiAlias, pColor, pStrokeWidth, pStrokeColor);
 	}
 
-	public static StrokeFont createStroke(final ITexture pTexture, final Typeface pTypeface, final float pSize, final boolean pAntiAlias, final int pColor, final float pStrokeWidth, final int pStrokeColor, final boolean pStrokeOnly) {
-		return new StrokeFont(pTexture, pTypeface, pSize, pAntiAlias, pColor, pStrokeWidth, pStrokeColor, pStrokeOnly);
+	public static StrokeFont createStroke(final Supplier<ITexture> pPageFactory, final Typeface pTypeface, final float pSize, final boolean pAntiAlias, final int pColor, final float pStrokeWidth, final int pStrokeColor, final boolean pStrokeOnly) {
+		return new StrokeFont(pPageFactory, pTypeface, pSize, pAntiAlias, pColor, pStrokeWidth, pStrokeColor, pStrokeOnly);
 	}
 
-	public static Font createFromAsset(final ITexture pTexture, final Context pContext, final String pAssetPath, final float pSize, final boolean pAntiAlias, final int pColor) {
-		return new Font(pTexture, Typeface.createFromAsset(pContext.getAssets(), FontFactory.sAssetBasePath + pAssetPath), pSize, pAntiAlias, pColor);
+	public static Font createFromAsset(final Supplier<ITexture> pPageFactory, final Context pContext, final String pAssetPath, final float pSize, final boolean pAntiAlias, final int pColor) {
+		return new Font(pPageFactory, Typeface.createFromAsset(pContext.getAssets(), FontFactory.sAssetBasePath + pAssetPath), pSize, pAntiAlias, pColor);
 	}
 
-	public static StrokeFont createStrokeFromAsset(final ITexture pTexture, final Context pContext, final String pAssetPath, final float pSize, final boolean pAntiAlias, final int pColor, final float pStrokeWidth, final int pStrokeColor) {
-		return new StrokeFont(pTexture, Typeface.createFromAsset(pContext.getAssets(), FontFactory.sAssetBasePath + pAssetPath), pSize, pAntiAlias, pColor, pStrokeWidth, pStrokeColor);
+	public static StrokeFont createStrokeFromAsset(final Supplier<ITexture> pPageFactory, final Context pContext, final String pAssetPath, final float pSize, final boolean pAntiAlias, final int pColor, final float pStrokeWidth, final int pStrokeColor) {
+		return new StrokeFont(pPageFactory, Typeface.createFromAsset(pContext.getAssets(), FontFactory.sAssetBasePath + pAssetPath), pSize, pAntiAlias, pColor, pStrokeWidth, pStrokeColor);
 	}
 
-	public static StrokeFont createStrokeFromAsset(final ITexture pTexture, final Context pContext, final String pAssetPath, final float pSize, final boolean pAntiAlias, final int pColor, final float pStrokeWidth, final int pStrokeColor, final boolean pStrokeOnly) {
-		return new StrokeFont(pTexture, Typeface.createFromAsset(pContext.getAssets(), FontFactory.sAssetBasePath + pAssetPath), pSize, pAntiAlias, pColor, pStrokeWidth, pStrokeColor, pStrokeOnly);
+	public static StrokeFont createStrokeFromAsset(final Supplier<ITexture> pPageFactory, final Context pContext, final String pAssetPath, final float pSize, final boolean pAntiAlias, final int pColor, final float pStrokeWidth, final int pStrokeColor, final boolean pStrokeOnly) {
+		return new StrokeFont(pPageFactory, Typeface.createFromAsset(pContext.getAssets(), FontFactory.sAssetBasePath + pAssetPath), pSize, pAntiAlias, pColor, pStrokeWidth, pStrokeColor, pStrokeOnly);
 	}
 
 	// ===========================================================

--- a/AndEngine/src/org/anddev/andengine/opengl/font/Letter.java
+++ b/AndEngine/src/org/anddev/andengine/opengl/font/Letter.java
@@ -3,6 +3,8 @@
  */
 package org.anddev.andengine.opengl.font;
 
+import org.anddev.andengine.opengl.texture.ITexture;
+
 /**
  * (c) 2010 Nicolas Gramlich 
  * (c) 2011 Zynga Inc.
@@ -10,7 +12,9 @@ package org.anddev.andengine.opengl.font;
  * @author Nicolas Gramlich
  * @since 10:30:22 - 03.04.2010
  */
-// osu!droid modified: Use String for characters to support UTF-16.
+// osu!droid modified:
+// * Use String for characters to support UTF-16.
+// * Track which Font atlas page this Letter was drawn to, since a Font may span multiple pages.
 public class Letter {
 	// ===========================================================
 	// Constants
@@ -19,6 +23,8 @@ public class Letter {
 	// ===========================================================
 	// Fields
 	// ===========================================================
+
+	private final ITexture mTexture;
 
 	public final int mAdvance;
 	public final int mWidth;
@@ -33,7 +39,8 @@ public class Letter {
 	// Constructors
 	// ===========================================================
 
-	Letter(final String pCharacter, final int pAdvance, final int pWidth, final int pHeight, final float pTextureX, final float pTextureY, final float pTextureWidth, final float pTextureHeight) {
+	Letter(final ITexture pTexture, final String pCharacter, final int pAdvance, final int pWidth, final int pHeight, final float pTextureX, final float pTextureY, final float pTextureWidth, final float pTextureHeight) {
+		this.mTexture = pTexture;
 		this.mCharacter = pCharacter;
 		this.mAdvance = pAdvance;
 		this.mWidth = pWidth;
@@ -47,6 +54,10 @@ public class Letter {
 	// ===========================================================
 	// Getter & Setter
 	// ===========================================================
+
+	public ITexture getTexture() {
+		return this.mTexture;
+	}
 
 	// ===========================================================
 	// Methods for/from SuperClass/Interfaces

--- a/AndEngine/src/org/anddev/andengine/opengl/font/StrokeFont.java
+++ b/AndEngine/src/org/anddev/andengine/opengl/font/StrokeFont.java
@@ -1,5 +1,7 @@
 package org.anddev.andengine.opengl.font;
 
+import java.util.function.Supplier;
+
 import org.anddev.andengine.opengl.texture.ITexture;
 
 import android.graphics.Paint;
@@ -13,6 +15,8 @@ import android.graphics.Typeface;
  * @author Nicolas Gramlich
  * @since 10:39:33 - 03.04.2010
  */
+// osu!droid modified: Constructors now take a Supplier<ITexture> pPageFactory, forwarded to
+// Font to allocate additional atlas pages on overflow.
 public class StrokeFont extends Font {
 	// ===========================================================
 	// Constants
@@ -29,12 +33,12 @@ public class StrokeFont extends Font {
 	// Constructors
 	// ===========================================================
 
-	public StrokeFont(final ITexture pTexture, final Typeface pTypeface, final float pSize, final boolean pAntiAlias, final int pColor, final float pStrokeWidth, final int pStrokeColor) {
-		this(pTexture, pTypeface, pSize, pAntiAlias, pColor, pStrokeWidth, pStrokeColor, false);
+	public StrokeFont(final Supplier<ITexture> pPageFactory, final Typeface pTypeface, final float pSize, final boolean pAntiAlias, final int pColor, final float pStrokeWidth, final int pStrokeColor) {
+		this(pPageFactory, pTypeface, pSize, pAntiAlias, pColor, pStrokeWidth, pStrokeColor, false);
 	}
 
-	public StrokeFont(final ITexture pTexture, final Typeface pTypeface, final float pSize, final boolean pAntiAlias, final int pColor, final float pStrokeWidth, final int pStrokeColor, final boolean pStrokeOnly) {
-		super(pTexture, pTypeface, pSize, pAntiAlias, pColor);
+	public StrokeFont(final Supplier<ITexture> pPageFactory, final Typeface pTypeface, final float pSize, final boolean pAntiAlias, final int pColor, final float pStrokeWidth, final int pStrokeColor, final boolean pStrokeOnly) {
+		super(pPageFactory, pTypeface, pSize, pAntiAlias, pColor);
 		this.mStrokePaint = new Paint();
 		this.mStrokePaint.setTypeface(pTypeface);
 		this.mStrokePaint.setStyle(Style.STROKE);

--- a/AndEngine/src/org/anddev/andengine/opengl/texture/buffer/TextTextureBuffer.java
+++ b/AndEngine/src/org/anddev/andengine/opengl/texture/buffer/TextTextureBuffer.java
@@ -8,6 +8,7 @@ import org.anddev.andengine.opengl.vertex.TextVertexBuffer;
 
 import java.nio.FloatBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -28,7 +29,7 @@ public class TextTextureBuffer extends BufferObject {
 	// Fields
 	// ===========================================================
 
-	private final List<PageRun> mPageRuns = new ArrayList<>();
+	private volatile List<PageRun> mPageRuns = Collections.emptyList();
 
 	// ===========================================================
 	// Constructors
@@ -42,7 +43,7 @@ public class TextTextureBuffer extends BufferObject {
 	// Getter & Setter
 	// ===========================================================
 
-	public synchronized List<PageRun> getPageRuns() {
+	public List<PageRun> getPageRuns() {
 		return this.mPageRuns;
 	}
 
@@ -58,7 +59,7 @@ public class TextTextureBuffer extends BufferObject {
 		final FloatBuffer textureFloatBuffer = this.mFloatBuffer;
 		textureFloatBuffer.position(0);
 
-        this.mPageRuns.clear();
+		final List<PageRun> pageRuns = new ArrayList<>();
 
 		final Font font = pFont;
 		final String[] lines = pLines;
@@ -94,16 +95,16 @@ public class TextTextureBuffer extends BufferObject {
 				textureFloatBuffer.put(letterTextureX);
 				textureFloatBuffer.put(letterTextureY);
 
-				this.appendToPageRuns(letter.getTexture());
+				appendToPageRuns(pageRuns, letter.getTexture());
 			}
 		}
 		textureFloatBuffer.position(0);
 
+		this.mPageRuns = pageRuns;
 		this.setHardwareBufferNeedsUpdate();
 	}
 
-	private void appendToPageRuns(final ITexture pTexture) {
-		final List<PageRun> pPageRuns = this.mPageRuns;
+	private static void appendToPageRuns(final List<PageRun> pPageRuns, final ITexture pTexture) {
 		final int vertexCount = TextVertexBuffer.VERTICES_PER_CHARACTER;
 
 		if (!pPageRuns.isEmpty()) {

--- a/AndEngine/src/org/anddev/andengine/opengl/texture/buffer/TextTextureBuffer.java
+++ b/AndEngine/src/org/anddev/andengine/opengl/texture/buffer/TextTextureBuffer.java
@@ -3,8 +3,12 @@ package org.anddev.andengine.opengl.texture.buffer;
 import org.anddev.andengine.opengl.buffer.BufferObject;
 import org.anddev.andengine.opengl.font.Font;
 import org.anddev.andengine.opengl.font.Letter;
+import org.anddev.andengine.opengl.texture.ITexture;
+import org.anddev.andengine.opengl.vertex.TextVertexBuffer;
 
 import java.nio.FloatBuffer;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * (c) 2010 Nicolas Gramlich 
@@ -13,6 +17,8 @@ import java.nio.FloatBuffer;
  * @author Nicolas Gramlich
  * @since 11:05:56 - 03.04.2010
  */
+// osu!droid modified: Track which atlas page each character's glyph came from, since a Font may now span multiple pages.
+// This is exposed as compressed PageRuns for Text to issue one draw call per contiguous run of same-page characters.
 public class TextTextureBuffer extends BufferObject {
 	// ===========================================================
 	// Constants
@@ -21,6 +27,8 @@ public class TextTextureBuffer extends BufferObject {
 	// ===========================================================
 	// Fields
 	// ===========================================================
+
+	private final List<PageRun> mPageRuns = new ArrayList<>();
 
 	// ===========================================================
 	// Constructors
@@ -34,6 +42,10 @@ public class TextTextureBuffer extends BufferObject {
 	// Getter & Setter
 	// ===========================================================
 
+	public synchronized List<PageRun> getPageRuns() {
+		return this.mPageRuns;
+	}
+
 	// ===========================================================
 	// Methods for/from SuperClass/Interfaces
 	// ===========================================================
@@ -45,6 +57,8 @@ public class TextTextureBuffer extends BufferObject {
 	public synchronized void update(final Font pFont, final String[] pLines) {
 		final FloatBuffer textureFloatBuffer = this.mFloatBuffer;
 		textureFloatBuffer.position(0);
+
+        this.mPageRuns.clear();
 
 		final Font font = pFont;
 		final String[] lines = pLines;
@@ -79,6 +93,8 @@ public class TextTextureBuffer extends BufferObject {
 
 				textureFloatBuffer.put(letterTextureX);
 				textureFloatBuffer.put(letterTextureY);
+
+				this.appendToPageRuns(letter.getTexture());
 			}
 		}
 		textureFloatBuffer.position(0);
@@ -86,7 +102,40 @@ public class TextTextureBuffer extends BufferObject {
 		this.setHardwareBufferNeedsUpdate();
 	}
 
+	private void appendToPageRuns(final ITexture pTexture) {
+		final List<PageRun> pPageRuns = this.mPageRuns;
+		final int vertexCount = TextVertexBuffer.VERTICES_PER_CHARACTER;
+
+		if (!pPageRuns.isEmpty()) {
+			final PageRun lastRun = pPageRuns.get(pPageRuns.size() - 1);
+
+			if (lastRun.texture == pTexture) {
+				lastRun.vertexCount += vertexCount;
+				return;
+			}
+		}
+
+		final int startVertex = pPageRuns.isEmpty() ? 0 : pPageRuns.get(pPageRuns.size() - 1).startVertex + pPageRuns.get(pPageRuns.size() - 1).vertexCount;
+		pPageRuns.add(new PageRun(pTexture, startVertex, vertexCount));
+	}
+
 	// ===========================================================
 	// Inner and Anonymous Classes
 	// ===========================================================
+
+	/**
+	 * A contiguous run of vertices (in {@link TextVertexBuffer}/{@link TextTextureBuffer} order) that all sample the
+	 * same atlas page.
+	 */
+	public static final class PageRun {
+		public final ITexture texture;
+		public final int startVertex;
+		public int vertexCount;
+
+		PageRun(final ITexture pTexture, final int pStartVertex, final int pVertexCount) {
+			this.texture = pTexture;
+			this.startVertex = pStartVertex;
+			this.vertexCount = pVertexCount;
+		}
+	}
 }

--- a/src/com/reco1l/andengine/UIResourceManager.kt
+++ b/src/com/reco1l/andengine/UIResourceManager.kt
@@ -8,6 +8,7 @@ import android.graphics.Typeface
 import android.util.Log
 import com.reco1l.andengine.component.UIComponent
 import org.anddev.andengine.opengl.font.Font
+import org.anddev.andengine.opengl.texture.ITexture
 import org.anddev.andengine.opengl.texture.TextureOptions
 import org.anddev.andengine.opengl.texture.atlas.bitmap.BitmapTextureAtlas
 import org.anddev.andengine.opengl.util.GLHelper
@@ -30,16 +31,19 @@ class UIResourceManager(private val context: Context) {
 
         Log.i("UIResourceManager", "Loading font: $fontIdentifier with texture size ${GLHelper.GlMaxTextureWidth / 2}x${GLHelper.GlMaxTextureWidth / 2}")
 
-        val texture = BitmapTextureAtlas(
-            GLHelper.GlMaxTextureWidth / 2,
-            GLHelper.GlMaxTextureWidth / 2,
-            TextureOptions.BILINEAR_PREMULTIPLYALPHA
-        )
         val typeface = Typeface.createFromAsset(context.assets, "fonts/${family}")
-        val font = Font(texture, typeface, size, true, Color.WHITE)
+
+        val pageFactory = Supplier<ITexture> {
+            val sideLength = GLHelper.GlMaxTextureWidth / 2
+            val page = BitmapTextureAtlas(sideLength, sideLength, TextureOptions.BILINEAR_PREMULTIPLYALPHA)
+
+            UIEngine.current.textureManager.loadTexture(page)
+            page
+        }
+
+        val font = Font(pageFactory, typeface, size, true, Color.WHITE)
 
         UIEngine.current.apply {
-            textureManager.loadTexture(texture)
             fontManager.loadFont(font)
 
             fonts[fontIdentifier] = font

--- a/src/com/reco1l/andengine/UIResourceManager.kt
+++ b/src/com/reco1l/andengine/UIResourceManager.kt
@@ -13,6 +13,7 @@ import org.anddev.andengine.opengl.texture.TextureOptions
 import org.anddev.andengine.opengl.texture.atlas.bitmap.BitmapTextureAtlas
 import org.anddev.andengine.opengl.util.GLHelper
 import java.lang.ref.WeakReference
+import java.util.function.Supplier
 
 class UIResourceManager(private val context: Context) {
 
@@ -73,7 +74,7 @@ class UIResourceManager(private val context: Context) {
 
             UIEngine.current.apply {
                 fontManager.unloadFont(font)
-                textureManager.unloadTexture(font.texture)
+                font.pages.forEach { textureManager.unloadTexture(it) }
             }
         }
     }

--- a/src/ru/nsu/ccfit/zuev/osu/ResourceManager.java
+++ b/src/ru/nsu/ccfit/zuev/osu/ResourceManager.java
@@ -18,6 +18,7 @@ import org.anddev.andengine.engine.Engine;
 import org.anddev.andengine.opengl.font.Font;
 import org.anddev.andengine.opengl.font.FontFactory;
 import org.anddev.andengine.opengl.font.StrokeFont;
+import org.anddev.andengine.opengl.texture.ITexture;
 import org.anddev.andengine.opengl.texture.TextureOptions;
 import org.anddev.andengine.opengl.texture.atlas.bitmap.BitmapTextureAtlas;
 import org.anddev.andengine.opengl.texture.region.TextureRegion;
@@ -33,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -416,20 +418,31 @@ public class ResourceManager {
         return frameIndex;
     }
 
+    /**
+     * Creates a new atlas page for a {@link Font} and registers it to the engine's
+     * {@link org.anddev.andengine.opengl.texture.TextureManager} so it gets uploaded like any other texture.
+     * Invoked by the {@link Font} whenever its current page runs out of room for new glyphs.
+     */
+    private Supplier<ITexture> createFontPageFactory(final int width, final int height) {
+        return () -> {
+            var page = new BitmapTextureAtlas(width, height, TextureOptions.BILINEAR_PREMULTIPLYALPHA);
+            engine.getTextureManager().loadTexture(page);
+            return page;
+        };
+    }
+
     public Font loadFont(final String resname, final String file, int size,
                          final int color) {
         size /= Config.getTextureQuality();
-        final BitmapTextureAtlas texture = new BitmapTextureAtlas(FONT_TEXTURE_SIZE, FONT_TEXTURE_SIZE,
-                TextureOptions.BILINEAR_PREMULTIPLYALPHA);
+        final Supplier<ITexture> pageFactory = createFontPageFactory(FONT_TEXTURE_SIZE, FONT_TEXTURE_SIZE);
         Font font;
         if (file == null) {
-            font = new Font(texture, Typeface.create(Typeface.DEFAULT,
+            font = new Font(pageFactory, Typeface.create(Typeface.DEFAULT,
                     Typeface.NORMAL), size, true, color);
         } else {
-            font = FontFactory.createFromAsset(texture, context, "fonts/"
+            font = FontFactory.createFromAsset(pageFactory, context, "fonts/"
                     + file, size, true, color);
         }
-        engine.getTextureManager().loadTexture(texture);
         engine.getFontManager().loadFont(font);
         fonts.put(resname, font);
         return font;
@@ -438,19 +451,17 @@ public class ResourceManager {
     public StrokeFont loadStrokeFont(final String resname, final String file,
                                      int size, final int color1, final int color2) {
         size /= Config.getTextureQuality();
-        final BitmapTextureAtlas texture = new BitmapTextureAtlas(STROKE_FONT_TEXTURE_WIDTH, STROKE_FONT_TEXTURE_HEIGHT,
-                TextureOptions.BILINEAR_PREMULTIPLYALPHA);
+        final Supplier<ITexture> pageFactory = createFontPageFactory(STROKE_FONT_TEXTURE_WIDTH, STROKE_FONT_TEXTURE_HEIGHT);
         StrokeFont font;
         if (file == null) {
-            font = new StrokeFont(texture, Typeface.create(Typeface.DEFAULT,
+            font = new StrokeFont(pageFactory, Typeface.create(Typeface.DEFAULT,
                     Typeface.NORMAL), size, true, color1,
                     Config.getTextureQuality() == 1 ? 2 : 0.75f, color2);
         } else {
-            font = FontFactory.createStrokeFromAsset(texture, context, "fonts/"
+            font = FontFactory.createStrokeFromAsset(pageFactory, context, "fonts/"
                             + file, size, true, color1, (float) 2 / Config.getTextureQuality(),
                     color2);
         }
-        engine.getTextureManager().loadTexture(texture);
         engine.getFontManager().loadFont(font);
         fonts.put(resname, font);
         return font;

--- a/tests/test/kotlin/org/anddev/andengine/opengl/font/FontTest.kt
+++ b/tests/test/kotlin/org/anddev/andengine/opengl/font/FontTest.kt
@@ -1,0 +1,90 @@
+package org.anddev.andengine.opengl.font
+
+import android.graphics.Color
+import android.graphics.Typeface
+import org.anddev.andengine.opengl.texture.ITexture
+import org.anddev.andengine.opengl.texture.atlas.bitmap.BitmapTextureAtlas
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.util.function.Supplier
+
+@RunWith(RobolectricTestRunner::class)
+class FontTest {
+    /**
+     * The starting point of the [CJK Unified Ideographs](https://www.compart.com/en/unicode/block/U+4E00) block.
+     *
+     * Specifically used in this test suite since the characters commonly overflow an atlas.
+     */
+    private val startingCodePoint = 0x4e00
+
+    @Test
+    fun `Created letters stay within their own atlas page`() {
+        val font = createFont()
+
+        repeat(1000) {
+            val character = (startingCodePoint + it).toChar().toString()
+            val letter = font.getLetter(character)
+
+            assertTrue(
+                "Letter ${letter.mCharacter} overflows its atlas page vertically",
+                letter.mTextureY + letter.mTextureHeight <= 1f,
+            )
+
+            assertTrue(
+                "Letter ${letter.mCharacter} overflows its atlas page horizontally",
+                letter.mTextureX + letter.mTextureWidth <= 1f,
+            )
+        }
+    }
+
+    @Test
+    fun `Overflowing a page allocates a new one instead of reusing the old`() {
+        val pages = mutableListOf<ITexture>()
+        val font = createFont(pages)
+
+        repeat(2000) { font.getLetter((startingCodePoint + it).toChar().toString()) }
+
+        assertTrue("Expected more than one atlas page to have been allocated", pages.size > 1)
+        assertEquals("All allocated pages should be distinct instances", pages.size, pages.distinct().size)
+    }
+
+    @Test
+    fun `No two letters are ever assigned the same page and position`() {
+        // Regression test:
+        // A destructive "reset the atlas and start over" fix (as opposed to allocating a new page) would let a later
+        // letter claim the same (page, x, y) as an earlier one, corrupting any Text still referencing the earlier letter.
+        val font = createFont()
+        val claimedPositions = HashMap<Triple<ITexture, Float, Float>, String>()
+
+        repeat(2000) {
+            val character = (startingCodePoint + it).toChar().toString()
+            val letter = font.getLetter(character)
+            val position = Triple(letter.texture, letter.mTextureX, letter.mTextureY)
+
+            val previousOccupant = claimedPositions.put(position, character)
+
+            assertTrue(
+                "Letters '$previousOccupant' and '$character' were both assigned position $position",
+                previousOccupant == null,
+            )
+        }
+    }
+
+    private fun createFont(pages: MutableList<ITexture>? = null) = FixedLineHeightFont {
+        BitmapTextureAtlas(512, 512).also { pages?.add(it) }
+    }
+
+    private class FixedLineHeightFont(pageFactory: Supplier<ITexture>) : Font(
+        pageFactory,
+        Typeface.DEFAULT,
+        28f,
+        true,
+        Color.WHITE,
+    ) {
+        override fun getLineHeight() = 32
+        override fun getLineGap() = 0
+    }
+}


### PR DESCRIPTION
Follow-up of https://github.com/osudroid/osu-droid/pull/655#issuecomment-4947790841.

This PR changes `Font` to use multiple atlases rather than a single atlas. This fixes an issue where an atlas overflow would make the allocator in `Font` to "roll back" to `(0, 0)` to place a new glyph. This causes the new glyph to overwrite an existing one in the same coordinates, so a character in a `Text` that was processed prior to the rollback would be drawn incorrectly if it maps to those same coordinates.

Engine-level `minimumSdkVersion` bump to 24 is needed to use `Supplier`. It doesn't affect anything as the game's `minimumSdkVersion` is already 24.